### PR TITLE
Use systemd as subreaper

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -109,14 +109,14 @@ $(OBJDIR)/.build-umu-launcher: | $(OBJDIR)
 umu-launcher: $(OBJDIR)/.build-umu-launcher
 
 umu-launcher-bin-install: umu-launcher
-	install -d $(DESTDIR)$(DATADIR)/$(INSTALLDIR)/umu-launcher
-	install -Dm 755 $(OBJDIR)/$(<)-run $(DESTDIR)$(DATADIR)/$(INSTALLDIR)/umu-launcher/umu-run
+	install -d $(DESTDIR)$(DATADIR)/steam/compatibilitytools.d/umu-launcher
+	install -Dm 755 $(OBJDIR)/$(<)-run $(DESTDIR)$(DATADIR)/steam/compatibilitytools.d/umu-launcher/umu-run
 
 umu-launcher-dist-install:
 	$(info :: Installing umu-launcher )
-	install -d $(DESTDIR)$(DATADIR)/$(INSTALLDIR)/umu-launcher
-	install -Dm 644 umu/umu-launcher/compatibilitytool.vdf -t $(DESTDIR)$(DATADIR)/$(INSTALLDIR)/umu-launcher
-	install -Dm 644 umu/umu-launcher/toolmanifest.vdf      -t $(DESTDIR)$(DATADIR)/$(INSTALLDIR)/umu-launcher
+	install -d $(DESTDIR)$(DATADIR)/steam/compatibilitytools.d/umu-launcher
+	install -Dm 644 umu/umu-launcher/compatibilitytool.vdf -t $(DESTDIR)$(DATADIR)/steam/compatibilitytools.d/umu-launcher
+	install -Dm 644 umu/umu-launcher/toolmanifest.vdf      -t $(DESTDIR)$(DATADIR)/steam/compatibilitytools.d/umu-launcher
 
 umu-launcher-install: umu-launcher-dist-install umu-launcher-bin-install
 

--- a/Makefile.in
+++ b/Makefile.in
@@ -139,7 +139,7 @@ release: $(RELEASEDIR) | version
 	$(info :: Creating source distribution for release )
 	mkdir -p $(<)
 	rm -rf umu/__pycache__
-	cp -r umu packaging subprojects Makefile.in configure.sh README.md LICENSE $(<)
+	cp -r umu packaging Makefile.in configure.sh README.md LICENSE $(<)
 	tar -cvzf $(<).tar.gz $(<)
 
 

--- a/Makefile.in
+++ b/Makefile.in
@@ -18,16 +18,16 @@ FLATPAK ?= xfalse
 
 .PHONY: all
 ifeq ($(FLATPAK), xtrue)
-all: version reaper umu umu-launcher
+all: version umu umu-launcher
 else
-all: version reaper umu umu-docs umu-launcher
+all: version umu umu-docs umu-launcher
 endif
 
 .PHONY: install
 ifeq ($(USERINSTALL), xtrue)
-install: reaper-install umu-install umu-launcher-install user-install
+install: umu-install umu-launcher-install user-install
 else
-install: reaper-install umu-install umu-launcher-install
+install: umu-install umu-launcher-install
 endif
 
 # Special case, do this inside the source directory for release distribution
@@ -35,7 +35,6 @@ umu/umu_version.json: umu/umu_version.json.in
 	$(info :: Updating $(@) )
 	cp $(<) $(<).tmp
 	sed 's|##UMU_VERSION##|$(shell git describe --always --long --tags)|g' -i $(<).tmp
-	sed 's|##REAPER_VERSION##|$(shell git describe --always --long --tags)|g' -i $(<).tmp
 	mv $(<).tmp $(@)
 
 .PHONY: version
@@ -119,20 +118,6 @@ umu-launcher-dist-install:
 	install -Dm 644 umu/umu-launcher/toolmanifest.vdf      -t $(DESTDIR)$(DATADIR)/steam/compatibilitytools.d/umu-launcher
 
 umu-launcher-install: umu-launcher-dist-install umu-launcher-bin-install
-
-
-$(OBJDIR)/.build-reaper: | $(OBJDIR)
-	$(info :: Building reaper )
-	meson setup $(OBJDIR)/reaper subprojects/reaper
-	ninja -C $(OBJDIR)/reaper -v
-	touch $(@)
-
-.PHONY: reaper
-reaper: $(OBJDIR)/.build-reaper
-
-reaper-install: reaper
-	$(info :: Installing reaper )
-	install -Dm 755 $(OBJDIR)/$</$< -t $(DESTDIR)$(DATADIR)/$(INSTALLDIR)
 
 
 $(OBJDIR):

--- a/packaging/flatpak/org.openwinecomponents.umu.umu-launcher.yml
+++ b/packaging/flatpak/org.openwinecomponents.umu.umu-launcher.yml
@@ -24,7 +24,7 @@ finish-args:
   - --filesystem=xdg-data/applications:rw
   - --filesystem=~/.steam:rw
   - --filesystem=~/Games:rw
-  - --filesystem=~/.local/share:rw
+  - --filesystem=~/.local/share/Steam:rw
   - --filesystem=~/.var/app/com.valvesoftware.Steam:rw
   - --filesystem=~/.var/app/org.openwinecomponents.umu.umu-launcher:rw
   - --filesystem=xdg-documents

--- a/umu/reaper
+++ b/umu/reaper
@@ -1,7 +1,0 @@
-#!/usr/bin/env sh
-# Fake reaper file to avoid errors while running from source
-while [ "$1" != "--" ]; do
-  shift
-done
-shift
-"$@"

--- a/umu/umu-launcher/toolmanifest.vdf
+++ b/umu/umu-launcher/toolmanifest.vdf
@@ -4,5 +4,6 @@
 	"commandline" "/umu-run %verb%"
 	"version" "2"
 	"use_tool_subprocess_reaper" "1"
+	"unlisted" "1"
 	"compatmanager_layer_name" "umu-launcher"
 }

--- a/umu/umu_consts.py
+++ b/umu/umu_consts.py
@@ -14,13 +14,6 @@ class Color(Enum):
     DEBUG = "\u001b[35m"
 
 
-class MODE(Enum):
-    """Represent the permission to apply to a file."""
-
-    USER_RW = 0o0644
-    USER_RWX = 0o0755
-
-
 SIMPLE_FORMAT = f"%(levelname)s:  {Color.BOLD.value}%(message)s{Color.RESET.value}"
 
 DEBUG_FORMAT = f"%(levelname)s [%(module)s.%(funcName)s:%(lineno)s]:{Color.BOLD.value}%(message)s{Color.RESET.value}"  # noqa: E501

--- a/umu/umu_consts.py
+++ b/umu/umu_consts.py
@@ -40,10 +40,8 @@ PROTON_VERBS = {
     "getnativepath",
 }
 
-FLATPAK_ID = environ.get("FLATPAK_ID") if environ.get("FLATPAK_ID") else ""
+FLATPAK_ID = environ.get("FLATPAK_ID") or ""
 
 FLATPAK_PATH: Path = Path(environ.get("XDG_DATA_HOME"), "umu") if FLATPAK_ID else None
 
-UMU_LOCAL: Path = (
-    FLATPAK_PATH if FLATPAK_PATH else Path.home().joinpath(".local", "share", "umu")
-)
+UMU_LOCAL: Path = FLATPAK_PATH or Path.home().joinpath(".local", "share", "umu")

--- a/umu/umu_plugins.py
+++ b/umu/umu_plugins.py
@@ -141,19 +141,6 @@ def enable_steam_game_drive(env: Dict[str, str]) -> Dict[str, str]:
     return env
 
 
-def enable_reaper(env: Dict[str, str], command: List[str], local: Path) -> List[str]:
-    """Enable Reaper to monitor and keep track of descendent processes."""
-    command.extend(
-        [
-            local.joinpath("reaper").as_posix(),
-            "UMU_ID=" + env["UMU_ID"],
-            "--",
-        ]
-    )
-
-    return command
-
-
 def enable_zenity(command: str, opts: List[str], msg: str) -> int:
     """Execute the command and pipe the output to Zenity.
 

--- a/umu/umu_plugins.py
+++ b/umu/umu_plugins.py
@@ -195,34 +195,3 @@ def enable_zenity(command: str, opts: List[str], msg: str) -> int:
         zenity_proc.stdin.close()
 
         return zenity_proc.wait()
-
-
-def enable_flatpak(
-    env: Dict[str, str], local: Path, command: List[str], verb: str, opts: List[str]
-) -> List[str]:
-    """Run umu in a Flatpak environment."""
-    bin: str = which("flatpak-spawn")
-
-    if not bin:
-        err: str = "flatpak-spawn not found\numu will fail to run the executable"
-        raise RuntimeError(err)
-
-    command.append(bin, "--host")
-    for key, val in env.items():
-        command.append(f"--env={key}={val}")
-
-    enable_reaper(env, command, local)
-
-    command.extend([local.joinpath("umu").as_posix(), "--verb", verb, "--"])
-    command.extend(
-        [
-            Path(env.get("PROTONPATH")).joinpath("proton").as_posix(),
-            verb,
-            env.get("EXE"),
-        ]
-    )
-
-    if opts:
-        command.extend([*opts])
-
-    return command

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -26,7 +26,6 @@ from umu_consts import (
 from umu_plugins import (
     enable_steam_game_drive,
     set_env_toml,
-    enable_reaper,
 )
 
 
@@ -253,7 +252,6 @@ def build_command(
         err: str = "The following file was not found in PROTONPATH: proton"
         raise FileNotFoundError(err)
 
-    enable_reaper(env, command, local)
 
     command.extend([local.joinpath("umu").as_posix(), "--verb", verb, "--"])
     command.extend(

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -321,9 +321,7 @@ def main() -> int:  # noqa: D103
     if FLATPAK_PATH and root == Path("/app/share/umu"):
         log.debug("Flatpak environment detected")
         log.debug("FLATPAK_ID: %s", FLATPAK_ID)
-        log.debug(
-            "The following path will be used to persist the runtime: %s", FLATPAK_PATH
-        )
+        log.debug("Persisting the runtime at: %s", FLATPAK_PATH)
 
     # Setup the launcher and runtime files
     # An internet connection is required for new setups

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -15,6 +15,7 @@ from errno import ENETUNREACH
 from threading import Thread
 from socket import AF_INET, SOCK_DGRAM, socket
 from pwd import getpwuid
+from shutil import which
 from umu_consts import (
     PROTON_VERBS,
     DEBUG_FORMAT,
@@ -238,6 +239,7 @@ def build_command(
 ) -> List[str]:
     """Build the command to be executed."""
     verb: str = env["PROTON_VERB"]
+    systemd: str = which("systemd-run")
 
     # Raise an error if the _v2-entry-point cannot be found
     if not local.joinpath("umu").is_file():
@@ -252,6 +254,16 @@ def build_command(
         err: str = "The following file was not found in PROTONPATH: proton"
         raise FileNotFoundError(err)
 
+    if systemd and not FLATPAK_PATH:
+        command.extend(
+            [
+                systemd,
+                "--user",
+                "--scope",
+                "--description",
+                f"UMU_ID={env.get('UMU_ID')}",
+            ]
+        )
 
     command.extend([local.joinpath("umu").as_posix(), "--verb", verb, "--"])
     command.extend(

--- a/umu/umu_test.py
+++ b/umu/umu_test.py
@@ -74,7 +74,6 @@ class TestGameLauncher(unittest.TestCase):
                     "launcher": "0.1-RC3",
                     "runner": "0.1-RC3",
                     "runtime_platform": "sniper_platform_0.20240125.75305",
-                    "reaper": "1.0",
                     "pressure_vessel": "v0.20240212.0",
                 }
             }
@@ -118,9 +117,6 @@ class TestGameLauncher(unittest.TestCase):
         Path(self.test_user_share, "umu-launcher").mkdir()
         Path(self.test_user_share, "umu-launcher", "compatibilitytool.vdf").touch()
         Path(self.test_user_share, "umu-launcher", "toolmanifest.vdf").touch()
-
-        # Mock Reaper
-        Path(self.test_user_share, "reaper").touch()
 
         # Mock the proton file in the dir
         self.test_proton_dir.joinpath("proton").touch(exist_ok=True)
@@ -226,7 +222,6 @@ class TestGameLauncher(unittest.TestCase):
                     "launcher": "0.1-RC3",
                     "runner": "0.1-RC3",
                     "runtime_platform": "sniper_platform_0.20240125.75305",
-                    "reaper": "1.0",
                     "pressure_vessel": "v0.20240212.0",
                 }
             }
@@ -254,7 +249,6 @@ class TestGameLauncher(unittest.TestCase):
             return_value=None,
         ):
             result = umu_util._update_umu(
-                self.test_user_share,
                 self.test_local_share,
                 json_root,
                 json_local,
@@ -357,7 +351,6 @@ class TestGameLauncher(unittest.TestCase):
                     "launcher": "0.1-RC3",
                     "runner": "0.1-RC3",
                     "runtime_platform": "sniper_platform_0.20240125.75305",
-                    "reaper": "1.0",
                     "pressure_vessel": "v0.20240212.0",
                 }
             }
@@ -439,7 +432,6 @@ class TestGameLauncher(unittest.TestCase):
             return_value=None,
         ):
             result = umu_util._update_umu(
-                self.test_user_share,
                 self.test_local_share,
                 json_root,
                 json_local,
@@ -647,7 +639,6 @@ class TestGameLauncher(unittest.TestCase):
                     "launcher": "0.1-RC3",
                     "runner": "0.1-RC3",
                     "runtime_platform": "sniper_platform_0.20240125.75305",
-                    "reaper": "1.0",
                     "pressure_vessel": "v0.20240212.0"
                 }
             }
@@ -660,7 +651,6 @@ class TestGameLauncher(unittest.TestCase):
                     "launcher": "0.1-RC3",
                     "runner": "0.1-RC3",
                     "runtime_platform": "sniper_platform_0.20240125.75305",
-                    "reaper": "1.0",
                     "pressure_vessel": "v0.20240212.0"
                 }
             }
@@ -1408,21 +1398,40 @@ class TestGameLauncher(unittest.TestCase):
         test_command = umu_run.build_command(
             self.env, self.test_local_share, test_command
         )
+        umu_id = self.env.get("UMU_ID")
         self.assertIsInstance(test_command, list, "Expected a List from build_command")
         self.assertEqual(
-            len(test_command), 10, "Expected 10 elements in the list from build_command"
+            len(test_command), 12, "Expected 12 elements in the list from build_command"
         )
-        reaper, id, opt0, entry_point, opt1, verb, opt2, proton, verb2, exe = [
-            *test_command
-        ]
+        (
+            reaper,
+            opt0,
+            opt1,
+            opt2,
+            id,
+            entry_point,
+            opt3,
+            verb,
+            opt4,
+            proton,
+            verb2,
+            exe,
+        ) = [*test_command]
         # The entry point dest could change. Just check if there's a value
-        self.assertTrue(reaper, "Expected reaper")
+        self.assertTrue(reaper, "Expected systemd")
+        self.assertEqual(opt0, "--user", "Expected --user")
+        self.assertEqual(opt1, "--scope", "Expected --scope")
+        self.assertEqual(opt2, "--description", "Expected --description")
+        self.assertEqual(
+            id,
+            f"UMU_ID={umu_id}",
+            f"Expected UMU_ID={umu_id}",
+        )
         self.assertTrue(id, "Expected a tag for reaper")
-        self.assertTrue(opt0, "Expected --")
         self.assertTrue(entry_point, "Expected an entry point")
-        self.assertEqual(opt1, "--verb", "Expected --verb")
+        self.assertEqual(opt3, "--verb", "Expected --verb")
         self.assertEqual(verb, self.test_verb, "Expected a verb")
-        self.assertEqual(opt2, "--", "Expected --")
+        self.assertEqual(opt4, "--", "Expected --")
         self.assertEqual(
             proton,
             Path(self.env.get("PROTONPATH") + "/proton").as_posix(),

--- a/umu/umu_test_plugins.py
+++ b/umu/umu_test_plugins.py
@@ -218,9 +218,7 @@ class TestGameLauncherPlugins(unittest.TestCase):
             "setup_runtime",
             return_value=None,
         ):
-            umu_util._install_umu(
-                self.test_user_share, self.test_local_share, self.test_compat, json
-            )
+            umu_util._install_umu(self.test_user_share, self.test_local_share, json)
             copytree(
                 Path(self.test_user_share, "sniper_platform_0.20240125.75305"),
                 Path(self.test_local_share, "sniper_platform_0.20240125.75305"),
@@ -287,9 +285,7 @@ class TestGameLauncherPlugins(unittest.TestCase):
             "setup_runtime",
             return_value=None,
         ):
-            umu_util._install_umu(
-                self.test_user_share, self.test_local_share, self.test_compat, json
-            )
+            umu_util._install_umu(self.test_user_share, self.test_local_share, json)
             copytree(
                 Path(self.test_user_share, "sniper_platform_0.20240125.75305"),
                 Path(self.test_local_share, "sniper_platform_0.20240125.75305"),
@@ -360,9 +356,7 @@ class TestGameLauncherPlugins(unittest.TestCase):
             "setup_runtime",
             return_value=None,
         ):
-            umu_util._install_umu(
-                self.test_user_share, self.test_local_share, self.test_compat, json
-            )
+            umu_util._install_umu(self.test_user_share, self.test_local_share, json)
             copytree(
                 Path(self.test_user_share, "sniper_platform_0.20240125.75305"),
                 Path(self.test_local_share, "sniper_platform_0.20240125.75305"),

--- a/umu/umu_test_plugins.py
+++ b/umu/umu_test_plugins.py
@@ -380,22 +380,43 @@ class TestGameLauncherPlugins(unittest.TestCase):
         test_command_result = umu_run.build_command(
             self.env, self.test_local_share, test_command
         )
+        umu_id = self.env.get("UMU_ID")
         self.assertTrue(
             test_command_result is test_command, "Expected the same reference"
         )
-
-        # Verify contents of the command
-        reaper, id, opt0, entry_point, opt1, verb, opt2, proton, verb2, exe = [
-            *test_command
-        ]
+        self.assertIsInstance(test_command, list, "Expected a List from build_command")
+        self.assertEqual(
+            len(test_command), 12, "Expected 12 elements in the list from build_command"
+        )
+        (
+            reaper,
+            opt0,
+            opt1,
+            opt2,
+            id,
+            entry_point,
+            opt3,
+            verb,
+            opt4,
+            proton,
+            verb2,
+            exe,
+        ) = [*test_command]
         # The entry point dest could change. Just check if there's a value
-        self.assertTrue(reaper, "Expected reaper")
+        self.assertTrue(reaper, "Expected systemd")
+        self.assertEqual(opt0, "--user", "Expected --user")
+        self.assertEqual(opt1, "--scope", "Expected --scope")
+        self.assertEqual(opt2, "--description", "Expected --description")
+        self.assertEqual(
+            id,
+            f"UMU_ID={umu_id}",
+            f"Expected UMU_ID={umu_id}",
+        )
         self.assertTrue(id, "Expected a tag for reaper")
-        self.assertTrue(opt0, "Expected --")
         self.assertTrue(entry_point, "Expected an entry point")
-        self.assertEqual(opt1, "--verb", "Expected --verb")
+        self.assertEqual(opt3, "--verb", "Expected --verb")
         self.assertEqual(verb, self.test_verb, "Expected a verb")
-        self.assertEqual(opt2, "--", "Expected --")
+        self.assertEqual(opt4, "--", "Expected --")
         self.assertEqual(
             proton,
             Path(self.env.get("PROTONPATH") + "/proton").as_posix(),

--- a/umu/umu_util.py
+++ b/umu/umu_util.py
@@ -142,7 +142,7 @@ def setup_umu(root: Path, local: Path) -> None:
     if not local.exists() or not any(local.iterdir()):
         return _install_umu(root, local, json)
 
-    return _update_umu(root, local, json, _get_json(local, CONFIG))
+    return _update_umu(local, json, _get_json(local, CONFIG))
 
 
 def _install_umu(root: Path, local: Path, json: Dict[str, Any]) -> None:
@@ -170,7 +170,6 @@ def _install_umu(root: Path, local: Path, json: Dict[str, Any]) -> None:
 
 
 def _update_umu(
-    root: Path,
     local: Path,
     json_root: Dict[str, Any],
     json_local: Dict[str, Any],
@@ -194,7 +193,7 @@ def _update_umu(
     # When a directory for a specific tool doesn't exist, remake the copy
     # Be lazy and just trust the integrity of local
     for key, val in json_root["umu"]["versions"].items():
-        elif key == "runtime_platform":
+        if key == "runtime_platform":
             runtime: str = json_local["umu"]["versions"]["runtime_platform"]
             # Redownload the runtime if absent or pressure vessel is absent
             if (

--- a/umu/umu_util.py
+++ b/umu/umu_util.py
@@ -131,8 +131,8 @@ def setup_umu(root: Path, local: Path) -> None:
 
     Performs full copies of tools on new installs and selectively on new updates
     The tools that will be copied are:
-    Pressure Vessel, Reaper, SteamRT, ULWLG launcher and the umu-launcher
-    The umu-launcher will be copied to .local/share/Steam/compatibilitytools.d
+
+    Pressure Vessel and the SteamRT
     """
     log.debug("Root: %s", root)
     log.debug("Local: %s", local)
@@ -152,7 +152,7 @@ def _install_umu(root: Path, local: Path, json: Dict[str, Any]) -> None:
     ~/.local/share/umu, ~/.local/share/Steam/compatibilitytools.d
 
     The tools that will be copied are:
-    umu-launcher, umu Launcher files, reaper and umu_version.json
+    umu-launcher, umu Launcher files, and umu_version.json
     """
     log.debug("New install detected")
     log.console("Setting up Unified Launcher for Windows Games on Linux ...")

--- a/umu/umu_util.py
+++ b/umu/umu_util.py
@@ -163,10 +163,6 @@ def _install_umu(root: Path, local: Path, json: Dict[str, Any]) -> None:
     log.console(f"Copied {CONFIG} -> {local}")
     copy(root.joinpath(CONFIG), local.joinpath(CONFIG))
 
-    # Reaper
-    log.console(f"Copied reaper -> {local}")
-    copy(root.joinpath("reaper"), local.joinpath("reaper"))
-
     # Runtime platform
     setup_runtime(json)
 
@@ -198,19 +194,6 @@ def _update_umu(
     # When a directory for a specific tool doesn't exist, remake the copy
     # Be lazy and just trust the integrity of local
     for key, val in json_root["umu"]["versions"].items():
-        if key == "reaper":
-            reaper: str = json_local["umu"]["versions"]["reaper"]
-            # Directory is absent
-            if not local.joinpath("reaper").is_file():
-                log.warning("Reaper not found")
-                copy(root.joinpath("reaper"), local.joinpath("reaper"))
-                log.console(f"Restored {key} to {val}")
-            # Update
-            if val != reaper:
-                log.console(f"Updating {key} to {val}")
-                local.joinpath("reaper").unlink(missing_ok=True)
-                copy(root.joinpath("reaper"), local.joinpath("reaper"))
-                json_local["umu"]["versions"]["reaper"] = val
         elif key == "runtime_platform":
             runtime: str = json_local["umu"]["versions"]["runtime_platform"]
             # Redownload the runtime if absent or pressure vessel is absent

--- a/umu/umu_util.py
+++ b/umu/umu_util.py
@@ -1,6 +1,6 @@
 from tarfile import open as tar_open, TarInfo
 from os import environ
-from umu_consts import CONFIG, STEAM_COMPAT, UMU_LOCAL, MODE
+from umu_consts import CONFIG, UMU_LOCAL
 from typing import Any, Dict, List, Callable
 from json import load, dump
 from umu_log import log
@@ -140,14 +140,12 @@ def setup_umu(root: Path, local: Path) -> None:
 
     # New install or umu dir is empty
     if not local.exists() or not any(local.iterdir()):
-        return _install_umu(root, local, STEAM_COMPAT, json)
+        return _install_umu(root, local, json)
 
-    return _update_umu(root, local, STEAM_COMPAT, json, _get_json(local, CONFIG))
+    return _update_umu(root, local, json, _get_json(local, CONFIG))
 
 
-def _install_umu(
-    root: Path, local: Path, steam_compat: Path, json: Dict[str, Any]
-) -> None:
+def _install_umu(root: Path, local: Path, json: Dict[str, Any]) -> None:
     """For new installations, copy all of the umu tools at a user-writable location.
 
     The designated locations to copy to will be:
@@ -178,7 +176,6 @@ def _install_umu(
 def _update_umu(
     root: Path,
     local: Path,
-    steam_compat: Path,
     json_root: Dict[str, Any],
     json_local: Dict[str, Any],
 ) -> None:

--- a/umu/umu_version.json.in
+++ b/umu/umu_version.json.in
@@ -4,7 +4,6 @@
       "launcher": "##UMU_VERSION##",
       "runner": "##UMU_VERSION##",
       "runtime_platform": "sniper_platform_0.20240125.75305",
-      "reaper": "##REAPER_VERSION##",
       "pressure_vessel": "v0.20240212.0"
     }
   }


### PR DESCRIPTION
Intended to be merged after 0.1 release, this pull request changes the subreaper from Valve's Reaper to systemd to reap spawned processes after a game is launched and exits. 

When systemd is used as a subreaper process, a user-scoped transient unit will be created to reliably track/control all of the processes created at launch and to, optionally, manage their system resource usages (which is how Flatpak uses it). Systemd relies on Linux Control Groups (cgroups) to accomplish this, and all processes in the unit will be logically grouped together in a hierachical tree.

For clients, this means reaper does not need to be compiled on the system, eliminating the [potential glibc locks when distributing reaper to old distributions](https://github.com/Open-Wine-Components/umu-launcher/issues/91), and all spawned subprocesses in that cgroup that fork/detach (e.g., winetricks) can reliably be killed. In addition, the entire process tree created after launching a game can be easily managed and monitored by the user via systemctl.

For example:
```
> systemctl status --user run-rc87623c08463475fbda10b1cc575cb38.scope;
● run-rc87623c08463475fbda10b1cc575cb38.scope - UMU_ID=1829980
     Loaded: loaded (/run/user/1000/systemd/transient/run-rc87623c08463475fbda10b1cc575cb38.scope; transient)
  Transient: yes
     Active: active (running) since Sun 2024-04-21 20:45:11 PDT; 3min 33s ago
      Tasks: 136 (limit: 18376)
     Memory: 1.7G (peak: 1.7G)
        CPU: 3min 33.516s
     CGroup: /user.slice/user-1000.slice/user@1000.service/app.slice/run-rc87623c08463475fbda10b1cc575cb38.scope
             ├─18064 /home/foo/.local/share/umu/pressure-vessel/bin/pv-bwrap --args 21 /usr/lib/pressure-vessel/from-host/bin/press>
             ├─18122 /usr/lib/pressure-vessel/from-host/bin/pressure-vessel-adverb --generate-locales --fd 12 --regenerate-ld.so-cache >
             ├─18220 /home/foo/.local/share/Steam/compatibilitytools.d/GE-Proton9-4/files/bin/wineserver
             ├─18224 "C:\\windows\\system32\\services.exe"
             ├─18227 "C:\\windows\\system32\\winedevice.exe"
             ├─18237 "C:\\windows\\system32\\winedevice.exe"
             ├─18250 "C:\\windows\\system32\\plugplay.exe"
             ├─18256 "C:\\windows\\system32\\svchost.exe" -k LocalServiceNetworkRestricted
             ├─18268 "Z:\\home\\foo\\Games\\cafe-stella\\CafeStella.exe"
             ├─18270 "C:\\windows\\system32\\explorer.exe" /desktop
             ├─18277 "C:\\windows\\system32\\rpcss.exe"
             └─18287 "C:\\windows\\system32\\tabtip.exe"

Apr 21 20:45:11 archlinux systemd[709]: Started UMU_ID=1829980.
```

This unit can be closed via `systemctl stop --user run-rc87623c08463475fbda10b1cc575cb38.scope` from the CLI or getting the invocation ID from `systemctl list-units --user -o json` by its UMU_ID then stopping the unit by its name.

Subreaping via systemd will not apply to the umu Flatpak as Flatpaks apply the `--die-with-parent` option by default, and already uses transient scoped units internally to accomplish the same effect.
