### PR TITLE
RFC: Rewrite _v2-entry-point in Python

### DIFF
--- a/ulwgl_plugins.py
+++ b/ulwgl_plugins.py
@@ -1,9 +1,34 @@
 import os
 from pathlib import Path
-from typing import Dict, Set
+from typing import Dict, Set, Tuple
+import ulwgl_pressure_vessel
+from io import TextIOWrapper
 
 
-def enable_steam_game_drive(env: Dict[str, str]):
+def enable_pressure_vessel(env: Dict[str, str]) -> Tuple[Dict[str, str], TextIOWrapper]:
+    """Enable Pressure Vessel."""
+    exe_dir: str = Path(__file__).parent.as_posix()
+    file: TextIOWrapper = None
+    env, file = ulwgl_pressure_vessel.set_pv(env)
+
+    if "LD_LIBRARY_PATH" in os.environ:
+        os.environ.pop("LD_LIBRARY_PATH")
+    if "STEAM_RUNTIME" in os.environ:
+        os.environ.pop("STEAM_RUNTIME")
+
+    # Replicates ./run or ./run-in-sniper
+    env["PRESSURE_VESSEL_COPY_RUNTIME"] = "1"
+    env["PRESSURE_VESSEL_GC_LEGACY_RUNTIMES"] = "1"
+    # Hardcode for now
+    # TODO: Read from a config file for this value
+    env["PRESSURE_VESSEL_RUNTIME"] = "sniper_platform_0.20231211.70175"
+    env["PRESSURE_VESSEL_RUNTIME_BASE"] = exe_dir
+    env["PRESSURE_VESSEL_VARIABLE_DIR"] = exe_dir + "/var"
+
+    return (env, file)
+
+
+def enable_steam_game_drive(env: Dict[str, str]) -> Dict[str, str]:
     """Enable Steam Game Drive functionality.
 
     Expects STEAM_COMPAT_INSTALL_PATH to be set

--- a/ulwgl_pressure_vessel.py
+++ b/ulwgl_pressure_vessel.py
@@ -1,0 +1,117 @@
+import os
+from io import TextIOWrapper
+from typing import Dict, Tuple
+from pathlib import Path
+import datetime
+import sys
+
+
+def set_pv_paths(env: Dict[str, str]) -> Dict[str, str]:
+    """Set library paths for Pressure Vessel."""
+    if (
+        "STEAM_RUNTIME" in os.environ
+        and Path(os.environ["STEAM_RUNTIME"]).is_absolute()
+        and "LD_LIBRARY_PATH" in os.environ
+    ):
+        paths = [
+            path
+            for path in os.environ.get("LD_LIBRARY_PATH").split(":")
+            if _filter_ld_paths(path)
+        ]
+        print("Setting the environment variable: ", paths)
+        env["PRESSURE_VESSEL_APP_LD_LIBRARY_PATH"] = ":".join(paths)
+    elif os.environ.get("LD_LIBRARY_PATH"):
+        env["PRESSURE_VESSEL_APP_LD_LIBRARY_PATH"] = os.environ.get("LD_LIBRARY_PATH")
+
+    return env
+
+
+def set_pv(env: Dict[str, str]) -> Tuple[Dict[str, str], TextIOWrapper]:
+    """Prepare and configure Pressure Vessel."""
+    # File handle created when enabling logs
+    # This needs to be closed from a caller or on exit
+    file: TextIOWrapper = None
+
+    # Check if the executing directory is a symbolic link then silently remove it
+    if Path(__file__ + "/var").is_symlink():
+        Path(__file__ + "/var").unlink()
+
+    file = set_pv_logs(env)
+    set_pv_paths(env)
+
+    return (env, file)
+
+
+def set_pv_logs(env: Dict[str, str]) -> TextIOWrapper:
+    """Set logs for Pressure Vessel.
+
+    Logs are enabled via STEAM_LINUX_RUNTIME_LOG environment variable
+    Logs are disabled by default unless it is set
+    """
+    app: str = "non-steam-game"
+    log_file: str = ""
+    log_dir: Path = None
+    # Used for logging
+    # NOTE: The file handle should be closed from a caller if enabling logs
+    file: TextIOWrapper = None
+
+    if os.environ.get("STEAM_LINUX_RUNTIME_VERBOSE"):
+        env["PRESSURE_VESSEL_VERBOSE"] = "1"
+
+    if env.get("STEAM_COMPAT_APP_ID") and env.get("SteamAppId"):
+        app = env.get("STEAM_COMPAT_APP_ID") + "-" + env.get("SteamAppId")
+
+    # When enabling logs create the log file and directory
+    if os.environ.get("STEAM_LINUX_RUNTIME_LOG"):
+        steamrt_log_dir = os.environ.get("STEAM_LINUX_RUNTIME_LOG_DIR")
+        pv_log_dir = os.environ.get("PRESSURE_VESSEL_VARIABLE_DIR")
+
+        # Set the appropiate log directory
+        if steamrt_log_dir and Path.exists(steamrt_log_dir):
+            print(f"Setting log directory to: {steamrt_log_dir}")
+            log_dir = steamrt_log_dir
+        elif pv_log_dir and Path.exists(pv_log_dir):
+            print(f"Setting log directory to: {pv_log_dir}")
+            log_dir = pv_log_dir
+        else:
+            log_dir: Path = Path(__file__ + "/var")
+            print(f"Creating log directory: {log_dir}")
+            log_dir.mkdir(parents=True, exist_ok=True)
+
+        # Create the new log file
+        print(f"Creating log file: {log_file}")
+        log_file = "slr-" + app + "-t" + datetime.now().strftime("%H:%M:%S.%f")[:-3]
+        Path(log_file).touch(exist_ok=True)
+        Path(log_file).symlink_to(log_dir.stem + "/slr-latest.log")
+
+        # Remove old log files
+        if not os.environ.get("STEAM_LINUX_RUNTIME_KEEP_LOGS"):
+            print(f"Removing old log files in directory: {log_dir}")
+            for file in log_dir.glob("slr-" + app + "-*.log"):
+                if file != log_file:
+                    print(f"Removing file: {file}")
+                    Path.unlink(file)
+
+        # Attempt to log to stderr and stdout
+        # Always log to stderr
+        file = Path(log_file).open(mode="a")
+        if os.environ.get("PRESSURE_VESSEL_BATCH"):
+            sys.stderr: TextIOWrapper = file
+        else:
+            sys.stdout: TextIOWrapper = file
+            sys.stderr: TextIOWrapper = file
+
+        env["PRESSURE_VESSEL_LOG_INFO"] = "1"
+        env["PRESSURE_VESSEL_LOG_WITH_TIMESTAMP"] = "1"
+
+    return file
+
+
+def _filter_ld_paths(path: str) -> bool:
+    """Filter for paths that isn't the Steam RT itself or a path that doesn't start with it."""
+    if not (
+        os.environ.get("STEAM_RUNTIME") == path
+        and path.startswith(os.environ.get("STEAM_RUNTIME"))
+    ):
+        return True
+    return False


### PR DESCRIPTION
Currently, our launchers shells out to two shell scripts -- _v2-entry-point ([ULWGL](https://github.com/Open-Wine-Components/ULWGL-launcher/blob/main/ULWGL)), [run](https://github.com/Open-Wine-Components/ULWGL-launcher/blob/main/run) or [run-in-sniper.](https://github.com/Open-Wine-Components/ULWGL-launcher/blob/main/run-in-sniper) This doesn't seem to be a problem and is perfectly fine to just leave it, however this PR demonstrates that it doesn't have to be that way as it's fairly trivial to implement in Python. Whether the benefits, if there is any, warrants the rewrite is left open to debate. Until there's a consensus, this PR will be left in a draft state.

Related to https://github.com/Open-Wine-Components/ULWGL-launcher/pull/8
