### PR TITLE
Change update routine

### DIFF
--- a/ULWGL/ulwgl_test.py
+++ b/ULWGL/ulwgl_test.py
@@ -228,6 +228,13 @@ class TestGameLauncher(unittest.TestCase):
                 Path(self.test_user_share, "ULWGL"),
                 Path(self.test_local_share, "ULWGL"),
             )
+            # When the runtime updates, pressure vessel needs to be updated
+            copytree(
+                Path(self.test_user_share, "pressure-vessel"),
+                Path(self.test_local_share, "pressure-vessel"),
+                dirs_exist_ok=True,
+                symlinks=True,
+            )
 
         self.assertFalse(result, "Expected None when calling _update_ulwgl")
 
@@ -378,7 +385,8 @@ class TestGameLauncher(unittest.TestCase):
             "ulwgl-run",
         ]
         # Mock an outdated ULWGL_VERSION.json in ~/.local/share/ULWGL
-        # Downgrade these files: launcher, runner, runtime_platform, pressure_vessel
+        # Downgrade these files: launcher, runner, runtime_platform
+        # We don't downgrade Pressure Vessel because it's a runtime property
         config = {
             "ulwgl": {
                 "versions": {
@@ -386,7 +394,7 @@ class TestGameLauncher(unittest.TestCase):
                     "runner": "0.1-RC2",
                     "runtime_platform": "sniper_platform_0.20240125.75304",
                     "reaper": "1.0",
-                    "pressure_vessel": "v0.20240211.0",
+                    "pressure_vessel": "v0.20240212.0",
                 }
             }
         }
@@ -491,6 +499,13 @@ class TestGameLauncher(unittest.TestCase):
             copy(
                 Path(self.test_user_share, "ULWGL"),
                 Path(self.test_local_share, "ULWGL"),
+            )
+            # When the runtime updates, pressure vessel needs to be updated
+            copytree(
+                Path(self.test_user_share, "pressure-vessel"),
+                Path(self.test_local_share, "pressure-vessel"),
+                dirs_exist_ok=True,
+                symlinks=True,
             )
 
         self.assertFalse(result, "Expected None when calling _update_ulwgl")

--- a/ULWGL/ulwgl_util.py
+++ b/ULWGL/ulwgl_util.py
@@ -303,16 +303,28 @@ def _update_ulwgl(
             # Old runtime
             runtime: str = json_local["ulwgl"]["versions"]["runtime_platform"]
 
-            # Directory is absent
-            if not (local.joinpath(runtime).is_dir() or local.joinpath(val).is_dir()):
+            # Redownload the runtime if absent or pressure vessel is absent
+            if (
+                not local.joinpath(runtime).is_dir()
+                or not local.joinpath("pressure-vessel").is_dir()
+            ):
+                # Redownload
                 log.warning("Runtime Platform not found")
+                if local.joinpath("pressure-vessel").is_dir():
+                    rmtree(local.joinpath("pressure-vessel").as_posix())
+                if local.joinpath(runtime).is_dir():
+                    rmtree(local.joinpath(runtime).as_posix())
 
-                # Download the runtime from the official source
                 setup_runtime(root, json_root)
-            elif local.joinpath(runtime).is_dir() and val != runtime:
+                log.console(f"Restored Runtime Platform to {val}")
+            elif (
+                local.joinpath(runtime).is_dir()
+                and local.joinpath("pressure-vessel").is_dir()
+                and val != runtime
+            ):
                 # Update
                 log.console(f"Updating {key} to {val}")
-
+                rmtree(local.joinpath("pressure-vessel").as_posix())
                 rmtree(local.joinpath(runtime).as_posix())
                 setup_runtime(root, json_root)
 

--- a/ULWGL/ulwgl_util.py
+++ b/ULWGL/ulwgl_util.py
@@ -299,34 +299,6 @@ def _update_ulwgl(
                 copy(root.joinpath("reaper"), local.joinpath("reaper"))
 
                 json_local["ulwgl"]["versions"]["reaper"] = val
-        elif key == "pressure_vessel":
-            # Pressure Vessel
-            pv: str = json_local["ulwgl"]["versions"]["pressure_vessel"]
-
-            # Directory is absent
-            if not local.joinpath("pressure-vessel").is_dir():
-                log.warning("Pressure Vessel not found")
-                log.console(f"Copying {key} -> {val} ...")
-
-                copytree(
-                    root.joinpath("pressure-vessel"),
-                    local.joinpath("pressure-vessel"),
-                    dirs_exist_ok=True,
-                    symlinks=True,
-                )
-            elif local.joinpath("pressure-vessel").is_dir() and val != pv:
-                # Update
-                log.console(f"Updating {key} to {val}")
-
-                rmtree(local.joinpath("pressure-vessel").as_posix())
-                copytree(
-                    root.joinpath("pressure-vessel"),
-                    local.joinpath("pressure-vessel"),
-                    dirs_exist_ok=True,
-                    symlinks=True,
-                )
-
-                json_local["ulwgl"]["versions"]["pressure_vessel"] = val
         elif key == "runtime_platform":
             # Old runtime
             runtime: str = json_local["ulwgl"]["versions"]["runtime_platform"]

--- a/ULWGL/ulwgl_util.py
+++ b/ULWGL/ulwgl_util.py
@@ -287,9 +287,8 @@ def _update_ulwgl(
             # Directory is absent
             if not local.joinpath("reaper").is_file():
                 log.warning("Reaper not found")
-                log.console(f"Copying {key} -> {local} ...")
-
                 copy(root.joinpath("reaper"), local.joinpath("reaper"))
+                log.console(f"Restored {key} to {val} ...")
 
             # Update
             if val != reaper:
@@ -372,7 +371,6 @@ def _update_ulwgl(
             # Directory is absent
             if not steam_compat.joinpath("ULWGL-Launcher").is_dir():
                 log.warning("ULWGL-Launcher not found")
-                log.console(f"Copying ULWGL-Launcher ->  {steam_compat} ...")
 
                 copytree(
                     root.joinpath("ULWGL-Launcher"),
@@ -384,6 +382,7 @@ def _update_ulwgl(
                 steam_compat.joinpath("ULWGL-Launcher", "ulwgl-run").symlink_to(
                     "../../../ULWGL/ulwgl_run.py"
                 )
+                log.console(f"Restored ULWGL-Launcher to {val}")
             elif steam_compat.joinpath("ULWGL-Launcher").is_dir() and val != runner:
                 # Update
                 log.console(f"Updating {key} to {val}")


### PR DESCRIPTION
This changes the update logic so Pressure Vessel updates when the runtime platform needs an update. Before, when the runtime platform changed, Pressure Vessel wouldn't be deleted first. Moreover, the old logic was still there, which had assumed it was still stored in the root directory.

This also makes it so the launcher attempts to restore missing Python files in ~/.local/share/ULWGL.