### PR TITLE
Update Flatpak support

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -13,10 +13,15 @@ MANDIR  := $(DATADIR)/man
 
 DESTDIR ?=
 USERINSTALL ?= xfalse
+FLATPAK ?= xfalse
 
 
 .PHONY: all
+ifeq ($(FLATPAK), xtrue)
+all: version reaper umu umu-launcher
+else
 all: version reaper umu umu-docs umu-launcher
+endif
 
 .PHONY: install
 ifeq ($(USERINSTALL), xtrue)
@@ -79,11 +84,14 @@ umu-dist-install:
 	install -Dm 644 umu/umu_dl_util.py   -t $(DESTDIR)$(DATADIR)/$(INSTALLDIR)
 	install -Dm 644 umu/umu_log.py       -t $(DESTDIR)$(DATADIR)/$(INSTALLDIR)
 	install -Dm 644 umu/umu_plugins.py   -t $(DESTDIR)$(DATADIR)/$(INSTALLDIR)
-	install -Dm 755 umu/umu_run.py     	 -t $(DESTDIR)$(DATADIR)/$(INSTALLDIR)
+	install -Dm 755 umu/umu_run.py       -t $(DESTDIR)$(DATADIR)/$(INSTALLDIR)
 	install -Dm 644 umu/umu_util.py      -t $(DESTDIR)$(DATADIR)/$(INSTALLDIR)
 
+ifeq ($(FLATPAK), xtrue)
+umu-install: version-install umu-dist-install umu-bin-install
+else
 umu-install: version-install umu-dist-install umu-docs-install umu-bin-install
-
+endif
 
 # umu-launcher is separate to allow control over installing the bin target
 $(OBJDIR)/.build-umu-launcher: | $(OBJDIR)

--- a/Makefile.in
+++ b/Makefile.in
@@ -93,10 +93,16 @@ else
 umu-install: version-install umu-dist-install umu-docs-install umu-bin-install
 endif
 
+ifeq ($(FLATPAK), xtrue)
+UMU_LAUNCHER_COMMAND = org.openwinecomponents.umu.launcher
+else
+UMU_LAUNCHER_COMMAND = $(DATADIR)/$(INSTALLDIR)/umu_run.py
+endif
+
 # umu-launcher is separate to allow control over installing the bin target
 $(OBJDIR)/.build-umu-launcher: | $(OBJDIR)
 	$(info :: Building umu-launcher )
-	sed 's|##INSTALL_PATH##|$(DATADIR)/$(INSTALLDIR)|g' umu/umu-launcher/umu-run.in > $(OBJDIR)/umu-launcher-run
+	sed 's|##INSTALL_PATH##|$(UMU_LAUNCHER_COMMAND)|g' umu/umu-launcher/umu-run.in > $(OBJDIR)/umu-launcher-run
 	touch $(@)
 
 .PHONY: umu-launcher
@@ -112,8 +118,7 @@ umu-launcher-dist-install:
 	install -Dm 644 umu/umu-launcher/compatibilitytool.vdf -t $(DESTDIR)$(DATADIR)/$(INSTALLDIR)/umu-launcher
 	install -Dm 644 umu/umu-launcher/toolmanifest.vdf      -t $(DESTDIR)$(DATADIR)/$(INSTALLDIR)/umu-launcher
 
-#umu-launcher-install: umu-launcher-dist-install umu-launcher-bin-install
-umu-launcher-install: umu-launcher-dist-install
+umu-launcher-install: umu-launcher-dist-install umu-launcher-bin-install
 
 
 $(OBJDIR)/.build-reaper: | $(OBJDIR)

--- a/packaging/flatpak/org.openwinecomponents.umu.launcher.yml
+++ b/packaging/flatpak/org.openwinecomponents.umu.launcher.yml
@@ -60,7 +60,6 @@ finish-args:
   - --share=network
   - --talk-name=org.freedesktop.Notifications
   - --talk-name=org.kde.StatusNotifierWatcher
-  - --talk-name=org.freedesktop.Flatpak
   # Required for bwrap to work
   - --talk-name=org.freedesktop.portal.Background
   # --- Steam ---

--- a/packaging/flatpak/org.openwinecomponents.umu.launcher.yml
+++ b/packaging/flatpak/org.openwinecomponents.umu.launcher.yml
@@ -60,8 +60,13 @@ finish-args:
   - --share=network
   - --talk-name=org.freedesktop.Notifications
   - --talk-name=org.kde.StatusNotifierWatcher
+  - --talk-name=org.freedesktop.Flatpak
   # Required for bwrap to work
   - --talk-name=org.freedesktop.portal.Background
+  # --- Steam ---
+  # Pressure Vessel
+  # See https://github.com/flathub/com.valvesoftware.Steam/commit/0538256facdb0837c33232bc65a9195a8a5bc750
+  - --env=XDG_DATA_DIRS=/app/share:/usr/lib/extensions/vulkan/share:/usr/share:/usr/share/runtime/share:/run/host/user-share:/run/host/share:/usr/lib/pressure-vessel/overrides/share
 
 add-extensions:
   org.freedesktop.Platform.Compat.i386:
@@ -143,14 +148,14 @@ modules:
   - name: umu-run
     buildsystem: simple
     build-commands:
-      - install -D umu-run-cli /app/bin/umu-run
-      - install -D umu-launcher.tar.gz /app/share/umu/umu-launcher.tar.gz
+      - |
+        git submodule update --init --recursive
+        ./configure --prefix=/app
+        make install
     sources:
-      - type: file
-        path: umu-run-cli
-      - type: file
-        url: https://github.com/Open-Wine-Components/umu-launcher/releases/download/0.1-RC3/umu-launcher.tar.gz
-        sha256: e25c4dd0636d04e7c8c534cf3c5bbdca5ae0d49f146ee8395306174700899952
+      - type: git
+        url: https://github.com/Open-Wine-Components/umu-launcher.git
+        branch: main
 
   - name: platform-bootstrap
     buildsystem: simple

--- a/packaging/flatpak/org.openwinecomponents.umu.launcher.yml
+++ b/packaging/flatpak/org.openwinecomponents.umu.launcher.yml
@@ -150,7 +150,7 @@ modules:
     build-commands:
       - |
         git submodule update --init --recursive
-        ./configure --prefix=/app
+        ./configure.sh --prefix=/app
         make install
     sources:
       - type: git

--- a/packaging/flatpak/org.openwinecomponents.umu.launcher.yml
+++ b/packaging/flatpak/org.openwinecomponents.umu.launcher.yml
@@ -154,7 +154,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/Open-Wine-Components/umu-launcher.git
-        branch: main
+        branch: flatpak
 
   - name: platform-bootstrap
     buildsystem: simple

--- a/packaging/flatpak/org.openwinecomponents.umu.launcher.yml
+++ b/packaging/flatpak/org.openwinecomponents.umu.launcher.yml
@@ -151,7 +151,7 @@ modules:
       - |
         git submodule update --init --recursive
         ./configure.sh --prefix=/app
-        make install
+        make FLATPAK=xtrue install
     sources:
       - type: git
         url: https://github.com/Open-Wine-Components/umu-launcher.git

--- a/umu/umu-launcher/umu-run.in
+++ b/umu/umu-launcher/umu-run.in
@@ -1,3 +1,3 @@
 #!/usr/bin/env sh
-##INSTALL_PATH##/umu_run.py "$@"
+##INSTALL_PATH## "$@"
 

--- a/umu/umu_consts.py
+++ b/umu/umu_consts.py
@@ -47,5 +47,3 @@ FLATPAK_PATH: Path = Path(environ.get("XDG_DATA_HOME"), "umu") if FLATPAK_ID els
 UMU_LOCAL: Path = (
     FLATPAK_PATH if FLATPAK_PATH else Path.home().joinpath(".local", "share", "umu")
 )
-
-UMU_CACHE: Path = Path.home().joinpath(".cache", "umu")

--- a/umu/umu_consts.py
+++ b/umu/umu_consts.py
@@ -1,5 +1,6 @@
 from enum import Enum
 from pathlib import Path
+from os import environ
 
 
 class Color(Enum):
@@ -13,15 +14,18 @@ class Color(Enum):
     DEBUG = "\u001b[35m"
 
 
+class MODE(Enum):
+    """Represent the permission to apply to a file."""
+
+    USER_RW = 0o0644
+    USER_RWX = 0o0755
+
+
 SIMPLE_FORMAT = f"%(levelname)s:  {Color.BOLD.value}%(message)s{Color.RESET.value}"
 
 DEBUG_FORMAT = f"%(levelname)s [%(module)s.%(funcName)s:%(lineno)s]:{Color.BOLD.value}%(message)s{Color.RESET.value}"  # noqa: E501
 
 CONFIG = "umu_version.json"
-
-UMU_LOCAL: Path = Path.home().joinpath(".local", "share", "umu")
-
-UMU_CACHE: Path = Path.home().joinpath(".cache", "umu")
 
 STEAM_COMPAT: Path = Path.home().joinpath(
     ".local", "share", "Steam", "compatibilitytools.d"
@@ -36,9 +40,12 @@ PROTON_VERBS = {
     "getnativepath",
 }
 
+FLATPAK_ID = environ.get("FLATPAK_ID") if environ.get("FLATPAK_ID") else ""
 
-class MODE(Enum):
-    """Represent the permission to apply to a file."""
+FLATPAK_PATH: Path = Path(environ.get("XDG_DATA_HOME"), "umu") if FLATPAK_ID else None
 
-    USER_RW = 0o0644
-    USER_RWX = 0o0755
+UMU_LOCAL: Path = (
+    FLATPAK_PATH if FLATPAK_PATH else Path.home().joinpath(".local", "share", "umu")
+)
+
+UMU_CACHE: Path = Path.home().joinpath(".cache", "umu")

--- a/umu/umu_plugins.py
+++ b/umu/umu_plugins.py
@@ -195,3 +195,34 @@ def enable_zenity(command: str, opts: List[str], msg: str) -> int:
         zenity_proc.stdin.close()
 
         return zenity_proc.wait()
+
+
+def enable_flatpak(
+    env: Dict[str, str], local: Path, command: List[str], verb: str, opts: List[str]
+) -> List[str]:
+    """Run umu in a Flatpak environment."""
+    bin: str = which("flatpak-spawn")
+
+    if not bin:
+        err: str = "flatpak-spawn not found\numu will fail to run the executable"
+        raise RuntimeError(err)
+
+    command.append(bin, "--host")
+    for key, val in env.items():
+        command.append(f"--env={key}={val}")
+
+    enable_reaper(env, command, local)
+
+    command.extend([local.joinpath("umu").as_posix(), "--verb", verb, "--"])
+    command.extend(
+        [
+            Path(env.get("PROTONPATH")).joinpath("proton").as_posix(),
+            verb,
+            env.get("EXE"),
+        ]
+    )
+
+    if opts:
+        command.extend([*opts])
+
+    return command

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -27,7 +27,6 @@ from umu_plugins import (
     enable_steam_game_drive,
     set_env_toml,
     enable_reaper,
-    enable_flatpak,
 )
 
 
@@ -250,9 +249,6 @@ def build_command(
     if not Path(env.get("PROTONPATH")).joinpath("proton").is_file():
         err: str = "The following file was not found in PROTONPATH: proton"
         raise FileNotFoundError(err)
-
-    if FLATPAK_PATH and Path(__file__).resolve().parent == Path("/app/share/umu"):
-        return enable_flatpak(env, local, command, env.get("PROTON_VERB"), opts)
 
     enable_reaper(env, command, local)
 

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -251,7 +251,7 @@ def build_command(
         err: str = "The following file was not found in PROTONPATH: proton"
         raise FileNotFoundError(err)
 
-    if FLATPAK_PATH and Path(__file__).resolve().parent == Path("/app/share"):
+    if FLATPAK_PATH and Path(__file__).resolve().parent == Path("/app/share/umu"):
         return enable_flatpak(env, local, command, env.get("PROTON_VERB"), opts)
 
     enable_reaper(env, command, local)
@@ -319,7 +319,7 @@ def main() -> int:  # noqa: D103
 
     log.debug("Arguments: %s", args)
 
-    if FLATPAK_PATH and root == Path("/app/share"):
+    if FLATPAK_PATH and root == Path("/app/share/umu"):
         log.debug("Flatpak environment detected")
         log.debug("FLATPAK_ID: %s", FLATPAK_ID)
         log.debug(

--- a/umu/umu_test.py
+++ b/umu/umu_test.py
@@ -720,7 +720,7 @@ class TestGameLauncher(unittest.TestCase):
         # Subtract one because a symbolic link is dynamically created
         self.assertEqual(
             num_share,
-            num_local - 1,
+            num_local,
             "Expected .local/share/Steam/compatibilitytools.d/umu-launcher"
             "and /usr/share/umu/umu-launcher to contain same files",
         )

--- a/umu/umu_util.py
+++ b/umu/umu_util.py
@@ -1,6 +1,6 @@
 from tarfile import open as tar_open, TarInfo
 from os import environ
-from umu_consts import CONFIG, STEAM_COMPAT, UMU_LOCAL, MODE
+from umu_consts import CONFIG, STEAM_COMPAT, UMU_LOCAL, MODE, FLATPAK_PATH
 from typing import Any, Dict, List, Callable
 from json import load, dump
 from umu_log import log
@@ -188,9 +188,11 @@ def _install_umu(
         root.joinpath("umu-launcher"),
         steam_compat.joinpath("umu-launcher"),
     )
-    steam_compat.joinpath("umu-launcher", "umu-run").symlink_to(
-        "../../../umu/umu_run.py"
-    )
+    # Only create the link for native system packages
+    if not (FLATPAK_PATH or root == Path("/app/share/umu")):
+        steam_compat.joinpath("umu-launcher", "umu-run").symlink_to(
+            "../../../umu/umu_run.py"
+        )
 
     # Runtime platform
     setup_runtime(json)
@@ -336,9 +338,10 @@ def _update_umu(
                     steam_compat.joinpath("umu-launcher"),
                 )
 
-                steam_compat.joinpath("umu-launcher", "umu-run").symlink_to(
-                    "../../../umu/umu_run.py"
-                )
+                if not (FLATPAK_PATH or root == Path("/app/share/umu")):
+                    steam_compat.joinpath("umu-launcher", "umu-run").symlink_to(
+                        "../../../umu/umu_run.py"
+                    )
                 log.console(f"Restored umu-launcher to {val}")
             elif steam_compat.joinpath("umu-launcher").is_dir() and val != runner:
                 # Update
@@ -350,9 +353,10 @@ def _update_umu(
                     steam_compat.joinpath("umu-launcher"),
                 )
 
-                steam_compat.joinpath("umu-launcher", "umu-run").symlink_to(
-                    "../../../umu/umu_run.py"
-                )
+                if not (FLATPAK_PATH or root == Path("/app/share/umu")):
+                    steam_compat.joinpath("umu-launcher", "umu-run").symlink_to(
+                        "../../../umu/umu_run.py"
+                    )
 
                 json_local["umu"]["versions"]["runner"] = val
 

--- a/umu/umu_util.py
+++ b/umu/umu_util.py
@@ -1,6 +1,6 @@
 from tarfile import open as tar_open, TarInfo
 from os import environ
-from umu_consts import CONFIG, STEAM_COMPAT, UMU_LOCAL, MODE, FLATPAK_PATH
+from umu_consts import CONFIG, STEAM_COMPAT, UMU_LOCAL, MODE
 from typing import Any, Dict, List, Callable
 from json import load, dump
 from umu_log import log
@@ -188,11 +188,6 @@ def _install_umu(
         root.joinpath("umu-launcher"),
         steam_compat.joinpath("umu-launcher"),
     )
-    # Only create the link for native system packages
-    if not (FLATPAK_PATH or root == Path("/app/share/umu")):
-        steam_compat.joinpath("umu-launcher", "umu-run").symlink_to(
-            "../../../umu/umu_run.py"
-        )
 
     # Runtime platform
     setup_runtime(json)
@@ -338,10 +333,6 @@ def _update_umu(
                     steam_compat.joinpath("umu-launcher"),
                 )
 
-                if not (FLATPAK_PATH or root == Path("/app/share/umu")):
-                    steam_compat.joinpath("umu-launcher", "umu-run").symlink_to(
-                        "../../../umu/umu_run.py"
-                    )
                 log.console(f"Restored umu-launcher to {val}")
             elif steam_compat.joinpath("umu-launcher").is_dir() and val != runner:
                 # Update
@@ -352,11 +343,6 @@ def _update_umu(
                     root.joinpath("umu-launcher"),
                     steam_compat.joinpath("umu-launcher"),
                 )
-
-                if not (FLATPAK_PATH or root == Path("/app/share/umu")):
-                    steam_compat.joinpath("umu-launcher", "umu-run").symlink_to(
-                        "../../../umu/umu_run.py"
-                    )
 
                 json_local["umu"]["versions"]["runner"] = val
 


### PR DESCRIPTION
This pull request updates the Flatpak manifest and the launcher to support running in a Flatpak environment. Flatpak clients who wish to use umu as their backend will be required to change their manifest to permit access to umu's $XDG_DATA_HOME/umu directory where the Steam Runtime platform and the launcher files will be stored/copied to.
