### PR TITLE
RFC: Add option to use gamescope in behalf of clients

### DIFF
--- a/ULWGL/ulwgl_consts.py
+++ b/ULWGL/ulwgl_consts.py
@@ -1,5 +1,6 @@
 from enum import Enum
 from pathlib import Path
+from typing import Dict, Any
 
 
 class Color(Enum):
@@ -35,3 +36,5 @@ PROTON_VERBS = {
     "getcompatpath",
     "getnativepath",
 }
+
+TOMLDocument = Dict[str, Any]

--- a/ULWGL/ulwgl_run.py
+++ b/ULWGL/ulwgl_run.py
@@ -20,6 +20,8 @@ from ulwgl_plugins import (
     set_env_toml,
     enable_reaper,
     enable_systemd,
+    enable_gamescope,
+)
 from ulwgl_consts import (
     PROTON_VERBS,
     DEBUG_FORMAT,
@@ -270,6 +272,22 @@ def build_command(
         log.debug("Using reaper as subreaper")
         enable_reaper(env, command, local)
 
+    # Gamescope
+    if env.get("ULWGL_GAMESCOPE") == "1":
+        log.debug("Using gamescope")
+        enable_gamescope(env, command)
+    elif (
+        config
+        and config.get("ulwgl").get("gamescope")
+        and config.get("plugins")
+        and config.get("plugins").get("gamescope")
+        and config.get("plugins").get("gamescope").get("options")
+    ):
+        log.debug("Using gamescope")
+        enable_gamescope(
+            env, command, config.get("plugins").get("gamescope").get("options")
+        )
+
     command.extend([local.joinpath("ULWGL").as_posix(), "--verb", verb, "--"])
     command.extend(
         [
@@ -307,6 +325,7 @@ def main() -> int:  # noqa: D103
         "STORE": "",
         "PROTON_VERB": "",
         "ULWGL_ID": "",
+        "ULWGL_GAMESCOPE": "",
         "ULWGL_SYSTEMD": "",
     }
     command: List[str] = []

--- a/ULWGL/ulwgl_test_plugins.py
+++ b/ULWGL/ulwgl_test_plugins.py
@@ -170,6 +170,127 @@ class TestGameLauncherPlugins(unittest.TestCase):
         if self.test_local_share.exists():
             rmtree(self.test_local_share.as_posix())
 
+    def test_build_command_systemd(self):
+        """Test build_command when systemd is set as the subreaper."""
+        test_toml = "foo.toml"
+        toml_str = f"""
+        [ulwgl]
+        prefix = "{self.test_file}"
+        proton = "{self.test_file}"
+        game_id = "{self.test_file}"
+        launch_args = ["{self.test_file}", "{self.test_file}"]
+        exe = "{self.test_exe}"
+        reaper = false
+        """
+        toml_path = self.test_file + "/" + test_toml
+        result = None
+        test_command = []
+        test_command_result = None
+        toml = None
+
+        Path(self.test_file + "/proton").touch()
+        Path(toml_path).touch()
+
+        with Path(toml_path).open(mode="w") as file:
+            file.write(toml_str)
+
+        with patch.object(
+            ulwgl_run,
+            "parse_args",
+            return_value=argparse.Namespace(config=toml_path),
+        ):
+            # Args
+            result = ulwgl_run.parse_args()
+            # Config
+            self.env, opts, toml = ulwgl_plugins.set_env_toml(self.env, result)
+            # Prefix
+            ulwgl_run.setup_pfx(self.env["WINEPREFIX"])
+            # Env
+            ulwgl_run.set_env(self.env, result)
+            # Game drive
+            ulwgl_plugins.enable_steam_game_drive(self.env)
+
+        # Mock setting up the runtime
+        with patch.object(
+            ulwgl_util,
+            "setup_runtime",
+            return_value=None,
+        ):
+            ulwgl_util._install_ulwgl(
+                self.test_user_share, self.test_local_share, self.test_compat, json
+            )
+            copytree(
+                Path(self.test_user_share, "sniper_platform_0.20240125.75305"),
+                Path(self.test_local_share, "sniper_platform_0.20240125.75305"),
+                dirs_exist_ok=True,
+                symlinks=True,
+            )
+            copy(Path(self.test_user_share, "run"), Path(self.test_local_share, "run"))
+            copy(
+                Path(self.test_user_share, "run-in-sniper"),
+                Path(self.test_local_share, "run-in-sniper"),
+            )
+            copy(
+                Path(self.test_user_share, "ULWGL"),
+                Path(self.test_local_share, "ULWGL"),
+            )
+            # When the runtime updates, pressure vessel needs to be updated
+            copytree(
+                Path(self.test_user_share, "pressure-vessel"),
+                Path(self.test_local_share, "pressure-vessel"),
+                dirs_exist_ok=True,
+                symlinks=True,
+            )
+
+        for key, val in self.env.items():
+            os.environ[key] = val
+
+        # Build
+        test_command_result = ulwgl_run.build_command(
+            self.env, self.test_local_share, test_command, config=toml
+        )
+        self.assertTrue(
+            test_command_result is test_command, "Expected the same reference"
+        )
+
+        # Verify contents of the command
+        (
+            reaper,
+            systemd_opt0,
+            systemd_opt1,
+            systemd_opt2,
+            systemd_opt3,
+            systemd_opt4,
+            entry_point,
+            opt1,
+            verb,
+            opt2,
+            proton,
+            verb2,
+            exe,
+        ) = [*test_command]
+        # The entry point dest could change and binary paths could vary.
+        # Just check if there's a value for the reaper and the entry point
+        self.assertTrue(reaper, "Expected systemd")
+        self.assertEqual(systemd_opt0, "--user", "Expected --user")
+        self.assertEqual(systemd_opt1, "--scope", "Expected --scope")
+        self.assertEqual(systemd_opt2, "--send-sighup", "Expected --sighup")
+        self.assertEqual(systemd_opt3, "--description", "Expected --description")
+        self.assertEqual(
+            systemd_opt4, "ulwgl-" + self.env["ULWGL_ID"], "Expected ULWGL_ID to be set"
+        )
+        self.assertTrue(entry_point, "Expected an entry point")
+        self.assertEqual(opt1, "--verb", "Expected --verb")
+        self.assertEqual(verb, self.test_verb, "Expected a verb")
+        self.assertEqual(opt2, "--", "Expected --")
+        self.assertEqual(
+            proton,
+            Path(self.env.get("PROTONPATH") + "/proton").as_posix(),
+            "Expected the proton file",
+        )
+        self.assertEqual(verb2, self.test_verb, "Expected a verb")
+        self.assertEqual(exe, self.env["EXE"], "Expected the EXE")
+
     def test_build_command_entry(self):
         """Test build_command.
 
@@ -409,6 +530,44 @@ class TestGameLauncherPlugins(unittest.TestCase):
         )
         self.assertEqual(verb2, self.test_verb, "Expected a verb")
         self.assertEqual(exe, self.env["EXE"], "Expected the EXE")
+
+    def test_set_env_toml_reaper(self):
+        """Test set_env_toml for reaper.
+
+        A ValueError should be raised if a boolean is not set
+        """
+        test_toml = "foo.toml"
+        toml_path = self.test_file + "/" + test_toml
+        toml_str = f"""
+        [ulwgl]
+        prefix = "{self.test_file}"
+        proton = "{self.test_file}"
+        game_id = "{self.test_file}"
+        launch_args = ["{toml_path}"]
+        exe = "{self.test_exe}"
+        reaper = "foo"
+        """
+        result = None
+
+        Path(toml_path).touch()
+
+        with Path(toml_path).open(mode="w") as file:
+            file.write(toml_str)
+
+        with patch.object(
+            ulwgl_run,
+            "parse_args",
+            return_value=argparse.Namespace(config=toml_path),
+        ):
+            # Args
+            result = ulwgl_run.parse_args()
+            self.assertIsInstance(
+                result, Namespace, "Expected a Namespace from parse_arg"
+            )
+            self.assertTrue(vars(result).get("config"), "Expected a value for --config")
+            # Env
+            with self.assertRaisesRegex(ValueError, "reaper"):
+                ulwgl_plugins.set_env_toml(self.env, result)
 
     def test_set_env_toml_nofile(self):
         """Test set_env_toml for values that are not a file.


### PR DESCRIPTION
### Summary
The launcher is responsible for subreaping in behalf of clients, however, we're not able to fullfill that responsibility if gamescope is used which will cause their users' games to not run when the game had exited improperly (e.g, closing the game window, control+c, etc.). As a result, clients are required to handle killing the zombie wine processes themselves which will require a proper subreaping system in place to do effectively.

However, by giving clients the **option** to use gamescope via ULWGL, we can ensure **all** zombie processes are killed for the client via systemd when the user exits their game improperly.

### Usage
To use systemd as the subreaper instead of Reaper, clients must set `ULWGL_SYSTEMD=1`. Example:

> ULWGL_SYSTEMD=1 WINEPREFIX=... PROTONPATH=... GAMEID=... ulwgl-run ...

To use gamescope, set `ULWGL_GAMESCOPE=1` and **optionally** write the gamescope options to `~/.local/share/ULWGL/state/ulwgl-$ULWGL_ID.json` for the launcher to read. Example:

```
 [
  {
    "name": "gamescope",
    "options": ["-F", "fsr"]
  }
]
```
After optionally defining the gamescope options, run:
> WINEPREFIX=... PROTONPATH=... GAMEID=... ULWGL_GAMESCOPE=1 ulwgl-run ...

### Complete usage
Systemd is **required** to ensure all lingering processes are killed when the game exits improperly when using gamescope. Therefore, to take full advantage of this feature, run: 
`> WINEPREFIX=... PROTONPATH=... GAMEID=... ULWGL_GAMESCOPE=1 ULWGL_SYSTEMD=1 ulwgl-run ...`

Or when using a configuration file:

> [ulwgl]
> prefix = "/home/foo/WINE/foo"
> exe = "/home/foo/Games/foo.exe"
> proton = "/home/foo/Proton/GE-Proton9-1"
> game_id = "0"
> gamescope = true
> reaper = false
> 
> [plugins.gamescope]
> options = ["-F", "fsr"] # Valid gamescope arguments