### PR TITLE
Add feature to use Gamescope

### DIFF
--- a/ULWGL/ulwgl_consts.py
+++ b/ULWGL/ulwgl_consts.py
@@ -12,6 +12,33 @@ class Color(Enum):
     DEBUG = "\u001b[35m"
 
 
+class GamescopeOptions(Enum):
+    """Represent valid and recognizable gamescope 3.14.2+ options organized by types."""
+
+    NUMBERS = {
+        "output-width",
+        "output-height",
+        "nested-width",
+        "nested-height",
+        "nested-refresh",
+        "sharpness",
+        "framerate-limit",
+        "sdr-gamut-wideness",
+        "hdr-sdr-content-nits",
+        "hdr-itm-enable",
+        "hdr-itm-target-nits",
+    }
+    STRINGS = {
+        "filter",
+        "hdr-enabled",
+    }
+    BOOLS = {
+        "immediate-flips",
+        "adaptive-sync",
+        "grab",
+    }
+
+
 SIMPLE_FORMAT = f"%(levelname)s:  {Color.BOLD.value}%(message)s{Color.RESET.value}"
 
 DEBUG_FORMAT = f"%(levelname)s [%(module)s.%(funcName)s:%(lineno)s]:{Color.BOLD.value}%(message)s{Color.RESET.value}"

--- a/ULWGL/ulwgl_run.py
+++ b/ULWGL/ulwgl_run.py
@@ -11,6 +11,7 @@ from ulwgl_plugins import (
     set_env_toml,
     enable_reaper,
     enable_systemd,
+    enable_gamescope,
 )
 from re import match
 from subprocess import run
@@ -241,8 +242,18 @@ def build_command(
         err: str = "The following file was not found in PROTONPATH: proton"
         raise FileNotFoundError(err)
 
+    # Gamescope
+    if (
+        toml
+        and toml["ulwgl"].get("gamescope")
+        and toml.get("plugins")
+        and toml.get("plugins").get("gamescope")
+    ):
+        log.debug("Using gamescope")
+        enable_gamescope(env, command, toml)
+
     # Subreaper
-    if toml and not toml["ulwgl"]["reaper"]:
+    if toml and "reaper" in toml["ulwgl"] and not toml["ulwgl"]["reaper"]:
         log.debug("Using systemd as subreaper")
         enable_systemd(env, command)
     else:
@@ -334,6 +345,7 @@ if __name__ == "__main__":
         sys.exit(main())
     except KeyboardInterrupt:
         log.warning("Keyboard Interrupt")
+        log.warning("Child processes may still exist if using Gamescope")
         sys.exit(1)
     except Exception as e:  # noqa: BLE001
         print_exception(e)


### PR DESCRIPTION
Intended for the configuration file usage and native package installations, this feature gives users the option to use the [Gamescope](https://github.com/ValveSoftware/gamescope) microcompositor when running games from the command line. Support for launchers is currently out of scope as it's most likely implemented already by them

This feature can be enabled by setting the `gamescope` key in the configuration file and assigning the boolean value `true`. To set options for gamescope, the table `[plugins.gamescope]` must also be defined. For example:

> [ulwgl]
> prefix = "home/foo/foo_prefix"
> exe = "/home/foo/foo.exe"
> game_id = "0"
> proton = "/home/foo/GE-Proton8-30"
> reaper = false
> gamescope = true

> [plugins.gamescope]
> nested_width = 1280
> nested_height = 720
> filter = "fsr"
> sdr_gamut_wideness = 1
> framerate_limit = 0
> grab = true

Then run:
> ulwgl-run --config config.toml

Please note that when enabling gamescope, the subreaper may not properly kill all descendent processes in the event of an interrupt or closing the game window. This is currently being investigated.

Also, only a subset of gamescope options are supported (for now) which are: 
- "output-width"
- "output-height"
- "nested-width"
- "nested-height"
- "nested-refresh"
- "sharpness"
- "framerate-limit"
- "sdr-gamut-wideness"
- "hdr-sdr-content-nits"
- "hdr-itm-enable"
- "hdr-itm-target-nits"
- "filter"
- "hdr-enabled"
- "immediate-flips"
- "adaptive-sync"
- "grab"
