### PR TITLE
Add version flag to launcher

### DIFF
--- a/ULWGL_VERSIONS.toml
+++ b/ULWGL_VERSIONS.toml
@@ -1,0 +1,3 @@
+[ulwgl.versions]
+runtime = "sniper_platform_0.20231211.70175"
+launcher = "0.1-RC3"

--- a/ulwgl_run.py
+++ b/ulwgl_run.py
@@ -7,7 +7,7 @@ from argparse import ArgumentParser, Namespace
 import sys
 from pathlib import Path
 import tomllib
-from typing import Dict, Any, List, Set, Union, Tuple, NoReturn
+from typing import Dict, Any, List, Set, Union, Tuple
 import ulwgl_plugins
 from re import match
 import subprocess
@@ -45,8 +45,8 @@ example usage:
     return sys.argv[1], sys.argv[2:]
 
 
-def print_versions(paths: List[Path]) -> NoReturn:
-    """Print the versions of this launcher and all of its associated tools declared in the config file.
+def get_versions(paths: List[Path]) -> str:
+    """Return the version of this launcher and all of its associated tools declared in the config file.
 
     NOTE: The following table is required: [ulwgl.versions]
     """
@@ -77,7 +77,7 @@ def print_versions(paths: List[Path]) -> NoReturn:
 
                 break
 
-    raise SystemExit(version)
+    return version
 
 
 def setup_pfx(path: str) -> None:
@@ -353,7 +353,10 @@ def main() -> int:  # noqa: D103
             Path(__file__).parent.joinpath("ULWGL_VERSIONS.toml"),
             Path("/usr/share/ULWGL/ULWGL_VERSIONS.toml"),
         ]
-        print_versions(paths)
+
+        print(get_versions(paths), file=sys.stderr)
+
+        return 0
 
     if isinstance(args, Namespace):
         set_env_toml(env, args)

--- a/ulwgl_run.py
+++ b/ulwgl_run.py
@@ -59,7 +59,11 @@ def print_versions(paths: List[Path]) -> NoReturn:
             with path.open(mode="rb") as file:
                 toml = tomllib.load(file)
 
-            if "ulwgl" in toml and "versions" in toml["ulwgl"]:
+            if (
+                "ulwgl" in toml
+                and "versions" in toml["ulwgl"]
+                and "launcher" in toml["ulwgl"]["versions"]
+            ):
                 exe: str = Path(__file__).name
                 launcher: str = toml["ulwgl"]["versions"]["launcher"]
                 tools: str = "\n".join(

--- a/ulwgl_test.py
+++ b/ulwgl_test.py
@@ -100,12 +100,37 @@ class TestGameLauncher(unittest.TestCase):
         if self.test_proton_dir.exists():
             rmtree(self.test_proton_dir.as_posix())
 
-    def test_print_versions(self):
-        """Test print_versions.
+    def test_versions_err(self):
+        """Test get_versions when for values we do not expect.
+
+        We expect: [ulwgl.versions] and launcher
+        Otherwise, we return an empty string
+        """
+        test_toml = "ULWGL_VERSIONS.toml"
+        result = ""
+        toml_str = """
+        [foo]
+        launcher = "foo"
+        runtime = "foo"
+        """
+        toml_path = self.test_file + "/" + test_toml
+        Path(toml_path).touch()
+
+        with Path(toml_path).open(mode="w") as file:
+            file.write(toml_str)
+
+        result = ulwgl_run.get_versions(
+            [Path(self.test_file).joinpath("ULWGL_VERSIONS.toml")]
+        )
+        self.assertFalse(result, "Expected an empty string for version")
+
+    def test_versions(self):
+        """Test get_versions.
 
         In the real usage, we search /usr/share/ULWGL or the current script's dir for the config.
         """
         test_toml = "ULWGL_VERSIONS.toml"
+        result = ""
         toml_str = """
         [ulwgl.versions]
         launcher = "foo"
@@ -117,10 +142,10 @@ class TestGameLauncher(unittest.TestCase):
         with Path(toml_path).open(mode="w") as file:
             file.write(toml_str)
 
-        with self.assertRaises(SystemExit):
-            ulwgl_run.print_versions(
-                [Path(self.test_file).joinpath("ULWGL_VERSIONS.toml")]
-            )
+        result = ulwgl_run.get_versions(
+            [Path(self.test_file).joinpath("ULWGL_VERSIONS.toml")]
+        )
+        self.assertTrue(result, "Expected a non-empty string for version")
 
     def test_latest_interrupt(self):
         """Test _get_latest in the event the user interrupts the download/extraction process.

--- a/ulwgl_test.py
+++ b/ulwgl_test.py
@@ -1486,13 +1486,10 @@ class TestGameLauncher(unittest.TestCase):
             "parse_args",
             return_value=argparse.Namespace(version=self.test_file),
         ):
-            with patch("ulwgl_run.print_versions"):
-                # Mock the print_version call
-                # The VM will probably not have the dirs/ULWGL_VERSIONS.toml file created
-                result = ulwgl_run.parse_args()
-                self.assertIsInstance(
-                    result, Namespace, "Expected a Namespace from parse_arg"
-                )
+            result = ulwgl_run.parse_args()
+            self.assertIsInstance(
+                result, Namespace, "Expected a Namespace from parse_arg"
+            )
 
     def test_env_proton_nodir(self):
         """Test check_env when $PROTONPATH is not set on failing to setting it.


### PR DESCRIPTION
Adds a version flag to launcher and prints the release version of the CLI as well as its associated tooling that are defined in the TOML config file -- ULWGL_VERSIONS.toml.

Example of ULWGL_VERSIONS.toml:

<pre>
# Required. We expect this table
[ulwgl.versions]
# Required. We expect this key
launcher = "1.0"
# All other key value pairs can be anything and we just print them all
reaper = "1.0" 
pressure_vessel = "1.0"
runtime = "sniper"
</pre>

NOTE: This file needs to be included in the release.

For the config. we check the current directory for the file and `/usr/share/ULWGL`. In case of absence, nothing will be printed.

As a result, versions for our tools are centralized and we avoid hard coding version names in scripts.  In addition, the version config files can be autogenerated via a Github Action
