### PR TITLE
Add xdg-download to flatpak filesystem perms

### DIFF
--- a/packaging/flatpak/org.openwinecomponents.umu.umu-launcher.yml
+++ b/packaging/flatpak/org.openwinecomponents.umu.umu-launcher.yml
@@ -29,6 +29,7 @@ finish-args:
   - --filesystem=~/.var/app/org.openwinecomponents.umu.umu-launcher:rw
   - --filesystem=xdg-documents
   - --filesystem=xdg-desktop
+  - --filesystem=xdg-download
   - --env=TZ=
   - --unset-env=TZ
   - --env=LC_ADDRESS=C


### PR DESCRIPTION
Tried to run an exe that was just downloaded. I imagine others would probably do the same, so allowing the `~/Downloads` makes sense.