### PR TITLE
Create `ULWGL_VERSION.json` when building

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ var
 builddir
 __pycache__
 .ref
+ULWGL/ULWGL_VERSION.json
+Makefile

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@ var
 builddir
 __pycache__
 .ref
-ULWGL/ULWGL_VERSION.json
+ULWGL_VERSION.json
+ULWGL_VERSION.json.in.tmp
 Makefile

--- a/Makefile.in
+++ b/Makefile.in
@@ -1,3 +1,5 @@
+PROJECT := ulwgl-launcher
+
 # If this is changed to ULWGL (uppercase), `uninstall` target will also remove the SLR directory
 INSTALLDIR ?= ulwgl
 
@@ -16,7 +18,7 @@ USERINSTALL ?= xfalse
 all: version reaper ulwgl ulwgl-launcher
 
 
-# Special case, do this inside the source directory for release source distribution
+# Special case, do this inside the source directory for release distribution
 ULWGL/ULWGL_VERSION.json: ULWGL/ULWGL_VERSION.json.in
 	$(info :: Updating $(@) )
 	cp $(<) $(<).tmp
@@ -93,36 +95,43 @@ reaper-install: reaper
 	install -Dm 755 $(OBJDIR)/$</$< -t $(DESTDIR)$(DATADIR)/$(INSTALLDIR)
 
 
-.PHONY: $(OBJDIR)
 $(OBJDIR):
-	@mkdir -p $(OBJDIR)
+	@mkdir -p $(@)
 
 
 .PHONY: clean
 clean:
-	$(info Cleaning "$(OBJDIR)" build directory)
-	@rm -rf -v $(OBJDIR) ULWGL/ULWGL_VERSION.json
+	$(info :: Cleaning source directory )
+	@rm -rf -v $(OBJDIR) ULWGL/ULWGL_VERSION.json ./$(RELEASEDIR) $(RELEASEDIR).tar.gz
 
+
+RELEASEDIR := $(PROJECT)-$(shell git describe --abbrev=0)
+$(RELEASEDIR):
+	mkdir -p $(@)
 
 .PHONY: release
-release: version
-	$(info Creating source distribution for release)
+release: $(RELEASEDIR) | version
+	$(info :: Creating source distribution for release )
+	mkdir -p $(<)
+	rm -rf ULWGL/__pycache__
+	cp -r ULWGL flatpak subprojects Makefile.in configure.sh README.md LICENSE $(<)
+	tar -cvzf $(<).tar.gz $(<)
 
 
 .PHONY: uninstall
 # NEVER use a wildcard here
 uninstall:
-	$(info Removing $(INSTALLDIR) files in $(DESTDIR)$(BINDIR))
+	$(info :: Removing $(INSTALLDIR) files in $(DESTDIR)$(BINDIR) )
 	@rm -rf -v --preserve-root=all $(DESTDIR)$(BINDIR)/ulwgl-run
-	$(info Removing $(INSTALLDIR) directory in $(DESTDIR)$(DATADIR))
+	$(info :: Removing $(INSTALLDIR) directory in $(DESTDIR)$(DATADIR) )
 	@rm -rf -v --preserve-root=all $(DESTDIR)$(DATADIR)/$(INSTALLDIR)
 
 
 .PHONY: user-install
 user-install:
-	$(info :: ---)
-	$(info :: Installed under user-only location "$(DATADIR)/$(INSTALLDIR)")
-	$(info :: To run you need to make sure "$(BINDIR)" is in your PATH)
+	$(info :: --- )
+	$(info :: Installed under user-only location "$(DATADIR)/$(INSTALLDIR)" )
+	$(info :: To run you need to make sure "$(BINDIR)" is in your PATH )
 
 
 .PHONY: install

--- a/Makefile.in
+++ b/Makefile.in
@@ -13,7 +13,24 @@ USERINSTALL ?= xfalse
 
 
 .PHONY: all
-all: reaper ulwgl ulwgl-launcher
+all: version reaper ulwgl ulwgl-launcher
+
+
+# Special case, do this inside the source directory for release source distribution
+ULWGL/ULWGL_VERSION.json: ULWGL/ULWGL_VERSION.json.in
+	$(info :: Updating $(@) )
+	cp $(<) $(<).tmp
+	sed 's|##ULWGL_VERSION##|$(shell git describe --always --long --tags)|g' -i $(<).tmp
+	sed 's|##REAPER_VERSION##|$(shell git -C subprojects/reaper describe --always --long --tags)|g' -i $(<).tmp
+	mv $(<).tmp $(@)
+
+.PHONY: version
+version: ULWGL/ULWGL_VERSION.json
+
+version-install: version
+	$(info :: Installing ULWGL_VERSION.json )
+	install -d $(DESTDIR)$(DATADIR)/$(INSTALLDIR)
+	install -Dm 644 ULWGL/ULWGL_VERSION.json -t $(DESTDIR)$(DATADIR)/$(INSTALLDIR)
 
 
 $(OBJDIR)/.build-ulwgl: | $(OBJDIR)
@@ -28,7 +45,7 @@ ulwgl-bin-install: ulwgl
 	install -d $(DESTDIR)$(BINDIR)
 	install -Dm 755 $(OBJDIR)/$(<)-run $(DESTDIR)$(BINDIR)/ulwgl-run
 
-ulwgl-dist-install:
+ulwgl-dist-install: version-install
 	$(info :: Installing ulwgl )
 	install -d $(DESTDIR)$(DATADIR)/$(INSTALLDIR)
 	install -Dm 644 ULWGL/ulwgl_consts.py    -t $(DESTDIR)$(DATADIR)/$(INSTALLDIR)
@@ -37,12 +54,8 @@ ulwgl-dist-install:
 	install -Dm 644 ULWGL/ulwgl_plugins.py   -t $(DESTDIR)$(DATADIR)/$(INSTALLDIR)
 	install -Dm 755 ULWGL/ulwgl_run.py     	 -t $(DESTDIR)$(DATADIR)/$(INSTALLDIR)
 	install -Dm 644 ULWGL/ulwgl_util.py      -t $(DESTDIR)$(DATADIR)/$(INSTALLDIR)
-	install -Dm 644 ULWGL/ULWGL_VERSION.json -t $(DESTDIR)$(DATADIR)/$(INSTALLDIR)
 
-# Install both dist and sh script target
 ulwgl-install: ulwgl-dist-install ulwgl-bin-install
-# Install dist only target
-#ulwgl-install: ulwgl-dist-install
 
 
 $(OBJDIR)/.build-ulwgl-launcher: | $(OBJDIR)
@@ -63,9 +76,6 @@ ulwgl-launcher-dist-install:
 	install -Dm 644 ULWGL/ULWGL-Launcher/compatibilitytool.vdf -t $(DESTDIR)$(DATADIR)/$(INSTALLDIR)/ULWGL-Launcher
 	install -Dm 644 ULWGL/ULWGL-Launcher/toolmanifest.vdf      -t $(DESTDIR)$(DATADIR)/$(INSTALLDIR)/ULWGL-Launcher
 
-# Install both dist and sh script target
-#ulwgl-launcher-install: ulwgl-launcher-dist-install ulwgl-launcher-bin-install
-# Install dist only target
 ulwgl-launcher-install: ulwgl-launcher-dist-install
 
 
@@ -91,7 +101,12 @@ $(OBJDIR):
 .PHONY: clean
 clean:
 	$(info Cleaning "$(OBJDIR)" build directory)
-	@rm -rf -v $(OBJDIR)
+	@rm -rf -v $(OBJDIR) ULWGL/ULWGL_VERSION.json
+
+
+.PHONY: release
+release: version
+	$(info Creating source distribution for release)
 
 
 .PHONY: uninstall

--- a/ULWGL/ULWGL_VERSION.json.in
+++ b/ULWGL/ULWGL_VERSION.json.in
@@ -1,10 +1,10 @@
 {
   "ulwgl": {
     "versions": {
-      "launcher": "0.1-RC3",
-      "runner": "0.1-RC3",
+      "launcher": "##ULWGL_VERSION##",
+      "runner": "##ULWGL_VERSION##",
       "runtime_platform": "sniper_platform_0.20240125.75305",
-      "reaper": "1.0",
+      "reaper": "##REAPER_VERSION##",
       "pressure_vessel": "v0.20240212.0"
     }
   }


### PR DESCRIPTION
This PR adds the ability to create `ULWGL_VERSION.json` when building. This should help with packages tracking development and automate updates.

New targets:
* `make version` : Creates `ULWGL_VERSION.json` from `ULWGL_VERSION.json.in` by using `git describe` on the the project's directory. It also updates `reaper` version in the same way. The version is described in the `--long` format for uniqueness.
* `make release` : Creates a release tarball versioned by the most recent tag. Useful for source releases that can be downloaded and built.

The `version` target is automatically run when appropriate when building.

For development purposes `make version` can also be used to prepare `ULWGL_VERSION.json` when running from source.