### PR TITLE
Update Pressure Vessel and Runtime

### DIFF
--- a/umu/umu_dl_util.py
+++ b/umu/umu_dl_util.py
@@ -1,3 +1,4 @@
+from sys import version
 from tarfile import open as tar_open, TarInfo
 from pathlib import Path
 from os import environ
@@ -192,7 +193,8 @@ def _extract_dir(file: Path, steam_compat: Path) -> None:
             log.debug("Using filter for archive")
             tar.extraction_filter = tar_filter
         else:
-            log.debug("Using no filter for archive")
+            log.warning("Python: %s", version)
+            log.warning("Using no data filter for archive")
             log.warning("Archive will be extracted insecurely")
 
         log.console(f"Extracting {file} -> {steam_compat} ...")

--- a/umu/umu_test.py
+++ b/umu/umu_test.py
@@ -155,6 +155,53 @@ class TestGameLauncher(unittest.TestCase):
         if self.test_local_share.exists():
             rmtree(self.test_local_share.as_posix())
 
+    def test_move(self):
+        """Test _move when copying a directory or a file.
+
+        This function simply wraps shutil.move but deletes the dest directory
+        before moving the source directory. While not strictly necesssary,
+        doing this maintains the integrity of the runtime platform's directory
+        tree defined in the mtree.txt.gz file
+        """
+        test_dir = self.test_user_share.joinpath("foo")
+        test_file = self.test_user_share.joinpath("bar")
+        test_dir.mkdir()
+        test_file.touch()
+        self.test_user_share.joinpath("qux").symlink_to(test_file)
+
+        # Directory
+        umu_util._move(test_dir, self.test_user_share, self.test_local_share)
+        self.assertFalse(
+            self.test_user_share.joinpath("foo").exists(), "foo did not move from src"
+        )
+        self.assertTrue(
+            self.test_local_share.joinpath("foo").exists(), "foo did not move to dst"
+        )
+
+        # File
+        umu_util._move(test_file, self.test_user_share, self.test_local_share)
+        self.assertFalse(
+            self.test_user_share.joinpath("bar").exists(), "bar did not move from src"
+        )
+        self.assertTrue(
+            self.test_local_share.joinpath("bar").exists(), "bar did not move to dst"
+        )
+
+        # Link
+        umu_util._move(
+            self.test_user_share.joinpath("qux"),
+            self.test_user_share,
+            self.test_local_share,
+        )
+        self.assertFalse(
+            self.test_user_share.joinpath("qux").is_symlink(),
+            "qux did not move from src",
+        )
+        self.assertTrue(
+            self.test_local_share.joinpath("qux").is_symlink(),
+            "qux did not move to dst",
+        )
+
     def test_ge_proton(self):
         """Test check_env when the code name GE-Proton is set for PROTONPATH.
 

--- a/umu/umu_test.py
+++ b/umu/umu_test.py
@@ -240,10 +240,8 @@ class TestGameLauncher(unittest.TestCase):
         )
 
         # Update
-        with patch.object(
-            umu_util,
-            "setup_runtime",
-            return_value=None,
+        with (
+            patch.object(umu_util, "setup_runtime", return_value=None),
         ):
             result = umu_util._update_umu(
                 self.test_local_share,
@@ -265,7 +263,6 @@ class TestGameLauncher(unittest.TestCase):
                 Path(self.test_user_share, "umu"),
                 Path(self.test_local_share, "umu"),
             )
-            # When the runtime updates, pressure vessel needs to be updated
             copytree(
                 Path(self.test_user_share, "pressure-vessel"),
                 Path(self.test_local_share, "pressure-vessel"),
@@ -391,10 +388,8 @@ class TestGameLauncher(unittest.TestCase):
         self.test_local_share.joinpath("pressure-vessel", "bar").touch()
 
         # Update
-        with patch.object(
-            umu_util,
-            "setup_runtime",
-            return_value=None,
+        with (
+            patch.object(umu_util, "setup_runtime", return_value=None),
         ):
             result = umu_util._update_umu(
                 self.test_local_share,
@@ -416,7 +411,6 @@ class TestGameLauncher(unittest.TestCase):
                 Path(self.test_user_share, "umu"),
                 Path(self.test_local_share, "umu"),
             )
-            # When the runtime updates, pressure vessel needs to be updated
             copytree(
                 Path(self.test_user_share, "pressure-vessel"),
                 Path(self.test_local_share, "pressure-vessel"),
@@ -494,10 +488,8 @@ class TestGameLauncher(unittest.TestCase):
         # Mock setting up the runtime
         # In the real usage, we callout to acquire the archive and
         # extract to .local/share/umu
-        with patch.object(
-            umu_util,
-            "setup_runtime",
-            return_value=None,
+        with (
+            patch.object(umu_util, "setup_runtime", return_value=None),
         ):
             result = umu_util._install_umu(
                 self.test_user_share, self.test_local_share, json
@@ -1307,10 +1299,8 @@ class TestGameLauncher(unittest.TestCase):
             os.environ[key] = val
 
         # Mock setting up the runtime
-        with patch.object(
-            umu_util,
-            "setup_runtime",
-            return_value=None,
+        with (
+            patch.object(umu_util, "setup_runtime", return_value=None),
         ):
             umu_util._install_umu(self.test_user_share, self.test_local_share, json)
             copytree(

--- a/umu/umu_test_plugins.py
+++ b/umu/umu_test_plugins.py
@@ -213,10 +213,8 @@ class TestGameLauncherPlugins(unittest.TestCase):
 
         # Mock setting up the runtime
         # Don't copy _v2-entry-point
-        with patch.object(
-            umu_util,
-            "setup_runtime",
-            return_value=None,
+        with (
+            patch.object(umu_util, "setup_runtime", return_value=None),
         ):
             umu_util._install_umu(self.test_user_share, self.test_local_share, json)
             copytree(
@@ -282,10 +280,8 @@ class TestGameLauncherPlugins(unittest.TestCase):
             umu_plugins.enable_steam_game_drive(self.env)
 
         # Mock setting up the runtime
-        with patch.object(
-            umu_util,
-            "setup_runtime",
-            return_value=None,
+        with (
+            patch.object(umu_util, "setup_runtime", return_value=None),
         ):
             umu_util._install_umu(self.test_user_share, self.test_local_share, json)
             copytree(
@@ -355,10 +351,8 @@ class TestGameLauncherPlugins(unittest.TestCase):
             umu_plugins.enable_steam_game_drive(self.env)
 
         # Mock setting up the runtime
-        with patch.object(
-            umu_util,
-            "setup_runtime",
-            return_value=None,
+        with (
+            patch.object(umu_util, "setup_runtime", return_value=None),
         ):
             umu_util._install_umu(self.test_user_share, self.test_local_share, json)
             copytree(

--- a/umu/umu_util.py
+++ b/umu/umu_util.py
@@ -173,10 +173,6 @@ def _update_umu(
     futures: List[Future] = []
     log.debug("Existing install detected")
 
-    # Attempt to copy only the updated versions
-    # Compare the local to the root config
-    # When a directory for a specific tool doesn't exist, remake the copy
-    # Be lazy and just trust the integrity of local
     for key, val in json_root["umu"]["versions"].items():
         if key == "reaper":
             if val == json_local["umu"]["versions"]["reaper"]:
@@ -228,7 +224,6 @@ def _update_umu(
         _.result()
     executor.shutdown()
 
-    # Finally, update the local config file
     with local.joinpath(CONFIG).open(mode="w") as file:
         dump(json_local, file, indent=4)
 
@@ -243,7 +238,7 @@ def _get_json(path: Path, config: str) -> Dict[str, Any]:
     """
     json: Dict[str, Any] = None
 
-    # The file in /usr/share/umu should always exist
+    # umu_version.json in the system path should always exist
     if not path.joinpath(config).is_file():
         err: str = (
             f"File not found: {config}\n"

--- a/umu/umu_util.py
+++ b/umu/umu_util.py
@@ -62,14 +62,14 @@ def setup_runtime(json: Dict[str, Any]) -> None:  # noqa: D103
             with tmp.joinpath(archive).open(mode="wb") as file:
                 file.write(resp.read())
 
-    log.debug("Opening: %s", tmp.joinpath(archive))
     # Open the tar file
+    log.debug("Opening: %s", tmp.joinpath(archive))
     with tar_open(tmp.joinpath(archive), "r:xz") as tar:
         if tar_filter:
             log.debug("Using filter for archive")
             tar.extraction_filter = tar_filter
         else:
-            log.debug("Using no filter for archive")
+            log.warning("Using no filter for archive")
             log.warning("Archive will be extracted insecurely")
 
         # Ensure the target directory exists
@@ -103,9 +103,8 @@ def setup_runtime(json: Dict[str, Any]) -> None:  # noqa: D103
         log.debug("Removing: %s", tmp.joinpath(archive))
         tmp.joinpath(archive).unlink(missing_ok=True)
 
-        log.debug("Renaming: _v2-entry-point -> umu")
-
         # Rename _v2-entry-point
+        log.debug("Renaming: _v2-entry-point -> umu")
         UMU_LOCAL.joinpath("_v2-entry-point").rename(UMU_LOCAL.joinpath("umu"))
 
 

--- a/umu/umu_util.py
+++ b/umu/umu_util.py
@@ -1,3 +1,4 @@
+from sys import version
 from tarfile import open as tar_open, TarInfo
 from os import environ
 from umu_consts import CONFIG, UMU_LOCAL
@@ -69,7 +70,8 @@ def setup_runtime(json: Dict[str, Any]) -> None:  # noqa: D103
             log.debug("Using filter for archive")
             tar.extraction_filter = tar_filter
         else:
-            log.warning("Using no filter for archive")
+            log.warning("Python: %s", version)
+            log.warning("Using no data filter for archive")
             log.warning("Archive will be extracted insecurely")
 
         # Ensure the target directory exists

--- a/umu/umu_version.json.in
+++ b/umu/umu_version.json.in
@@ -3,9 +3,8 @@
     "versions": {
       "launcher": "##UMU_VERSION##",
       "runner": "##UMU_VERSION##",
-      "runtime_platform": "sniper_platform_0.20240125.75305",
-      "reaper": "##REAPER_VERSION##",
-      "pressure_vessel": "v0.20240212.0"
+      "runtime_platform": "0.20240423.85483",
+      "reaper": "##REAPER_VERSION##"
     }
   }
 }


### PR DESCRIPTION
Depends on https://github.com/Open-Wine-Components/umu-launcher/pull/95 being merged.

Currently, the launcher uses a runtime platform, steamrt3 (sniper), that is several releases behind the latest. As a result, the launcher misses the latest bug/security fixes that address CVEs such as CVE-2024-3094 and improvements that may effect games.

This pull request updates the sniper runtime and pressure vessel to the current latest, and changes the launcher to download the new official archive for the runtime, `SteamLinuxRuntime_sniper.tar.xz`, which has superseded `steam-container-runtime{,-complete}.tar.gz`

See https://gitlab.steamos.cloud/steamrt/steamrt/-/wikis/Sniper-release-notes#container-runtime-5