### PR TITLE
Support multiple arguments.

### DIFF
--- a/gamelauncher.sh
+++ b/gamelauncher.sh
@@ -29,7 +29,8 @@ export PROTON_CRASH_REPORT_DIR='/tmp/ULWGL_crashreports'
 export FONTCONFIG_PATH=''
 
 export EXE="$2"
-export LAUNCHARGS="$3"
+shift 2
+export LAUNCHARGS="$@"
 me="$(readlink -f "$0")"
 here="${me%/*}"
-$here/ULWGL --verb=waitforexitandrun -- "$PROTONPATH"/proton waitforexitandrun "$EXE" "$LAUNCHARGS"
+$here/ULWGL --verb=waitforexitandrun -- "$PROTONPATH"/proton waitforexitandrun "$EXE" $LAUNCHARGS


### PR DESCRIPTION
When I run this:
```sh
WINEPREFIX=~/prefix GAMEID=kocxyz "$HOME/Games/ULWGL-launcher/gamelauncher.sh" "$HOME/.steam/steam/compatibilitytools.d/GE-Proton8-27" start.exe /unix $HOME/Games/KOCity/highRes/KnockoutCity/KnockoutCity.exe --lang=en
```
only `/unix` get passed to the final script.