### PR TITLE
Do not silence subprocess's exit code and avoid polluting `stdout`

### DIFF
--- a/ulwgl_run.py
+++ b/ulwgl_run.py
@@ -2,6 +2,7 @@
 
 import os
 import argparse
+from traceback import print_exception
 from argparse import ArgumentParser, Namespace
 import sys
 from pathlib import Path
@@ -281,7 +282,7 @@ def build_command(
     return command
 
 
-def main() -> None:  # noqa: D103
+def main() -> int:  # noqa: D103
     env: Dict[str, str] = {
         "WINEPREFIX": "",
         "GAMEID": "",
@@ -327,8 +328,12 @@ def main() -> None:  # noqa: D103
         os.environ[key] = val
 
     build_command(env, command, opts)
-    subprocess.run(command)
+    return subprocess.run(command).returncode
 
 
 if __name__ == "__main__":
-    main()
+    try:
+        sys.exit(main())
+    except Exception as e:  # noqa: BLE001
+        print_exception(e)
+        sys.exit(1)

--- a/ulwgl_run.py
+++ b/ulwgl_run.py
@@ -35,13 +35,13 @@ example usage:
 
     if not sys.argv[1:]:
         err: str = "Please see project README.md for more info and examples.\nhttps://github.com/Open-Wine-Components/ULWGL-launcher"
-        parser.print_help()
+        parser.print_help(sys.stderr)
         raise SystemExit(err)
 
     if sys.argv[1:][0] in opt_args:
         return parser.parse_args(sys.argv[1:])
 
-    return (sys.argv[1], sys.argv[2:])
+    return sys.argv[1], sys.argv[2:]
 
 
 def setup_pfx(path: str) -> None:


### PR DESCRIPTION
This PR aims to address the following issues.

* Capture and return the exit code from the `subprocess` to the caller in case ULWGL itself was executed successfully. The caller might use the exit code to identify issues in the execution of the subprocess or ULWGL itself. Note: the ruff check was explicitly disabled because the exception at [line](https://github.com/Open-Wine-Components/ULWGL-launcher/pull/31/commits/f0f557688c4f489f5aeb61b7c26227bafca4af0e#diff-3bad07da2f6fd387cac60a26fa0bf37268bf5a8b4b63e03a05fa30abbfc04385R338) is used for logging, similar to the patterns ruff [ignores by default]( https://docs.astral.sh/ruff/rules/blind-except/)

* ULWGL should use `stderr` only for its own logging to avoid polluting `stdout` where the caller might expect the result of the argument command. Examples of such internal commands are `winepath.exe` and `reg.exe` where the output can be used by the caller.

@R1kaB3rN Since you are actively working on the python code and they might cause conflicts, feel free to either cherry-pick or merge by hand any of these changes if you agree with them. I also updated a few long strings to not exceed the 100th column to make the code slightly easier to parse.