### PR TITLE
Add initial logging functionality

### DIFF
--- a/ulwgl_consts.py
+++ b/ulwgl_consts.py
@@ -1,0 +1,26 @@
+from enum import Enum
+from logging import INFO, WARNING, DEBUG, ERROR
+
+SIMPLE_FORMAT = "%(levelname)s:  %(message)s"
+
+DEBUG_FORMAT = "%(levelname)s [%(module)s.%(funcName)s:%(lineno)s]:%(message)s"
+
+
+class Level(Enum):
+    """Represent the Log level values for the logger module."""
+
+    INFO = INFO
+    WARNING = WARNING
+    DEBUG = DEBUG
+    ERROR = ERROR
+
+
+class Color(Enum):
+    """Represent the color to be applied to a string."""
+
+    RESET = "\u001b[0m"
+    INFO = "\u001b[34m"
+    WARNING = "\033[33m"
+    ERROR = "\033[31m"
+    BOLD = "\033[1m"
+    DEBUG = "\u001b[35m"

--- a/ulwgl_log.py
+++ b/ulwgl_log.py
@@ -1,0 +1,13 @@
+import logging
+from sys import stderr
+from ulwgl_consts import SIMPLE_FORMAT, DEBUG_FORMAT
+
+simple_formatter = logging.Formatter(SIMPLE_FORMAT)
+debug_formatter = logging.Formatter(DEBUG_FORMAT)
+
+log = logging.getLogger(__name__)
+
+console_handler = logging.StreamHandler(stream=stderr)
+console_handler.setFormatter(simple_formatter)
+log.addHandler(console_handler)
+log.setLevel(logging.CRITICAL + 1)

--- a/ulwgl_util.py
+++ b/ulwgl_util.py
@@ -1,0 +1,20 @@
+from ulwgl_consts import Color, Level
+from typing import Any
+
+
+def msg(msg: Any, level: Level):
+    """Return a log message depending on the log level.
+
+    The message will bolden the typeface and apply a color.
+    Expects the first parameter to be a string or implement __str__
+    """
+    log: str = ""
+
+    if level == Level.INFO:
+        log = f"{Color.BOLD.value}{Color.INFO.value}{msg}{Color.RESET.value}"
+    elif level == Level.WARNING:
+        log = f"{Color.BOLD.value}{Color.WARNING.value}{msg}{Color.RESET.value}"
+    elif level == Level.DEBUG:
+        log = f"{Color.BOLD.value}{Color.DEBUG.value}{msg}{Color.RESET.value}"
+
+    return log


### PR DESCRIPTION
Closes https://github.com/Open-Wine-Components/ULWGL-launcher/issues/34

Add initial logging functionality for the launcher via the ULWGL_LOG environment variable. To enable logging, simply assign the values: 1, warn or debug. 

Example:

> ULWGL_LOG=debug GAMEID=0 ./ulwgl-run foo.exe

NOTE: This feature is primarily intended for developers to inspect the environment variables that are set or command that is to be executed.
