### PR TITLE
Add download functionality to ulwgl_run

### DIFF
--- a/ulwgl_dl_util.py
+++ b/ulwgl_dl_util.py
@@ -111,9 +111,7 @@ def _fetch_proton(
     """Download the latest ULWGL-Proton and set it as PROTONPATH."""
     hash, hash_url = files[0]
     proton, proton_url = files[1]
-    proton_dir: str = proton[
-        : proton.find(".tar.gz")
-    ]  # Proton dir without suffixes/dashes
+    proton_dir: str = proton[: proton.find(".tar.gz")]  # Proton dir
 
     # TODO: Parallelize this
     print(f"Downloading {hash} ...")
@@ -169,9 +167,7 @@ def _get_from_steamcompat(
     proton_dir: str = ""  # Latest Proton
 
     if len(files) == 2:
-        proton_dir: str = files[1][0][
-            : files[1][0].find(".tar.gz")
-        ]  # Proton dir without suffixes/dashes
+        proton_dir: str = files[1][0][: files[1][0].find(".tar.gz")]  # Proton dir
 
     for proton in steam_compat.glob("ULWGL-Proton*"):
         print(f"{proton.name} found in: {steam_compat.as_posix()}")
@@ -215,9 +211,7 @@ def _get_from_cache(
         break
 
     if path:
-        proton_dir: str = name[
-            : name.find(".tar.gz")
-        ]  # Proton dir without suffixes/dashes
+        proton_dir: str = name[: name.find(".tar.gz")]  # Proton dir
 
         try:
             _extract_dir(path, steam_compat)
@@ -252,9 +246,7 @@ def _get_latest(
             return None
         except KeyboardInterrupt:
             tarball: str = files[1][0]
-            proton_dir: str = tarball[
-                : tarball.find(".tar.gz")
-            ]  # Proton dir without suffixes/dashes
+            proton_dir: str = tarball[: tarball.find(".tar.gz")]  # Proton dir
 
             # Exit cleanly
             # Clean up extracted data and cache to prevent corruption/errors

--- a/ulwgl_dl_util.py
+++ b/ulwgl_dl_util.py
@@ -1,13 +1,13 @@
 from pathlib import Path
 from os import environ
 from tarfile import open as tar_open
-from requests import Timeout
 from typing import Dict, List, Tuple, Any, Union
 from hashlib import sha512
 from shutil import rmtree
 from http.client import HTTPSConnection
 from http.client import HTTPConnection
 from http.client import HTTPResponse
+from http.client import HTTPException
 from ssl import create_default_context
 from json import loads as loads_json
 from urllib.request import urlretrieve
@@ -23,7 +23,7 @@ def get_ulwgl_proton(env: Dict[str, str]) -> Union[Dict[str, str], None]:
 
     try:
         files = _fetch_releases()
-    except Timeout:
+    except HTTPException:
         print("Offline.\nContinuing ...")
 
     cache: Path = Path.home().joinpath(".cache/ULWGL")

--- a/ulwgl_dl_util.py
+++ b/ulwgl_dl_util.py
@@ -44,15 +44,19 @@ def get_ulwgl_proton(env: Dict[str, str]) -> Union[Dict[str, str], None]:
         files
         and Path(Path().home().as_posix() + "/.cache/ULWGL" + files[1][0]).is_file()
     ):
+        proton: str = files[1][0]
+        print(f"{proton} found in: {cache.as_posix()}")
         _extract_dir(
             Path(Path().home().as_posix() + "/.cache/ULWGL").joinpath(files[1][0]),
             steam_compat,
         )
 
         environ["PROTONPATH"] = steam_compat.joinpath(
-            proton.name[: proton.name.find(".")]
+            proton[: proton.find(".")]
         ).as_posix()
         env["PROTONPATH"] = environ["PROTONPATH"]
+
+        return env
 
     # Download the latest if GE-Proton is not in Steam compat
     # If the digests mismatched, refer to the cache in the next block

--- a/ulwgl_dl_util.py
+++ b/ulwgl_dl_util.py
@@ -256,8 +256,6 @@ def _get_latest(
     When the digests mismatched or when interrupted, refer to cache for an old version
     """
     if files:
-        tarball: str = files[1][0]
-
         print("Fetching latest release ...")
         try:
             _fetch_proton(env, steam_compat, cache, files)
@@ -267,6 +265,8 @@ def _get_latest(
             # Refer to the cache for old version next
             return None
         except KeyboardInterrupt:
+            tarball: str = files[1][0]
+
             # Exit cleanly
             # Clean up extracted data and cache to prevent corruption/errors
             # Refer to the cache for old version next

--- a/ulwgl_dl_util.py
+++ b/ulwgl_dl_util.py
@@ -62,7 +62,7 @@ def _fetch_releases() -> List[Tuple[str, str]]:
 
     conn.request(
         "GET",
-        "/repos/GloriousEggroll/proton-ge-custom/releases",
+        "/repos/Open-Wine-Components/ULWGL-Proton/releases",
         headers={
             "Accept": "application/vnd.github+json",
             "X-GitHub-Api-Version": "2022-11-28",
@@ -88,7 +88,7 @@ def _fetch_releases() -> List[Tuple[str, str]]:
                         asset["name"].endswith("sum")
                         or (
                             asset["name"].endswith("tar.gz")
-                            and asset["name"].startswith("GE-Proton")
+                            and asset["name"].startswith("ULWGL-Proton")
                         )
                     )
                     and "browser_download_url" in asset
@@ -164,6 +164,8 @@ def _get_from_steamcompat(
 ) -> Dict[str, str]:
     """Refer to Steam compat folder for any existing Proton directories."""
     for proton in steam_compat.glob("GE-Proton*"):
+
+    for proton in steam_compat.glob("ULWGL-Proton*"):
         print(f"{proton.name} found in: {steam_compat.as_posix()}")
         environ["PROTONPATH"] = proton.as_posix()
         env["PROTONPATH"] = environ["PROTONPATH"]
@@ -171,7 +173,7 @@ def _get_from_steamcompat(
         # Notify the user that they're not using the latest
         if len(files) == 2 and proton.name != files[1][0][: files[1][0].find(".")]:
             print(
-                "GE-Proton is outdated and requires manual intervention.\nFor latest release, please download "
+                "ULWGL-Proton is outdated.\nFor latest release, please download "
                 + files[1][1]
             )
 
@@ -194,7 +196,7 @@ def _get_from_cache(
     path: Path = None
     name: str = ""
 
-    for tarball in cache.glob("GE-Proton*.tar.gz"):
+    for tarball in cache.glob("ULWGL-Proton*.tar.gz"):
         if files and tarball == cache.joinpath(files[1][0]) and use_latest:
             path = tarball
             name = tarball.name

--- a/ulwgl_dl_util.py
+++ b/ulwgl_dl_util.py
@@ -31,18 +31,7 @@ def get_ulwgl_proton(env: Dict[str, str]) -> Union[Dict[str, str], None]:
     steam_compat.mkdir(exist_ok=True, parents=True)
 
     # Prioritize the Steam compat
-    for proton in steam_compat.glob("GE-Proton*"):
-        print(f"{proton.name} found in: {steam_compat.as_posix()}")
-        environ["PROTONPATH"] = proton.as_posix()
-        env["PROTONPATH"] = environ["PROTONPATH"]
-
-        # Notify the user that they're not using the latest
-        if len(files) == 2 and proton.name != files[1][0][: files[1][0].find(".")]:
-            print(
-                "GE-Proton is outdated and requires manual intervention.\nFor latest release, please download "
-                + files[1][0]
-            )
-
+    if _get_from_steamcompat(env, steam_compat, cache, files):
         return env
 
     # Check if the latest isn't already in the cache
@@ -230,3 +219,24 @@ def _cleanup(tarball, proton, cache, steam_compat) -> None:
     if steam_compat.joinpath(proton).is_dir():
         print(f"Purging {proton} in {steam_compat} ...")
         rmtree(steam_compat.joinpath(proton).as_posix())
+
+
+def _get_from_steamcompat(
+    env: Dict[str, str], steam_compat: Path, cache: Path, files: List[Tuple[str, str]]
+) -> Dict[str, str]:
+    """Refer to Steam compat folder for any existing Proton directories."""
+    for proton in steam_compat.glob("GE-Proton*"):
+        print(f"{proton.name} found in: {steam_compat.as_posix()}")
+        environ["PROTONPATH"] = proton.as_posix()
+        env["PROTONPATH"] = environ["PROTONPATH"]
+
+        # Notify the user that they're not using the latest
+        if len(files) == 2 and proton.name != files[1][0][: files[1][0].find(".")]:
+            print(
+                "GE-Proton is outdated and requires manual intervention.\nFor latest release, please download "
+                + files[1][1]
+            )
+
+        return env
+
+    return None

--- a/ulwgl_dl_util.py
+++ b/ulwgl_dl_util.py
@@ -26,10 +26,8 @@ def get_ulwgl_proton(env: Dict[str, str]) -> Union[Dict[str, str], None]:
     except Timeout:
         print("Offline.\nContinuing ...")
 
-    cache: Path = Path(Path().home().as_posix() + "/.cache/ULWGL")
-    steam_compat: Path = Path(
-        Path().home().as_posix() + "/.local/share/Steam/compatibilitytools.d"
-    )
+    cache: Path = Path.home().joinpath(".cache/ULWGL")
+    steam_compat: Path = Path.home().joinpath(".local/share/Steam/compatibilitytools.d")
 
     cache.mkdir(exist_ok=True, parents=True)
     steam_compat.mkdir(exist_ok=True, parents=True)
@@ -134,7 +132,7 @@ def _fetch_proton(
             raise ValueError(err)
         print(f"{proton}: SHA512 is OK")
 
-    _extract_dir(Path(f"{cache.as_posix()}/{proton}"), steam_compat)
+    _extract_dir(cache.joinpath(proton), steam_compat)
     environ["PROTONPATH"] = steam_compat.joinpath(proton[: proton.find(".")]).as_posix()
     env["PROTONPATH"] = environ["PROTONPATH"]
 

--- a/ulwgl_dl_util.py
+++ b/ulwgl_dl_util.py
@@ -4,10 +4,7 @@ from tarfile import open as tar_open
 from typing import Dict, List, Tuple, Any, Union
 from hashlib import sha512
 from shutil import rmtree
-from http.client import HTTPSConnection
-from http.client import HTTPConnection
-from http.client import HTTPResponse
-from http.client import HTTPException
+from http.client import HTTPSConnection, HTTPResponse, HTTPException, HTTPConnection
 from ssl import create_default_context
 from json import loads as loads_json
 from urllib.request import urlretrieve

--- a/ulwgl_dl_util.py
+++ b/ulwgl_dl_util.py
@@ -204,11 +204,13 @@ def _get_from_cache(
         if files and tarball == cache.joinpath(files[1][0]) and use_latest:
             path = tarball
             name = tarball.name
-        elif not use_latest:
+            break
+        if tarball != cache.joinpath(files[1][0]) and not use_latest:
             path = tarball
             name = tarball.name
-        print(f"{tarball.name} found in: {cache.as_posix()}")
-        break
+            break
+
+    print(f"{name} found in: {path}")
 
     if path:
         proton_dir: str = name[: name.find(".tar.gz")]  # Proton dir

--- a/ulwgl_dl_util.py
+++ b/ulwgl_dl_util.py
@@ -10,7 +10,7 @@ from json import loads as loads_json
 from urllib.request import urlretrieve
 
 
-def get_ulwgl_proton(env: Dict[str, str]) -> Union[Dict[str, str], None]:
+def get_ulwgl_proton(env: Dict[str, str]) -> Union[Dict[str, str]]:
     """Attempt to find existing Proton from the system or downloads the latest if PROTONPATH is not set.
 
     Only fetches the latest if not first found in .local/share/Steam/compatibilitytools.d
@@ -161,7 +161,7 @@ def _cleanup(tarball: str, proton: str, cache: Path, steam_compat: Path) -> None
 
 def _get_from_steamcompat(
     env: Dict[str, str], steam_compat: Path, cache: Path, files: List[Tuple[str, str]]
-) -> Dict[str, str]:
+) -> Union[Dict[str, str], None]:
     """Refer to Steam compat folder for any existing Proton directories."""
     proton_dir: str = ""  # Latest Proton
 
@@ -191,7 +191,7 @@ def _get_from_cache(
     cache: Path,
     files: List[Tuple[str, str]],
     use_latest=True,
-) -> Dict[str, str]:
+) -> Union[Dict[str, str], None]:
     """Refer to ULWGL cache directory.
 
     Use the latest in the cache when present. When download fails, use an old version
@@ -231,7 +231,7 @@ def _get_from_cache(
 
 def _get_latest(
     env: Dict[str, str], steam_compat: Path, cache: Path, files: List[Tuple[str, str]]
-) -> Dict[str, str]:
+) -> Union[Dict[str, str], None]:
     """Download the latest Proton for new installs -- empty cache and Steam compat.
 
     When the digests mismatched or when interrupted, refer to cache for an old version

--- a/ulwgl_dl_util.py
+++ b/ulwgl_dl_util.py
@@ -1,0 +1,178 @@
+from pathlib import Path
+from os import environ
+from requests import get
+from tarfile import open as tar_open
+from requests import Response
+from typing import Dict, List, Tuple, Any, Union
+from hashlib import sha512
+
+
+def get_ulwgl_proton(env: Dict[str, str]) -> Union[Dict[str, str], None]:
+    """Attempt to find Proton and downloads the latest if PROTONPATH is not set.
+
+    Only fetches the latest if not first found in the Steam compat
+    Cache is only referred to last
+    """
+    # TODO: Put this in the background
+    files: List[Tuple[str, str]] = _fetch_releases()
+    cache: Path = Path(Path().home().as_posix() + "/.cache/ULWGL")
+    steam_compat: Path = Path(
+        Path().home().as_posix() + "/.local/share/Steam/compatibilitytools.d"
+    )
+
+    cache.mkdir(exist_ok=True, parents=True)
+    steam_compat.mkdir(exist_ok=True, parents=True)
+
+    # Prioritize the Steam compat
+    for proton in steam_compat.glob("GE-Proton*"):
+        print(f"{proton.name} found in: {steam_compat.as_posix()}")
+        environ["PROTONPATH"] = proton.as_posix()
+        env["PROTONPATH"] = environ["PROTONPATH"]
+
+        # Notify the user that they're not using the latest
+        if len(files) == 2 and proton.name != files[1][0][: files[1][0].find(".")]:
+            print(
+                "GE-Proton is outdated and requires manual intervention.\nFor latest release, please download "
+                + files[1][0]
+            )
+
+        return env
+
+    # Check if the latest isn't already in the cache
+    # Assumes the tarball is legitimate
+    if (
+        files
+        and Path(Path().home().as_posix() + "/.cache/ULWGL" + files[1][0]).is_file()
+    ):
+        _extract_dir(
+            Path(Path().home().as_posix() + "/.cache/ULWGL").joinpath(files[1][0]),
+            steam_compat,
+        )
+
+        environ["PROTONPATH"] = steam_compat.joinpath(
+            proton.name[: proton.name.find(".")]
+        ).as_posix()
+        env["PROTONPATH"] = environ["PROTONPATH"]
+
+    # Download the latest if GE-Proton is not in Steam compat
+    # If the digests mismatched, refer to the cache in the next block
+    if files:
+        try:
+            print("Fetching latest release ...")
+            _fetch_proton(env, steam_compat, cache, files)
+            env["PROTONPATH"] = environ["PROTONPATH"]
+
+            return env
+        except ValueError as err:
+            print(err)
+
+    # Cache
+    for proton in cache.glob("GE-Proton*.tar.gz"):
+        print(f"{proton.name} found in: {cache.as_posix()}")
+
+        # Extract it to Steam compat then set it as Proton
+        _extract_dir(proton, steam_compat)
+
+        environ["PROTONPATH"] = steam_compat.joinpath(
+            proton.name[: proton.name.find(".")]
+        ).as_posix()
+        env["PROTONPATH"] = environ["PROTONPATH"]
+
+        return env
+
+    # No internet and cache/compat tool is empty, just return and raise an exception from the caller
+    return env
+
+
+def _fetch_releases() -> List[Tuple[str, str]]:
+    """Fetch the latest releases from the Github API."""
+    resp: Response = get(
+        "https://api.github.com/repos/GloriousEggroll/proton-ge-custom/releases"
+    )
+    # The file name and its URL as one element
+    # Checksum will be the first element, GE-Proton second
+    files: List[Tuple[str, str]] = []
+
+    if not resp or not resp.status_code == 200:
+        return files
+
+    # Attempt to acquire the tarball and checksum from the JSON data
+    releases: List[Dict[str, Any]] = resp.json()
+    for release in releases:
+        if "assets" in release:
+            assets: List[Dict[str, Any]] = release["assets"]
+
+            for asset in assets:
+                if (
+                    "name" in asset
+                    and (
+                        asset["name"].endswith("sum")
+                        or (
+                            asset["name"].endswith("tar.gz")
+                            and asset["name"].startswith("GE-Proton")
+                        )
+                    )
+                    and "browser_download_url" in asset
+                ):
+                    if asset["name"].endswith("sum"):
+                        files.append((asset["name"], asset["browser_download_url"]))
+                    else:
+                        files.append((asset["name"], asset["browser_download_url"]))
+
+                if len(files) == 2:
+                    break
+        break
+
+    return files
+
+
+def _fetch_proton(
+    env: Dict[str, str], steam_compat: Path, cache: Path, files: List[Tuple[str, str]]
+) -> Dict[str, str]:
+    """Download the latest ULWGL-Proton and set it as PROTONPATH."""
+    hash, hash_url = files[0]
+    proton, proton_url = files[1]
+    stored_digest: str = ""
+
+    # TODO: Parallelize this
+    print(f"Downloading {hash} ...")
+    resp_hash: Response = get(hash_url)
+    print(f"Downloading {proton} ...")
+    resp: Response = get(proton_url)
+    if (
+        not resp_hash
+        and resp_hash.status_code != 200
+        and not resp
+        and resp.status_code != 200
+    ):
+        err: str = "Failed.\nFalling back to cache directory ..."
+        raise ValueError(err)
+
+    print("Completed.")
+
+    # Download the hash
+    with Path(f"{cache.as_posix()}/{hash}").open(mode="wb") as file:
+        file.write(resp_hash.content)
+    stored_digest = Path(f"{cache.as_posix()}/{hash}").read_text().split(" ")[0]
+
+    # If checksum fails, raise an error and fallback to the cache
+    with Path(f"{cache.as_posix()}/{proton}").open(mode="wb") as file:
+        file.write(resp.content)
+
+        if sha512(resp.content).hexdigest() != stored_digest:
+            err: str = "Digests mismatched.\nFalling back to the cache ..."
+            raise ValueError(err)
+        print(f"{proton}: SHA512 is OK")
+
+    _extract_dir(Path(f"{cache.as_posix()}/{proton}"), steam_compat)
+    environ["PROTONPATH"] = steam_compat.joinpath(proton[: proton.find(".")]).as_posix()
+    env["PROTONPATH"] = environ["PROTONPATH"]
+
+    return env
+
+
+def _extract_dir(proton: Path, steam_compat: Path) -> None:
+    """Extract from the cache and to another location."""
+    with tar_open(proton.as_posix(), "r:gz") as tar:
+        print(f"Extracting {proton} -> {steam_compat.as_posix()} ...")
+        tar.extractall(path=steam_compat.as_posix())

--- a/ulwgl_dl_util.py
+++ b/ulwgl_dl_util.py
@@ -145,7 +145,7 @@ def _extract_dir(proton: Path, steam_compat: Path) -> None:
         print("Completed.")
 
 
-def _cleanup(tarball, proton, cache, steam_compat) -> None:
+def _cleanup(tarball: str, proton: str, cache: Path, steam_compat: Path) -> None:
     """Remove files that may have been left in an incomplete state to avoid corruption.
 
     We want to do this when a download for a new release is interrupted

--- a/ulwgl_dl_util.py
+++ b/ulwgl_dl_util.py
@@ -41,13 +41,13 @@ def get_ulwgl_proton(env: Dict[str, str]) -> Union[Dict[str, str], None]:
     # Check if the latest isn't already in the cache
     # Assumes the tarball is legitimate
     if (
-        files
-        and Path(Path().home().as_posix() + "/.cache/ULWGL" + files[1][0]).is_file()
-    ):
+        files and Path(Path().home().as_posix() + "/.cache/ULWGL").joinpath(files[1][0])
+    ).is_file():
         proton: str = files[1][0]
+
         print(f"{proton} found in: {cache.as_posix()}")
         _extract_dir(
-            Path(Path().home().as_posix() + "/.cache/ULWGL").joinpath(files[1][0]),
+            Path(Path().home().as_posix() + "/.cache/ULWGL").joinpath(proton),
             steam_compat,
         )
 

--- a/ulwgl_dl_util.py
+++ b/ulwgl_dl_util.py
@@ -10,10 +10,10 @@ from shutil import rmtree
 
 
 def get_ulwgl_proton(env: Dict[str, str]) -> Union[Dict[str, str], None]:
-    """Attempt to find Proton and downloads the latest if PROTONPATH is not set.
+    """Attempt to find existing Proton from the system or downloads the latest if PROTONPATH is not set.
 
-    Only fetches the latest if not first found in the Steam compat
-    Cache is only referred to last
+    Only fetches the latest if not first found in .local/share/Steam/compatibilitytools.d
+    The cache directory, .cache/ULWGL, is referenced next for latest or as fallback
     """
     files: List[Tuple[str, str]] = []
 

--- a/ulwgl_dl_util.py
+++ b/ulwgl_dl_util.py
@@ -146,6 +146,7 @@ def _extract_dir(proton: Path, steam_compat: Path) -> None:
     with tar_open(proton.as_posix(), "r:gz") as tar:
         print(f"Extracting {proton} -> {steam_compat.as_posix()} ...")
         tar.extractall(path=steam_compat.as_posix())
+        print("Completed.")
 
 
 def _cleanup(tarball, proton, cache, steam_compat) -> None:

--- a/ulwgl_dl_util.py
+++ b/ulwgl_dl_util.py
@@ -210,11 +210,10 @@ def _get_from_cache(
             name = tarball.name
             break
 
-    print(f"{name} found in: {path}")
-
     if path:
         proton_dir: str = name[: name.find(".tar.gz")]  # Proton dir
 
+        print(f"{name} found in: {path}")
         try:
             _extract_dir(path, steam_compat)
             environ["PROTONPATH"] = steam_compat.joinpath(proton_dir).as_posix()

--- a/ulwgl_run.py
+++ b/ulwgl_run.py
@@ -10,7 +10,7 @@ from typing import Dict, Any, List, Set, Union, Tuple
 import ulwgl_plugins
 from re import match
 import subprocess
-import ulwgl_dl_util
+from ulwgl_dl_util import get_ulwgl_proton
 
 
 def parse_args() -> Union[Namespace, Tuple[str, List[str]]]:  # noqa: D103
@@ -121,7 +121,7 @@ def check_env(
     ):
         # Attempt to auto set this env var for the user
         os.environ["PROTONPATH"] = ""
-        ulwgl_dl_util.get_ulwgl_proton(env)
+        get_ulwgl_proton(env)
     else:
         env["PROTONPATH"] = os.environ["PROTONPATH"]
 

--- a/ulwgl_run.py
+++ b/ulwgl_run.py
@@ -127,7 +127,7 @@ def check_env(
 
     # If download fails/doesn't exist in the system, raise an error
     if not os.environ["PROTONPATH"]:
-        err: str = "GE-Proton could not be found in cache or compatibilitytools.d\nGE-Proton also failed to be downloaded\nPlease set a Proton directory or visit https://github.com/GloriousEggroll/proton-ge-custom/releases"
+        err: str = "Download failed.\nProton could not be found in cache or compatibilitytools.d\nPlease set $PROTONPATH or visit https://github.com/Open-Wine-Components/ULWGL-Proton/releases"
         raise FileNotFoundError(err)
 
     return env

--- a/ulwgl_run.py
+++ b/ulwgl_run.py
@@ -10,6 +10,7 @@ from typing import Dict, Any, List, Set, Union, Tuple
 import ulwgl_plugins
 from re import match
 import subprocess
+import ulwgl_dl_util
 
 
 def parse_args() -> Union[Namespace, Tuple[str, List[str]]]:  # noqa: D103
@@ -118,9 +119,16 @@ def check_env(
         "PROTONPATH" not in os.environ
         or not Path(os.environ["PROTONPATH"]).expanduser().is_dir()
     ):
-        err: str = "Environment variable not set or not a directory: PROTONPATH"
-        raise ValueError(err)
-    env["PROTONPATH"] = os.environ["PROTONPATH"]
+        # Attempt to auto set this env var for the user
+        os.environ["PROTONPATH"] = ""
+        ulwgl_dl_util.get_ulwgl_proton(env)
+    else:
+        env["PROTONPATH"] = os.environ["PROTONPATH"]
+
+    # If download fails/doesn't exist in the system, raise an error
+    if not os.environ["PROTONPATH"]:
+        err: str = "GE-Proton could not be found in cache or compatibilitytools.d\nGE-Proton also failed to be downloaded\nPlease set a Proton directory or visit https://github.com/GloriousEggroll/proton-ge-custom/releases"
+        raise FileNotFoundError(err)
 
     return env
 

--- a/ulwgl_test.py
+++ b/ulwgl_test.py
@@ -110,11 +110,19 @@ class TestGameLauncher(unittest.TestCase):
 
         ulwgl_dl_util._extract_dir(self.test_archive, self.test_compat)
 
+        # Create a file in the cache and compat
+        self.test_cache.joinpath("foo").touch()
+        self.test_compat.joinpath("foo").touch()
+
         # Before cleaning
         # On setUp, an archive is created and a dir should exist in compat after extraction
         self.assertTrue(
-            self.test_compat.joinpath(self.test_proton_dir).exists(),
-            "Expected proton dir to exist in compat before cleaning",
+            self.test_compat.joinpath("foo").exists(),
+            "Expected test file to exist in compat before cleaning",
+        )
+        self.assertTrue(
+            self.test_cache.joinpath("foo").exists(),
+            "Expected test file to exist in cache before cleaning",
         )
         self.assertTrue(
             self.test_archive.exists(),
@@ -135,6 +143,14 @@ class TestGameLauncher(unittest.TestCase):
 
         # Verify state of cache and compat after cleaning
         self.assertFalse(result, "Expected None after cleaning")
+        self.assertTrue(
+            self.test_compat.joinpath("foo").exists(),
+            "Expected test file to exist in compat after cleaning",
+        )
+        self.assertTrue(
+            self.test_cache.joinpath("foo").exists(),
+            "Expected test file to exist in cache after cleaning",
+        )
         self.assertTrue(
             self.test_compat.joinpath(self.test_proton_dir).exists(),
             "Expected proton dir to still exist after cleaning",

--- a/ulwgl_test.py
+++ b/ulwgl_test.py
@@ -100,6 +100,120 @@ class TestGameLauncher(unittest.TestCase):
         if self.test_proton_dir.exists():
             rmtree(self.test_proton_dir.as_posix())
 
+    def test_cache_interrupt(self):
+        """Test _get_from_cache on keyboard interrupt."""
+        result = None
+        # In the real usage, should be populated after successful callout for latest Proton releases
+        # Just mock it and assumes its the latest
+        files = [("", ""), (self.test_archive.name, "")]
+
+        # Populate the Steam compat dir by extracting the tarball
+        ulwgl_dl_util._extract_dir(self.test_archive, self.test_compat)
+
+        self.assertTrue(
+            self.test_compat.joinpath(
+                self.test_archive.name[: self.test_archive.name.find(".tar.gz")]
+            ).exists(),
+            "Expected Proton dir to exist in compat",
+        )
+
+        with patch("ulwgl_dl_util._extract_dir") as mock_function:
+            with self.assertRaisesRegex(KeyboardInterrupt, ""):
+                # Mock the interrupt
+                # We want the dir we tried to extract to be cleaned
+                mock_function.side_effect = KeyboardInterrupt
+                result = ulwgl_dl_util._get_from_cache(
+                    self.env, self.test_compat, self.test_cache, files, True
+                )
+
+                self.assertFalse(result, "Expected None on keyboard interrupt")
+                self.assertFalse(
+                    self.env["PROTONPATH"],
+                    "Expected PROTONPATH to be empty when the cache is empty",
+                )
+                self.assertFalse(
+                    self.test_compat.joinpath(
+                        self.test_archive.name[: self.test_archive.name.find(".tar.gz")]
+                    ).exists(),
+                    "Expected Proton dir in compat to be cleaned",
+                )
+
+    def test_cache_old(self):
+        """Test _get_from_cache when the cache is empty.
+
+        In real usage, this only happens as a last resort when: download fails, digests mismatched, etc.
+        """
+        result = None
+        # In the real usage, should be populated after successful callout for latest Proton releases
+        # Just mock it and assumes its the latest
+        files = [("", ""), (self.test_archive.name, "")]
+
+        # Mock old Proton versions in the cache
+        test_proton_dir = Path("ULWGL-Proton-foo")
+        test_proton_dir.mkdir(exist_ok=True)
+        test_archive = Path(self.test_cache).joinpath(
+            f"{test_proton_dir.as_posix()}.tar.gz"
+        )
+
+        with tarfile.open(test_archive.as_posix(), "w:gz") as tar:
+            tar.add(test_proton_dir.as_posix(), arcname=test_proton_dir.as_posix())
+
+        result = ulwgl_dl_util._get_from_cache(
+            self.env, self.test_compat, self.test_cache, files, False
+        )
+
+        # Verify that the old Proton was assigned
+        self.assertTrue(result is self.env, "Expected the same reference")
+        self.assertEqual(
+            self.env["PROTONPATH"],
+            self.test_compat.joinpath(
+                test_archive.name[: test_archive.name.find(".tar.gz")]
+            ).as_posix(),
+            "Expected PROTONPATH to be proton dir in compat",
+        )
+
+        test_archive.unlink()
+        test_proton_dir.rmdir()
+
+    def test_cache_empty(self):
+        """Test _get_from_cache when the cache is empty."""
+        result = None
+        # In the real usage, should be populated after successful callout for latest Proton releases
+        # Just mock it and assumes its the latest
+        files = [("", ""), (self.test_archive.name, "")]
+
+        self.test_archive.unlink()
+
+        result = ulwgl_dl_util._get_from_cache(
+            self.env, self.test_compat, self.test_cache, files, True
+        )
+        self.assertFalse(result, "Expected None when calling _get_from_cache")
+        self.assertFalse(
+            self.env["PROTONPATH"],
+            "Expected PROTONPATH to be empty when the cache is empty",
+        )
+
+    def test_cache(self):
+        """Test _get_from_cache.
+
+        Tests the case when the latest Proton already exists in the cache
+        """
+        result = None
+        # In the real usage, should be populated after successful callout for latest Proton releases
+        # Just mock it and assumes its the latest
+        files = [("", ""), (self.test_archive.name, "")]
+
+        result = ulwgl_dl_util._get_from_cache(
+            self.env, self.test_compat, self.test_cache, files, True
+        )
+        self.assertTrue(result is self.env, "Expected the same reference")
+        self.assertEqual(
+            self.env["PROTONPATH"],
+            self.test_compat.joinpath(
+                self.test_archive.name[: self.test_archive.name.find(".tar.gz")]
+            ).as_posix(),
+            "Expected PROTONPATH to be proton dir in compat",
+        )
 
     def test_steamcompat_nodir(self):
         """Test _get_from_steamcompat when a Proton doesn't exist in the Steam compat dir.


### PR DESCRIPTION
Closes https://github.com/Open-Wine-Components/ULWGL-launcher/issues/29 and https://github.com/Open-Wine-Components/ULWGL-launcher/issues/16 

With the current rewrite, when the user does not specify the `$PROTONPATH,` no download of the latest Proton is made on their behalf and this PR aims add that same functionality.

When no Proton is specified, we only attempt to download the latest Proton if a Proton cannot be found in the Steam compat tools directory. Otherwise, referring to `$HOME/.cache/ULWGL` if something wrong happens when downloading or if the user is offline.

Concretely the order is:

> Steam compat -> Cache -> Download -> Cache

Effectively, new installations will always download the latest Proton, while existing ones will simply be warned to the console of a later version. Downloading is avoided if the latest version already exists in the cache, and the cache will be used as a last resort (e.g. download fails, digest mismatch, etc.) to set the variable. When we're unable to find an existing Proton or download one, we simply terminate the script as we there's no point using it without specifying Proton.

TODO:
- [x]  Change GE-Proton -> ULWGL-Proton
- [x]  Add tests
