### PR TITLE
Separate self-update and download/extraction into a wrapper script for CLI use

### DIFF
--- a/org.openwinecomponents.ulwgl.launcher.yml
+++ b/org.openwinecomponents.ulwgl.launcher.yml
@@ -143,11 +143,11 @@ modules:
   - name: ulwgl-run
     buildsystem: simple
     build-commands:
-      - install -D ulwgl-run /app/bin/ulwgl-run
+      - install -D ulwgl-run-cli /app/bin/ulwgl-run
       - install -D ULWGL-launcher.tar.gz /app/share/ULWGL/ULWGL-launcher.tar.gz
     sources:
       - type: file
-        path: ulwgl-run
+        path: ulwgl-run-cli
       - type: file
         url: https://github.com/Open-Wine-Components/ULWGL-launcher/releases/download/0.1-RC3/ULWGL-launcher.tar.gz
         sha256: e25c4dd0636d04e7c8c534cf3c5bbdca5ae0d49f146ee8395306174700899952

--- a/toolmanifest.vdf
+++ b/toolmanifest.vdf
@@ -1,7 +1,7 @@
 // Generated file, do not edit
 "manifest"
 {
-	"commandline" "/_v2-entry-point --verb=%verb% --"
+	"commandline" "/ULWGL --verb=%verb% --"
 	"version" "2"
 	"use_tool_subprocess_reaper" "1"
 	"unlisted" "1"

--- a/ulwgl-run
+++ b/ulwgl-run
@@ -3,41 +3,15 @@
 # use for debug only.
 # set -x
 
-if [ -z "$1" ] || [ -z "$WINEPREFIX" ] || [ -z "$GAMEID" ]; then
+if [ -z "$1" ] || [ -z "$WINEPREFIX" ] || [ -z "$GAMEID" ] || [ -z "$PROTONPATH" ]; then
  echo "Usage: WINEPREFIX=<wine-prefix-path> GAMEID=<ulwgl-id> PROTONPATH=<proton-version-path> ./gamelauncher.sh <executable-path> <arguments>"
  echo "Ex:"
  echo "WINEPREFIX=$HOME/Games/epic-games-store GAMEID=egs PROTONPATH=\"$HOME/.steam/steam/compatibilitytools.d/GE-Proton8-28\" ./gamelauncher.sh \"$HOME/Games/epic-games-store/drive_c/Program Files (x86)/Epic Games/Launcher/Portal/Binaries/Win32/EpicGamesLauncher.exe\" \"-opengl -SkipBuildPatchPrereq\""
  exit 1
 fi
 
-ULWGL_PROTON_VER="ULWGL-Proton-8.0-5"
-ULWGL_LAUNCHER_VER="0.1-RC3"
-
 me="$(readlink -f "$0")"
-#here="${me%/*}"
-
-# Self-update
-# In flatpak it will check for /app/share/ULWGL/ULWGL-launcher.tar.gz and check version
-# In distro package it will check for /usr/share/ULWGL/ULWGL-launcher.tar.gz and check version
-# If tarball does not exist it will just download it.
-if [ ! -d "$HOME"/.local/share/ULWGL/ ]; then
-  if [ -f "${me%/*/*}"/share/ULWGL/ULWGL-launcher.tar.gz ]; then
-    tar -zxvf "${me%/*/*}"/share/ULWGL/ULWGL-launcher.tar.gz --one-top-level="$HOME"/.local/share/ULWGL
-  else
-    wget https://github.com/Open-Wine-Components/ULWGL-launcher/releases/download/$ULWGL_LAUNCHER_VER/ULWGL-launcher.tar.gz
-    tar -zxvf ULWGL-launcher.tar.gz --one-top-level="$HOME"/.local/share/ULWGL
-  fi
-else
-    if [ "$ULWGL_LAUNCHER_VER" != "$(cat "$HOME"/.local/share/ULWGL/ULWGL-VERSION)" ]; then
-      rm -Rf "$HOME"/.local/share/ULWGL/
-      if [ -f "${me%/*/*}"/share/ULWGL/ULWGL-launcher.tar.gz ]; then
-        tar -zxvf "${me%/*/*}"/share/ULWGL/ULWGL-launcher.tar.gz --one-top-level="$HOME"/.local/share/ULWGL
-      else
-        wget https://github.com/Open-Wine-Components/ULWGL-launcher/releases/download/$ULWGL_LAUNCHER_VER/ULWGL-launcher.tar.gz
-        tar -zxvf ULWGL-launcher.tar.gz --one-top-level="$HOME"/.local/share/ULWGL
-      fi
-    fi
-fi
+here="${me%/*}"
 
 if [ "$WINEPREFIX" ]; then
    if [ ! -d "$WINEPREFIX" ]; then
@@ -55,32 +29,14 @@ if [ "$WINEPREFIX" ]; then
      ln -s "../drive_c" "$WINEPREFIX/dosdevices/c:" > log 2>&1
    fi
 fi
+
 if [ -n "$PROTONPATH" ]; then
   if [ ! -d "$PROTONPATH" ]; then
     echo "ERROR: $PROTONPATH is invalid, aborting!"    exit 1
     exit 1
   fi
 fi
-if [ -z "$PROTONPATH" ]; then
-  if [ ! -d "$HOME"/.local/share/Steam/compatibilitytools.d/$ULWGL_PROTON_VER ]; then
-    wget https://github.com/Open-Wine-Components/ULWGL-Proton/releases/download/$ULWGL_PROTON_VER/$ULWGL_PROTON_VER.tar.gz
-    wget https://github.com/Open-Wine-Components/ULWGL-Proton/releases/download/$ULWGL_PROTON_VER/$ULWGL_PROTON_VER.sha512sum
-    checksum=$(sha512sum $ULWGL_PROTON_VER.tar.gz)
-    if [ "$checksum" = "$(cat $ULWGL_PROTON_VER.sha512sum)" ]; then
-      tar -zxvf $ULWGL_PROTON_VER.tar.gz --one-top-level="$HOME"/.local/share/Steam/compatibilitytools.d/
-      rm $ULWGL_PROTON_VER.tar.gz
-      rm $ULWGL_PROTON_VER.sha512sum
-    else
-      echo "ERROR: $ULWGL_PROTON_VER.tar.gz checksum does not match $ULWGL_PROTON_VER.sha512sum, aborting!"
-      rm $ULWGL_PROTON_VER.tar.gz
-      rm $ULWGL_PROTON_VER.sha512sum
-      exit 1
-    fi
-  fi
-  PROTONPATH="$HOME"/.local/share/Steam/compatibilitytools.d/$ULWGL_PROTON_VER
-else
-  export PROTONPATH="$PROTONPATH"
-fi
+
 export ULWGL_ID="$GAMEID"
 export STEAM_COMPAT_APP_ID="0"
 numcheck='^[0-9]+$'
@@ -146,8 +102,7 @@ if [ "$EXE" = "createprefix"  ]; then
 fi
 shift 1
 
-export STEAM_COMPAT_TOOL_PATHS="$PROTONPATH:$HOME"/.local/share/ULWGL
-export STEAM_COMPAT_MOUNTS="$PROTONPATH:$HOME"/.local/share/ULWGL
+export STEAM_COMPAT_TOOL_PATHS="$PROTONPATH:$here"
+export STEAM_COMPAT_MOUNTS="$PROTONPATH:$here"
 
-"$HOME"/.local/share/ULWGL/ULWGL "--verb=$PROTON_VERB" -- "$PROTONPATH"/proton "$PROTON_VERB" "$EXE" "$@"
-
+"$here"/ULWGL "--verb=$PROTON_VERB" -- "$PROTONPATH"/proton "$PROTON_VERB" "$EXE" "$@"

--- a/ulwgl-run-cli
+++ b/ulwgl-run-cli
@@ -1,0 +1,71 @@
+#!/bin/sh
+
+# use for debug only.
+# set -x
+
+ULWGL_PROTON_VER="ULWGL-Proton-8.0-5"
+ULWGL_LAUNCHER_VER="0.1-RC3"
+
+me="$(readlink -f "$0")"
+
+ulwgl_link="https://github.com/Open-Wine-Components/ULWGL-launcher/releases/download/$ULWGL_LAUNCHER_VER/ULWGL-launcher.tar.gz"
+ulwgl_dir="$HOME"/.local/share/ULWGL
+
+proton_link="https://github.com/Open-Wine-Components/ULWGL-Proton/releases/download/$ULWGL_PROTON_VER/$ULWGL_PROTON_VER"
+proton_dir="$HOME"/.local/share/Steam/compatibilitytools.d
+
+ulwgl_cache="$HOME"/.cache/ULWGL
+
+if [ ! -d "$ulwgl_cache" ]; then
+	mkdir -p "$ulwgl_cache"
+fi
+
+# Self-update
+# In flatpak it will check for /app/share/ULWGL/ULWGL-launcher.tar.gz and check version
+# In distro package it will check for /usr/share/ULWGL/ULWGL-launcher.tar.gz and check version
+# If tarball does not exist it will just download it.
+if [ ! -d "$ulwgl_dir" ]; then
+	mkdir -p "$ulwgl_dir"
+  if [ -f "${me%/*/*}"/share/ULWGL/ULWGL-launcher.tar.gz ]; then
+    tar -zxvf "${me%/*/*}"/share/ULWGL/ULWGL-launcher.tar.gz --one-top-level="$ulwgl_dir"
+  else
+    wget "$ulwgl_link" -O "$ulwgl_cache/ULWGL-launcher.tar.gz"
+    tar -zxvf "$ulwgl_cache/ULWGL-launcher.tar.gz" --one-top-level="$ulwgl_dir"
+    rm "$ulwgl_cache/ULWGL-launcher.tar.gz"
+  fi
+else
+    if [ "$ULWGL_LAUNCHER_VER" != "$(cat "$ulwgl_dir"/ULWGL-VERSION)" ]; then
+      rm -Rf "$ulwgl_dir" --preserve-root=all
+      if [ -f "${me%/*/*}"/share/ULWGL/ULWGL-launcher.tar.gz ]; then
+        tar -zxvf "${me%/*/*}"/share/ULWGL/ULWGL-launcher.tar.gz --one-top-level="$ulwgl_dir"
+      else
+    		wget "$ulwgl_link" -O "$ulwgl_cache/ULWGL-launcher.tar.gz"
+        tar -zxvf "$ulwgl_cache/ULWGL-launcher.tar.gz" --one-top-level="$ulwgl_dir"
+        rm "$ulwgl_cache/ULWGL-launcher.tar.gz"
+      fi
+    fi
+fi
+
+if [ -z "$PROTONPATH" ]; then
+  if [ ! -d "$proton_dir"/$ULWGL_PROTON_VER ]; then
+
+    wget "$proton_link".tar.gz -O "$ulwgl_cache/$ULWGL_PROTON_VER".tar.gz
+    wget "$proton_link".sha512sum -O "$ulwgl_cache/$ULWGL_PROTON_VER".sha512sum
+    checksum=$(sha512sum "$ulwgl_cache/$ULWGL_PROTON_VER".tar.gz)
+    if [ "$checksum" = "$(cat "$ulwgl_cache/$ULWGL_PROTON_VER".sha512sum)" ]; then
+      tar -zxvf "$ulwgl_cache/$ULWGL_PROTON_VER".tar.gz --one-top-level="$proton_dir"
+      rm "$ulwgl_cache/$ULWGL_PROTON_VER".tar.gz
+      rm "$ulwgl_cache/$ULWGL_PROTON_VER".sha512sum
+    else
+      echo "ERROR: $ulwgl_cache/$ULWGL_PROTON_VER.tar.gz checksum does not match $ulwgl_cache/$ULWGL_PROTON_VER.sha512sum, aborting!"
+      rm "$ulwgl_cache/$ULWGL_PROTON_VER".tar.gz
+      rm "$ulwgl_cache/$ULWGL_PROTON_VER".sha512sum
+      exit 1
+    fi
+  fi
+  PROTONPATH="$proton_dir/$ULWGL_PROTON_VER"
+else
+  export PROTONPATH="$PROTONPATH"
+fi
+
+"$ulwgl_dir/ulwgl-run" "$@"

--- a/ulwgl-run-cli
+++ b/ulwgl-run-cli
@@ -48,10 +48,11 @@ fi
 
 if [ -z "$PROTONPATH" ]; then
   if [ ! -d "$proton_dir"/$ULWGL_PROTON_VER ]; then
-
     wget "$proton_link".tar.gz -O "$ulwgl_cache/$ULWGL_PROTON_VER".tar.gz
     wget "$proton_link".sha512sum -O "$ulwgl_cache/$ULWGL_PROTON_VER".sha512sum
-    checksum=$(sha512sum "$ulwgl_cache/$ULWGL_PROTON_VER".tar.gz)
+    cd "$ulwgl_cache" || exit
+    checksum=$(sha512sum "$ULWGL_PROTON_VER".tar.gz)
+    cd - || exit
     if [ "$checksum" = "$(cat "$ulwgl_cache/$ULWGL_PROTON_VER".sha512sum)" ]; then
       tar -zxvf "$ulwgl_cache/$ULWGL_PROTON_VER".tar.gz --one-top-level="$proton_dir"
       rm "$ulwgl_cache/$ULWGL_PROTON_VER".tar.gz
@@ -63,7 +64,7 @@ if [ -z "$PROTONPATH" ]; then
       exit 1
     fi
   fi
-  PROTONPATH="$proton_dir/$ULWGL_PROTON_VER"
+  export PROTONPATH="$proton_dir/$ULWGL_PROTON_VER"
 else
   export PROTONPATH="$PROTONPATH"
 fi


### PR DESCRIPTION
Example implementation of https://github.com/Open-Wine-Components/ULWGL-launcher/issues/16

Create a new script `ulwgl-run-cli` which can be installed as `bin/ulgwl-run` (example in flatpak manifest) and it takes care of downloading/extracting ULWGL-launcher and ULWGL-Proton in to their respective paths. The downloads are stored temporarily in the `$HOME/.cache/ULWGL` directory (this could be `/tmp` too since they are later deleted) to avoid cluttering the current directory. The actual implementation is a direct copy of the existing one in `ulwgl-run`