### PR TITLE
Update launcher and packaging

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -109,14 +109,14 @@ $(OBJDIR)/.build-umu-launcher: | $(OBJDIR)
 umu-launcher: $(OBJDIR)/.build-umu-launcher
 
 umu-launcher-bin-install: umu-launcher
-	install -d $(DESTDIR)$(DATADIR)/$(INSTALLDIR)/umu-launcher
-	install -Dm 755 $(OBJDIR)/$(<)-run $(DESTDIR)$(DATADIR)/$(INSTALLDIR)/umu-launcher/umu-run
+	install -d $(DESTDIR)$(DATADIR)/steam/compatibilitytools.d/umu-launcher
+	install -Dm 755 $(OBJDIR)/$(<)-run $(DESTDIR)$(DATADIR)/steam/compatibilitytools.d/umu-launcher/umu-run
 
 umu-launcher-dist-install:
 	$(info :: Installing umu-launcher )
-	install -d $(DESTDIR)$(DATADIR)/$(INSTALLDIR)/umu-launcher
-	install -Dm 644 umu/umu-launcher/compatibilitytool.vdf -t $(DESTDIR)$(DATADIR)/$(INSTALLDIR)/umu-launcher
-	install -Dm 644 umu/umu-launcher/toolmanifest.vdf      -t $(DESTDIR)$(DATADIR)/$(INSTALLDIR)/umu-launcher
+	install -d $(DESTDIR)$(DATADIR)/steam/compatibilitytools.d/umu-launcher
+	install -Dm 644 umu/umu-launcher/compatibilitytool.vdf -t $(DESTDIR)$(DATADIR)/steam/compatibilitytools.d/umu-launcher
+	install -Dm 644 umu/umu-launcher/toolmanifest.vdf      -t $(DESTDIR)$(DATADIR)/steam/compatibilitytools.d/umu-launcher
 
 umu-launcher-install: umu-launcher-dist-install umu-launcher-bin-install
 

--- a/packaging/flatpak/org.openwinecomponents.umu.umu-launcher.yml
+++ b/packaging/flatpak/org.openwinecomponents.umu.umu-launcher.yml
@@ -24,7 +24,7 @@ finish-args:
   - --filesystem=xdg-data/applications:rw
   - --filesystem=~/.steam:rw
   - --filesystem=~/Games:rw
-  - --filesystem=~/.local/share:rw
+  - --filesystem=~/.local/share/Steam:rw
   - --filesystem=~/.var/app/com.valvesoftware.Steam:rw
   - --filesystem=~/.var/app/org.openwinecomponents.umu.umu-launcher:rw
   - --filesystem=xdg-documents

--- a/umu/umu-launcher/toolmanifest.vdf
+++ b/umu/umu-launcher/toolmanifest.vdf
@@ -4,5 +4,6 @@
 	"commandline" "/umu-run %verb%"
 	"version" "2"
 	"use_tool_subprocess_reaper" "1"
+	"unlisted" "1"
 	"compatmanager_layer_name" "umu-launcher"
 }

--- a/umu/umu_consts.py
+++ b/umu/umu_consts.py
@@ -14,13 +14,6 @@ class Color(Enum):
     DEBUG = "\u001b[35m"
 
 
-class MODE(Enum):
-    """Represent the permission to apply to a file."""
-
-    USER_RW = 0o0644
-    USER_RWX = 0o0755
-
-
 SIMPLE_FORMAT = f"%(levelname)s:  {Color.BOLD.value}%(message)s{Color.RESET.value}"
 
 DEBUG_FORMAT = f"%(levelname)s [%(module)s.%(funcName)s:%(lineno)s]:{Color.BOLD.value}%(message)s{Color.RESET.value}"  # noqa: E501

--- a/umu/umu_consts.py
+++ b/umu/umu_consts.py
@@ -40,10 +40,8 @@ PROTON_VERBS = {
     "getnativepath",
 }
 
-FLATPAK_ID = environ.get("FLATPAK_ID") if environ.get("FLATPAK_ID") else ""
+FLATPAK_ID = environ.get("FLATPAK_ID") or ""
 
 FLATPAK_PATH: Path = Path(environ.get("XDG_DATA_HOME"), "umu") if FLATPAK_ID else None
 
-UMU_LOCAL: Path = (
-    FLATPAK_PATH if FLATPAK_PATH else Path.home().joinpath(".local", "share", "umu")
-)
+UMU_LOCAL: Path = FLATPAK_PATH or Path.home().joinpath(".local", "share", "umu")

--- a/umu/umu_plugins.py
+++ b/umu/umu_plugins.py
@@ -141,19 +141,6 @@ def enable_steam_game_drive(env: Dict[str, str]) -> Dict[str, str]:
     return env
 
 
-def enable_reaper(env: Dict[str, str], command: List[str], local: Path) -> List[str]:
-    """Enable Reaper to monitor and keep track of descendent processes."""
-    command.extend(
-        [
-            local.joinpath("reaper").as_posix(),
-            "UMU_ID=" + env["UMU_ID"],
-            "--",
-        ]
-    )
-
-    return command
-
-
 def enable_zenity(command: str, opts: List[str], msg: str) -> int:
     """Execute the command and pipe the output to Zenity.
 

--- a/umu/umu_plugins.py
+++ b/umu/umu_plugins.py
@@ -195,34 +195,3 @@ def enable_zenity(command: str, opts: List[str], msg: str) -> int:
         zenity_proc.stdin.close()
 
         return zenity_proc.wait()
-
-
-def enable_flatpak(
-    env: Dict[str, str], local: Path, command: List[str], verb: str, opts: List[str]
-) -> List[str]:
-    """Run umu in a Flatpak environment."""
-    bin: str = which("flatpak-spawn")
-
-    if not bin:
-        err: str = "flatpak-spawn not found\numu will fail to run the executable"
-        raise RuntimeError(err)
-
-    command.append(bin, "--host")
-    for key, val in env.items():
-        command.append(f"--env={key}={val}")
-
-    enable_reaper(env, command, local)
-
-    command.extend([local.joinpath("umu").as_posix(), "--verb", verb, "--"])
-    command.extend(
-        [
-            Path(env.get("PROTONPATH")).joinpath("proton").as_posix(),
-            verb,
-            env.get("EXE"),
-        ]
-    )
-
-    if opts:
-        command.extend([*opts])
-
-    return command

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -322,9 +322,7 @@ def main() -> int:  # noqa: D103
     if FLATPAK_PATH and root == Path("/app/share/umu"):
         log.debug("Flatpak environment detected")
         log.debug("FLATPAK_ID: %s", FLATPAK_ID)
-        log.debug(
-            "The following path will be used to persist the runtime: %s", FLATPAK_PATH
-        )
+        log.debug("Persisting the runtime at: %s", FLATPAK_PATH)
 
     # Setup the launcher and runtime files
     # An internet connection is required for new setups

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -26,7 +26,6 @@ from umu_consts import (
 from umu_plugins import (
     enable_steam_game_drive,
     set_env_toml,
-    enable_reaper,
 )
 
 
@@ -235,7 +234,11 @@ def set_env(
 
 
 def build_command(
-    env: Dict[str, str], local: Path, command: List[str], opts: List[str] = None
+    env: Dict[str, str],
+    local: Path,
+    root: Path,
+    command: List[str],
+    opts: List[str] = None,
 ) -> List[str]:
     """Build the command to be executed."""
     verb: str = env["PROTON_VERB"]
@@ -253,8 +256,13 @@ def build_command(
         err: str = "The following file was not found in PROTONPATH: proton"
         raise FileNotFoundError(err)
 
-    enable_reaper(env, command, local)
-
+    command.extend(
+        [
+            root.joinpath("reaper").as_posix(),
+            f"UMU_ID={env.get('UMU_ID')}",
+            "--",
+        ]
+    )
     command.extend([local.joinpath("umu").as_posix(), "--verb", verb, "--"])
     command.extend(
         [
@@ -378,7 +386,7 @@ def main() -> int:  # noqa: D103
     executor.shutdown()
 
     # Run
-    build_command(env, UMU_LOCAL, command, opts)
+    build_command(env, UMU_LOCAL, root, command, opts)
     log.debug("%s", command)
 
     return run(command, check=False).returncode

--- a/umu/umu_test.py
+++ b/umu/umu_test.py
@@ -254,7 +254,6 @@ class TestGameLauncher(unittest.TestCase):
             return_value=None,
         ):
             result = umu_util._update_umu(
-                self.test_user_share,
                 self.test_local_share,
                 json_root,
                 json_local,
@@ -439,7 +438,6 @@ class TestGameLauncher(unittest.TestCase):
             return_value=None,
         ):
             result = umu_util._update_umu(
-                self.test_user_share,
                 self.test_local_share,
                 json_root,
                 json_local,
@@ -500,7 +498,7 @@ class TestGameLauncher(unittest.TestCase):
         num_local = len([file for file in self.test_local_share.glob("*")])
         self.assertEqual(
             num_share,
-            num_local - 2,
+            num_local - 1,
             "Expected /usr/share/umu and .local/share/umu to contain same files",
         )
 
@@ -1406,7 +1404,7 @@ class TestGameLauncher(unittest.TestCase):
 
         # Build
         test_command = umu_run.build_command(
-            self.env, self.test_local_share, test_command
+            self.env, self.test_local_share, self.test_user_share, test_command
         )
         self.assertIsInstance(test_command, list, "Expected a List from build_command")
         self.assertEqual(

--- a/umu/umu_test_plugins.py
+++ b/umu/umu_test_plugins.py
@@ -218,9 +218,7 @@ class TestGameLauncherPlugins(unittest.TestCase):
             "setup_runtime",
             return_value=None,
         ):
-            umu_util._install_umu(
-                self.test_user_share, self.test_local_share, self.test_compat, json
-            )
+            umu_util._install_umu(self.test_user_share, self.test_local_share, json)
             copytree(
                 Path(self.test_user_share, "sniper_platform_0.20240125.75305"),
                 Path(self.test_local_share, "sniper_platform_0.20240125.75305"),
@@ -287,9 +285,7 @@ class TestGameLauncherPlugins(unittest.TestCase):
             "setup_runtime",
             return_value=None,
         ):
-            umu_util._install_umu(
-                self.test_user_share, self.test_local_share, self.test_compat, json
-            )
+            umu_util._install_umu(self.test_user_share, self.test_local_share, json)
             copytree(
                 Path(self.test_user_share, "sniper_platform_0.20240125.75305"),
                 Path(self.test_local_share, "sniper_platform_0.20240125.75305"),
@@ -360,9 +356,7 @@ class TestGameLauncherPlugins(unittest.TestCase):
             "setup_runtime",
             return_value=None,
         ):
-            umu_util._install_umu(
-                self.test_user_share, self.test_local_share, self.test_compat, json
-            )
+            umu_util._install_umu(self.test_user_share, self.test_local_share, json)
             copytree(
                 Path(self.test_user_share, "sniper_platform_0.20240125.75305"),
                 Path(self.test_local_share, "sniper_platform_0.20240125.75305"),

--- a/umu/umu_test_plugins.py
+++ b/umu/umu_test_plugins.py
@@ -236,7 +236,9 @@ class TestGameLauncherPlugins(unittest.TestCase):
 
         # Build
         with self.assertRaisesRegex(FileNotFoundError, "_v2-entry-point"):
-            umu_run.build_command(self.env, self.test_local_share, test_command)
+            umu_run.build_command(
+                self.env, self.test_local_share, self.test_user_share, test_command
+            )
 
     def test_build_command_proton(self):
         """Test build_command.
@@ -307,7 +309,9 @@ class TestGameLauncherPlugins(unittest.TestCase):
 
         # Build
         with self.assertRaisesRegex(FileNotFoundError, "proton"):
-            umu_run.build_command(self.env, self.test_local_share, test_command)
+            umu_run.build_command(
+                self.env, self.test_local_share, self.test_user_share, test_command
+            )
 
     def test_build_command_toml(self):
         """Test build_command.
@@ -378,7 +382,7 @@ class TestGameLauncherPlugins(unittest.TestCase):
 
         # Build
         test_command_result = umu_run.build_command(
-            self.env, self.test_local_share, test_command
+            self.env, self.test_local_share, self.test_user_share, test_command
         )
         self.assertTrue(
             test_command_result is test_command, "Expected the same reference"

--- a/umu/umu_util.py
+++ b/umu/umu_util.py
@@ -1,6 +1,6 @@
 from tarfile import open as tar_open, TarInfo
 from os import environ
-from umu_consts import CONFIG, STEAM_COMPAT, UMU_LOCAL
+from umu_consts import CONFIG, UMU_LOCAL
 from typing import Any, Dict, List, Callable
 from json import load, dump
 from umu_log import log
@@ -137,9 +137,9 @@ def setup_umu(root: Path, local: Path) -> None:
 
     # New install or umu dir is empty
     if not local.exists() or not any(local.iterdir()):
-        return _install_umu(root, local, STEAM_COMPAT, json)
+        return _install_umu(root, local, json)
 
-    return _update_umu(root, local, STEAM_COMPAT, json, _get_json(local, CONFIG))
+    return _update_umu(root, local, json, _get_json(local, CONFIG))
 
 
 def _install_umu(root: Path, local: Path, json: Dict[str, Any]) -> None:

--- a/umu/umu_util.py
+++ b/umu/umu_util.py
@@ -202,7 +202,6 @@ def _update_umu(
                 not local.joinpath(runtime).is_dir()
                 or not local.joinpath("pressure-vessel").is_dir()
             ):
-                # Redownload
                 log.warning("Runtime Platform not found")
                 if local.joinpath("pressure-vessel").is_dir():
                     rmtree(local.joinpath("pressure-vessel").as_posix())
@@ -210,7 +209,8 @@ def _update_umu(
                     rmtree(local.joinpath(runtime).as_posix())
                 futures.append(executor.submit(setup_runtime, json_root))
                 log.console(f"Restoring Runtime Platform to {val} ...")
-            elif (
+                continue
+            if (
                 local.joinpath(runtime).is_dir()
                 and local.joinpath("pressure-vessel").is_dir()
                 and val != runtime
@@ -221,6 +221,16 @@ def _update_umu(
                 rmtree(local.joinpath(runtime).as_posix())
                 futures.append(executor.submit(setup_runtime, json_root))
                 json_local["umu"]["versions"]["runtime_platform"] = val
+        elif key == "launcher":
+            if val == json_local["umu"]["versions"]["launcher"]:
+                continue
+            log.console(f"Updating {key} to {val}")
+            json_local["umu"]["versions"]["launcher"] = val
+        elif key == "runner":
+            if val == json_local["umu"]["versions"]["runner"]:
+                continue
+            log.console(f"Updating {key} to {val}")
+            json_local["umu"]["versions"]["runner"] = val
 
     for _ in futures:
         _.result()

--- a/umu/umu_util.py
+++ b/umu/umu_util.py
@@ -1,6 +1,6 @@
 from tarfile import open as tar_open, TarInfo
 from os import environ
-from umu_consts import CONFIG, STEAM_COMPAT, UMU_LOCAL, MODE
+from umu_consts import CONFIG, STEAM_COMPAT, UMU_LOCAL
 from typing import Any, Dict, List, Callable
 from json import load, dump
 from umu_log import log
@@ -142,9 +142,7 @@ def setup_umu(root: Path, local: Path) -> None:
     return _update_umu(root, local, STEAM_COMPAT, json, _get_json(local, CONFIG))
 
 
-def _install_umu(
-    root: Path, local: Path, steam_compat: Path, json: Dict[str, Any]
-) -> None:
+def _install_umu(root: Path, local: Path, json: Dict[str, Any]) -> None:
     """For new installations, copy all of the umu tools at a user-writable location.
 
     The designated locations to copy to will be:
@@ -160,31 +158,11 @@ def _install_umu(
 
     # Config
     log.console(f"Copied {CONFIG} -> {local}")
-    _copy(root.joinpath(CONFIG), local.joinpath(CONFIG))
+    copy(root.joinpath(CONFIG), local.joinpath(CONFIG))
 
     # Reaper
     log.console(f"Copied reaper -> {local}")
-    _copy(root.joinpath("reaper"), local.joinpath("reaper"), MODE.USER_RWX)
-
-    # Launcher files
-    for file in root.glob("*.py"):
-        if not file.name.startswith(("umu_test", "umu_run")):
-            log.console(f"Copied {file} -> {local}")
-            _copy(file, local.joinpath(file.name))
-    _copy(root.joinpath("umu_run.py"), local.joinpath("umu_run.py"), MODE.USER_RWX)
-
-    local.joinpath("umu-run").symlink_to("umu_run.py")
-
-    # Runner
-    log.console(f"Copied umu-launcher -> {steam_compat}")
-    steam_compat.mkdir(parents=True, exist_ok=True)
-    # Remove existing files if they exist -- this is a clean install.
-    if steam_compat.joinpath("umu-launcher").is_dir():
-        rmtree(steam_compat.joinpath("umu-launcher").as_posix())
-    _copytree(
-        root.joinpath("umu-launcher"),
-        steam_compat.joinpath("umu-launcher"),
-    )
+    copy(root.joinpath("reaper"), local.joinpath("reaper"))
 
     # Runtime platform
     setup_runtime(json)
@@ -195,7 +173,6 @@ def _install_umu(
 def _update_umu(
     root: Path,
     local: Path,
-    steam_compat: Path,
     json_root: Dict[str, Any],
     json_local: Dict[str, Any],
 ) -> None:
@@ -221,25 +198,19 @@ def _update_umu(
     for key, val in json_root["umu"]["versions"].items():
         if key == "reaper":
             reaper: str = json_local["umu"]["versions"]["reaper"]
-
             # Directory is absent
             if not local.joinpath("reaper").is_file():
                 log.warning("Reaper not found")
-                _copy(root.joinpath("reaper"), local.joinpath("reaper"), MODE.USER_RWX)
+                copy(root.joinpath("reaper"), local.joinpath("reaper"))
                 log.console(f"Restored {key} to {val}")
-
             # Update
             if val != reaper:
                 log.console(f"Updating {key} to {val}")
-
                 local.joinpath("reaper").unlink(missing_ok=True)
-                _copy(root.joinpath("reaper"), local.joinpath("reaper"), MODE.USER_RWX)
-
+                copy(root.joinpath("reaper"), local.joinpath("reaper"))
                 json_local["umu"]["versions"]["reaper"] = val
         elif key == "runtime_platform":
-            # Old runtime
             runtime: str = json_local["umu"]["versions"]["runtime_platform"]
-
             # Redownload the runtime if absent or pressure vessel is absent
             if (
                 not local.joinpath(runtime).is_dir()
@@ -251,7 +222,6 @@ def _update_umu(
                     rmtree(local.joinpath("pressure-vessel").as_posix())
                 if local.joinpath(runtime).is_dir():
                     rmtree(local.joinpath(runtime).as_posix())
-
                 futures.append(executor.submit(setup_runtime, json_root))
                 log.console(f"Restoring Runtime Platform to {val} ...")
             elif (
@@ -264,83 +234,7 @@ def _update_umu(
                 rmtree(local.joinpath("pressure-vessel").as_posix())
                 rmtree(local.joinpath(runtime).as_posix())
                 futures.append(executor.submit(setup_runtime, json_root))
-
                 json_local["umu"]["versions"]["runtime_platform"] = val
-        elif key == "launcher":
-            # Launcher
-            is_missing: bool = False
-            launcher: str = json_local["umu"]["versions"]["launcher"]
-
-            # Update
-            if val != launcher:
-                log.console(f"Updating {key} to {val}")
-
-                # Python files
-                for file in root.glob("*.py"):
-                    if not file.name.startswith(("umu_test", "umu_run")):
-                        local.joinpath(file.name).unlink(missing_ok=True)
-                        _copy(file, local.joinpath(file.name))
-                _copy(
-                    root.joinpath("umu_run.py"),
-                    local.joinpath("umu_run.py"),
-                    MODE.USER_RWX,
-                )
-
-                # Symlink
-                local.joinpath("umu-run").unlink(missing_ok=True)
-                local.joinpath("umu-run").symlink_to("umu_run.py")
-
-                json_local["umu"]["versions"]["launcher"] = val
-                continue
-
-            # Check for missing files
-            for file in [
-                file
-                for file in root.glob("*.py")
-                if not file.name.startswith(("umu_test", "umu_run"))
-                and not local.joinpath(file.name).is_file()
-            ]:
-                is_missing = True
-                log.warning("Missing %s", file.name)
-                _copy(file, local.joinpath(file.name))
-
-            if not local.joinpath("umu_run.py"):
-                log.warning("Missing %s", file.name)
-                _copy(
-                    root.joinpath("umu_run.py"),
-                    local.joinpath("umu_run.py"),
-                    MODE.USER_RWX,
-                )
-
-            if is_missing:
-                log.console(f"Restored {key} to {val}")
-                local.joinpath("umu-run").unlink(missing_ok=True)
-                local.joinpath("umu-run").symlink_to("umu_run.py")
-        elif key == "runner":
-            # Runner
-            runner: str = json_local["umu"]["versions"]["runner"]
-
-            # Directory is absent
-            if not steam_compat.joinpath("umu-launcher").is_dir():
-                log.warning("umu-launcher not found")
-
-                _copytree(
-                    root.joinpath("umu-launcher"),
-                    steam_compat.joinpath("umu-launcher"),
-                )
-
-                log.console(f"Restored umu-launcher to {val}")
-            elif steam_compat.joinpath("umu-launcher").is_dir() and val != runner:
-                # Update
-                log.console(f"Updating {key} to {val}")
-
-                rmtree(steam_compat.joinpath("umu-launcher").as_posix())
-                _copytree(
-                    root.joinpath("umu-launcher"),
-                    steam_compat.joinpath("umu-launcher"),
-                )
-
-                json_local["umu"]["versions"]["runner"] = val
 
     for _ in futures:
         _.result()
@@ -379,24 +273,3 @@ def _get_json(path: Path, config: str) -> Dict[str, Any]:
         raise ValueError(err)
 
     return json
-
-
-def _copy(src: Path, dst: Path, mode: MODE = MODE.USER_RW) -> None:
-    dst.parent.mkdir(parents=True, exist_ok=True)
-
-    if src.is_symlink():
-        dst.symlink_to(src.readlink())
-        return
-
-    copy(src, dst)
-    dst.chmod(mode.value)
-
-
-def _copytree(src: Path, dest: Path, mode: MODE = MODE.USER_RW) -> None:
-    for file in src.iterdir():
-        if file.is_dir():
-            dest_subdir = dest / file.name
-            dest_subdir.mkdir(parents=True, exist_ok=True)
-            _copytree(file, dest_subdir)
-        else:
-            _copy(file, dest / file.name, mode)


### PR DESCRIPTION
This pull request makes few changes in the launcher and the launcher's packaging. Only the `umu_version.json` configuration file will be copied to the user's home directory, and the `umu-launcher` compatibilitytool will be installed in Valve's official system path. The configuration file and the runtime platform are the only files needed in the home directoy to execute games.

In addition, the `umu-launcher` compatibility tool will remain hidden for now until umu has built its custom runtime. The umu Flatpak's access to `~/.local/share` is now limited to `~/.local/share/Steam` instead of exposing the entire directory. This is good for security, and the launcher only requires `~/.local/share/Steam` to write Proton. If the launcher ever needs more access to files, such as `~/.local/share/lutris`, the manifest should be changed to allow them.
