### PR TITLE
Remove requirement for setting WINEPREFIX

### DIFF
--- a/ulwgl_run.py
+++ b/ulwgl_run.py
@@ -19,6 +19,8 @@ def parse_args() -> Union[Namespace, Tuple[str, List[str]]]:  # noqa: D103
     exe: str = Path(__file__).name
     usage: str = f"""
 example usage:
+  GAMEID= {exe} /home/foo/example.exe
+  WINEPREFIX= GAMEID= {exe} /home/foo/example.exe
   WINEPREFIX= GAMEID= PROTONPATH= {exe} /home/foo/example.exe
   WINEPREFIX= GAMEID= PROTONPATH= {exe} /home/foo/example.exe -opengl
   WINEPREFIX= GAMEID= PROTONPATH= {exe} ""

--- a/ulwgl_run.py
+++ b/ulwgl_run.py
@@ -103,18 +103,24 @@ def check_env(
 
         return toml
 
-    if "WINEPREFIX" not in os.environ:
-        err: str = "Environment variable not set or not a directory: WINEPREFIX"
-        raise ValueError(err)
-
-    if not Path(os.environ["WINEPREFIX"]).expanduser().is_dir():
-        Path(os.environ["WINEPREFIX"]).mkdir(parents=True)
-    env["WINEPREFIX"] = os.environ["WINEPREFIX"]
-
     if "GAMEID" not in os.environ:
         err: str = "Environment variable not set: GAMEID"
         raise ValueError(err)
     env["GAMEID"] = os.environ["GAMEID"]
+
+    if (
+        "WINEPREFIX" not in os.environ
+        or not Path(os.environ["WINEPREFIX"]).expanduser().is_dir()
+    ):
+        # Automatically create a prefix for the user if WINEPREFIX is not set
+        # The GAMEID will be the name of the dir
+        pfx: Path = Path.home().joinpath("Games/ULWGL/" + env["GAMEID"])
+
+        pfx.mkdir(parents=True, exist_ok=True)
+        os.environ["WINEPREFIX"] = pfx.as_posix()
+        env["WINEPREFIX"] = os.environ["WINEPREFIX"]
+    else:
+        env["WINEPREFIX"] = os.environ["WINEPREFIX"]
 
     if "PROTONPATH" not in os.environ:
         os.environ["PROTONPATH"] = ""

--- a/ulwgl_run.py
+++ b/ulwgl_run.py
@@ -125,8 +125,16 @@ def check_env(
     if "PROTONPATH" not in os.environ:
         os.environ["PROTONPATH"] = ""
         get_ulwgl_proton(env)
-    elif Path("~/.local/share/Steam/compatibilitytools.d/" + os.environ["PROTONPATH"]).expanduser().is_dir():
-        env["PROTONPATH"] = Path("~/.local/share/Steam/compatibilitytools.d/").expanduser().joinpath(os.environ["PROTONPATH"])
+    elif (
+        Path("~/.local/share/Steam/compatibilitytools.d/" + os.environ["PROTONPATH"])
+        .expanduser()
+        .is_dir()
+    ):
+        env["PROTONPATH"] = (
+            Path("~/.local/share/Steam/compatibilitytools.d/")
+            .expanduser()
+            .joinpath(os.environ["PROTONPATH"])
+        )
     elif not Path(os.environ["PROTONPATH"]).expanduser().is_dir():
         os.environ["PROTONPATH"] = ""
         get_ulwgl_proton(env)

--- a/ulwgl_test.py
+++ b/ulwgl_test.py
@@ -1553,8 +1553,11 @@ class TestGameLauncher(unittest.TestCase):
             ulwgl_run.check_env(self.env)
 
     def test_env_vars_none(self):
-        """Tests check_env when setting no env vars."""
-        with self.assertRaisesRegex(ValueError, "WINEPREFIX"):
+        """Tests check_env when setting no env vars.
+
+        GAMEID should be the only strictly required env var
+        """
+        with self.assertRaisesRegex(ValueError, "GAMEID"):
             ulwgl_run.check_env(self.env)
 
 


### PR DESCRIPTION
Currently, setting the WINEPREFIX is a hard requirement and this PR makes it so the only hard requirement will be the GAMEID. To that end, we create the directories ~/Games/ULWGL/<ULWGL_ID> with the stem being the WINE prefix in which its title is the GAMEID.

As a result, a new valid usage will be:

GAMEID= ulwgl-run /home/foo/foo.exe
