### PR TITLE
Make Zenity optional

### DIFF
--- a/ULWGL/ulwgl_dl_util.py
+++ b/ULWGL/ulwgl_dl_util.py
@@ -129,10 +129,8 @@ def _fetch_proton(
         )
 
         # Without the runtime, the launcher will not work
-        if resp and resp.status != 200:
-            err: str = (
-                f"Unable to download {proton}\nGithub returned the status {resp.status}"
-            )
+        if resp.status != 200:
+            err: str = f"Unable to download {proton}\ngithub.com returned the status: {resp.status}"
             raise HTTPException(err)
 
         with Path(cache.joinpath(proton).as_posix()).open(mode="wb") as file:

--- a/ULWGL/ulwgl_dl_util.py
+++ b/ULWGL/ulwgl_dl_util.py
@@ -9,6 +9,7 @@ from ssl import create_default_context
 from json import loads as loads_json
 from urllib.request import urlretrieve
 from sys import stderr
+from ulwgl_plugins import enable_zenity
 
 
 def get_ulwgl_proton(env: Dict[str, str]) -> Union[Dict[str, str]]:
@@ -114,11 +115,16 @@ def _fetch_proton(
     proton, proton_url = files[1]
     proton_dir: str = proton[: proton.find(".tar.gz")]  # Proton dir
 
-    # TODO: Parallelize this
     print(f"Downloading {hash} ...", file=stderr)
     urlretrieve(hash_url, cache.joinpath(hash).as_posix())
-    print(f"Downloading {proton} ...", file=stderr)
-    urlretrieve(proton_url, cache.joinpath(proton).as_posix())
+
+    try:
+        download_command: str = f"curl -LJ --progress-bar {proton_url} -o {cache.joinpath(proton).as_posix()}"
+        msg: str = f"Downloading {proton} ..."
+        enable_zenity(download_command, msg)
+    except FileNotFoundError:
+        print(f"Downloading {proton} ...", file=stderr)
+        urlretrieve(proton_url, cache.joinpath(proton).as_posix())
 
     print("Completed.", file=stderr)
 

--- a/ULWGL/ulwgl_dl_util.py
+++ b/ULWGL/ulwgl_dl_util.py
@@ -120,7 +120,7 @@ def _fetch_proton(
 
     try:
         download_command: str = f"curl -LJ --progress-bar {proton_url} -o {cache.joinpath(proton).as_posix()}"
-        msg: str = f"Downloading {proton} ..."
+        msg: str = f"Downloading {proton_dir} ..."
         enable_zenity(download_command, msg)
     except FileNotFoundError:
         print(f"Downloading {proton} ...", file=stderr)

--- a/ULWGL/ulwgl_test.py
+++ b/ULWGL/ulwgl_test.py
@@ -447,7 +447,9 @@ class TestGameLauncher(unittest.TestCase):
         self.test_compat.joinpath("ULWGL-Launcher").mkdir()
         for file in runner_files:
             if file == "ulwgl-run":
-                self.test_compat.joinpath("ulwgl-run").symlink_to("../../../ulwgl_run.py")
+                self.test_compat.joinpath("ulwgl-run").symlink_to(
+                    "../../../ulwgl_run.py"
+                )
             else:
                 with self.test_compat.joinpath(file).open(mode="w") as filer:
                     filer.write("foo")
@@ -856,7 +858,6 @@ class TestGameLauncher(unittest.TestCase):
         if test_dir.exists():
             test_dir.joinpath("ULWGL_VERSION.json").unlink()
             test_dir.rmdir()
-
 
     def test_copy(self):
         """Test copyfile_reflink.

--- a/ULWGL/ulwgl_util.py
+++ b/ULWGL/ulwgl_util.py
@@ -81,8 +81,8 @@ def setup_runtime(root: Path, json: Dict[str, Any]) -> None:  # noqa: D103
         )
 
         # Without the runtime, the launcher will not work
-        if resp and resp.status != 200:
-            err: str = f"Unable to download the Steam Runtime\nrepo.steampowered.com returned the status {resp.status}"
+        if resp.status != 200:
+            err: str = f"Unable to download the Steam Runtime\nrepo.steampowered.com returned the status: {resp.status}"
             raise HTTPException(err)
 
         log.debug(f"Writing: {tar_path}")


### PR DESCRIPTION
Closes https://github.com/Open-Wine-Components/ULWGL-launcher/issues/44

Zenity will be used when downloading Proton and makes it an optional dependency. In the case when Zenity can't be found, the launcher falls back to printing to stderr. 
