### PR TITLE
Fix configuring Steam game drive and misc

### DIFF
--- a/umu/ruff.toml
+++ b/umu/ruff.toml
@@ -82,7 +82,10 @@ select = [
     # Ensure explicit check= for subprocess.run to avoid silent failures
     "PLW1510",
     "UP",
-    "FURB"
+    "FURB",
+    # Enforce the encoding argument when opening files
+    # Encoding for text should be utf-8
+    "PLW1514"
 ]
 ignore = [
     # Format

--- a/umu/umu_plugins.py
+++ b/umu/umu_plugins.py
@@ -105,40 +105,6 @@ def _check_env_toml(toml: dict[str, Any]) -> dict[str, Any]:
     return toml
 
 
-def enable_steam_game_drive(env: dict[str, str]) -> dict[str, str]:
-    """Enable Steam Game Drive functionality.
-
-    Expects STEAM_COMPAT_INSTALL_PATH to be set
-    STEAM_RUNTIME_LIBRARY_PATH will not be set if the exe directory does not exist
-    """
-    paths: set[str] = set()
-    root: Path = Path("/")
-
-    # Check for mount points going up toward the root
-    # NOTE: Subvolumes can be mount points
-    for path in Path(env["STEAM_COMPAT_INSTALL_PATH"]).parents:
-        if path.is_mount() and path != root:
-            if env["STEAM_COMPAT_LIBRARY_PATHS"]:
-                env["STEAM_COMPAT_LIBRARY_PATHS"] = (
-                    env["STEAM_COMPAT_LIBRARY_PATHS"] + ":" + path.as_posix()
-                )
-            else:
-                env["STEAM_COMPAT_LIBRARY_PATHS"] = path.as_posix()
-            break
-
-    if environ.get("LD_LIBRARY_PATH"):
-        paths = {path for path in environ["LD_LIBRARY_PATH"].split(":")}
-
-    if env["STEAM_COMPAT_INSTALL_PATH"]:
-        paths.add(env["STEAM_COMPAT_INSTALL_PATH"])
-
-    # Hard code for now because these paths seem to be pretty standard
-    # This way we avoid shelling to ldconfig
-    paths.add("/usr/lib")
-    paths.add("/usr/lib32")
-    env["STEAM_RUNTIME_LIBRARY_PATH"] = ":".join(list(paths))
-
-    return env
 
 
 def enable_zenity(command: str, opts: list[str], msg: str) -> int:

--- a/umu/umu_plugins.py
+++ b/umu/umu_plugins.py
@@ -1,5 +1,4 @@
 from subprocess import Popen, TimeoutExpired, PIPE, STDOUT
-from os import environ
 from pathlib import Path
 from typing import Any
 from argparse import Namespace
@@ -103,8 +102,6 @@ def _check_env_toml(toml: dict[str, Any]) -> dict[str, Any]:
             raise ValueError(err)
 
     return toml
-
-
 
 
 def enable_zenity(command: str, opts: list[str], msg: str) -> int:

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -259,7 +259,9 @@ def enable_steam_game_drive(env: dict[str, str]) -> dict[str, str]:
     if env["STEAM_COMPAT_INSTALL_PATH"]:
         paths.add(env["STEAM_COMPAT_INSTALL_PATH"])
 
-    # Include all paths that are supported by the container runtime framework
+    # Include all paths that are currently supported by the container
+    # runtime framework
+    # See https://gitlab.steamos.cloud/steamrt/steam-runtime-tools/-/blob/main/docs/distro-assumptions.md
     for path in [
         "/usr/lib64",
         "/usr/lib32",

--- a/umu/umu_test.py
+++ b/umu/umu_test.py
@@ -3,7 +3,6 @@ import umu_run
 import os
 import argparse
 import re
-import umu_plugins
 import umu_dl_util
 import tarfile
 import umu_util
@@ -1141,7 +1140,7 @@ class TestGameLauncher(unittest.TestCase):
             os.environ["LD_LIBRARY_PATH"] = paths
 
             # Game drive
-            result_gamedrive = umu_plugins.enable_steam_game_drive(self.env)
+            result_gamedrive = umu_run.enable_steam_game_drive(self.env)
 
         for key, val in self.env.items():
             os.environ[key] = val
@@ -1226,7 +1225,7 @@ class TestGameLauncher(unittest.TestCase):
             os.environ["LD_LIBRARY_PATH"] = paths
 
             # Game drive
-            result_gamedrive = umu_plugins.enable_steam_game_drive(self.env)
+            result_gamedrive = umu_run.enable_steam_game_drive(self.env)
 
         for key, val in self.env.items():
             os.environ[key] = val
@@ -1305,7 +1304,7 @@ class TestGameLauncher(unittest.TestCase):
                 os.environ.pop("LD_LIBRARY_PATH")
 
             # Game drive
-            result_gamedrive = umu_plugins.enable_steam_game_drive(self.env)
+            result_gamedrive = umu_run.enable_steam_game_drive(self.env)
 
         # Ubuntu sources this variable and will be added once Game Drive is enabled
         # Just test the case without it
@@ -1373,7 +1372,7 @@ class TestGameLauncher(unittest.TestCase):
             # Env
             umu_run.set_env(self.env, result_args)
             # Game drive
-            umu_plugins.enable_steam_game_drive(self.env)
+            umu_run.enable_steam_game_drive(self.env)
 
         for key, val in self.env.items():
             os.environ[key] = val

--- a/umu/umu_test.py
+++ b/umu/umu_test.py
@@ -1286,6 +1286,14 @@ class TestGameLauncher(unittest.TestCase):
         """
         args = None
         result_gamedrive = None
+        # Expected library paths for the container runtime framework
+        libpaths = {
+            "/usr/lib64",
+            "/usr/lib32",
+            "/usr/lib",
+            "/usr/lib/x86_64-linux-gnu",
+            "/usr/lib/i386-linux-gnu",
+        }
         Path(self.test_file + "/proton").touch()
 
         # Replicate main's execution and test up until enable_steam_game_drive
@@ -1334,12 +1342,11 @@ class TestGameLauncher(unittest.TestCase):
             "Expected two values in STEAM_RUNTIME_LIBRARY_PATH",
         )
 
-        # We need to sort the elements because the values were originally in a set
-        str1, str2 = [*sorted(self.env["STEAM_RUNTIME_LIBRARY_PATH"].split(":"))]
-
-        # Check that there are no trailing colons or unexpected characters
-        self.assertEqual(str1, "/usr/lib", "Expected /usr/lib")
-        self.assertEqual(str2, "/usr/lib32", "Expected /usr/lib32")
+        # Check that there are no trailing colons, unexpected characters
+        # and is officially supported
+        str1, str2 = self.env["STEAM_RUNTIME_LIBRARY_PATH"].split(":")
+        self.assertTrue(str1 in libpaths, f"Expected a path in: {libpaths}")
+        self.assertTrue(str2 in libpaths, f"Expected a path in: {libpaths}")
 
         # Both of these values should be empty still after calling
         # enable_steam_game_drive

--- a/umu/umu_test.py
+++ b/umu/umu_test.py
@@ -91,7 +91,9 @@ class TestGameLauncher(unittest.TestCase):
         # Mock a valid configuration file at /usr/share/umu:
         # tmp.BXk2NnvW2m/umu_version.json
         Path(self.test_user_share, "umu_version.json").touch()
-        with Path(self.test_user_share, "umu_version.json").open(mode="w") as file:
+        with Path(self.test_user_share, "umu_version.json").open(
+            mode="w", encoding="utf-8"
+        ) as file:
             file.write(self.test_config)
 
         # Mock the launcher files
@@ -666,7 +668,9 @@ class TestGameLauncher(unittest.TestCase):
         Path(self.test_user_share, "umu_version.json").unlink(missing_ok=True)
 
         Path(self.test_user_share, "umu_version.json").touch()
-        with Path(self.test_user_share, "umu_version.json").open(mode="w") as file:
+        with Path(self.test_user_share, "umu_version.json").open(
+            mode="w", encoding="utf-8"
+        ) as file:
             file.write(test_config)
 
         # Test when "umu" doesn't exist
@@ -677,7 +681,9 @@ class TestGameLauncher(unittest.TestCase):
         Path(self.test_user_share, "umu_version.json").unlink(missing_ok=True)
 
         Path(self.test_user_share, "umu_version.json").touch()
-        with Path(self.test_user_share, "umu_version.json").open(mode="w") as file:
+        with Path(self.test_user_share, "umu_version.json").open(
+            mode="w", encoding="utf-8"
+        ) as file:
             file.write(test_config2)
 
         with self.assertRaisesRegex(ValueError, "load"):

--- a/umu/umu_test_plugins.py
+++ b/umu/umu_test_plugins.py
@@ -88,7 +88,9 @@ class TestGameLauncherPlugins(unittest.TestCase):
         # Mock a valid configuration file at /usr/share/umu:
         # tmp.BXk2NnvW2m/umu_version.json
         Path(self.test_user_share, "umu_version.json").touch()
-        with Path(self.test_user_share, "umu_version.json").open(mode="w") as file:
+        with Path(self.test_user_share, "umu_version.json").open(
+            mode="w", encoding="utf-8"
+        ) as file:
             file.write(self.test_config)
 
         # Mock the launcher files
@@ -192,7 +194,7 @@ class TestGameLauncherPlugins(unittest.TestCase):
         # Mock the proton file
         Path(self.test_file, "proton").touch()
 
-        with Path(toml_path).open(mode="w") as file:
+        with Path(toml_path).open(mode="w", encoding="utf-8") as file:
             file.write(toml_str)
 
         with patch.object(
@@ -260,7 +262,7 @@ class TestGameLauncherPlugins(unittest.TestCase):
         test_command = []
         Path(toml_path).touch()
 
-        with Path(toml_path).open(mode="w") as file:
+        with Path(toml_path).open(mode="w", encoding="utf-8") as file:
             file.write(toml_str)
 
         with patch.object(
@@ -331,7 +333,7 @@ class TestGameLauncherPlugins(unittest.TestCase):
         Path(self.test_file + "/proton").touch()
         Path(toml_path).touch()
 
-        with Path(toml_path).open(mode="w") as file:
+        with Path(toml_path).open(mode="w", encoding="utf-8") as file:
             file.write(toml_str)
 
         with patch.object(
@@ -421,7 +423,7 @@ class TestGameLauncherPlugins(unittest.TestCase):
 
         Path(toml_path).touch()
 
-        with Path(toml_path).open(mode="w") as file:
+        with Path(toml_path).open(mode="w", encoding="utf-8") as file:
             file.write(toml_str)
 
         with patch.object(
@@ -457,7 +459,7 @@ class TestGameLauncherPlugins(unittest.TestCase):
 
         Path(toml_path).touch()
 
-        with Path(toml_path).open(mode="w") as file:
+        with Path(toml_path).open(mode="w", encoding="utf-8") as file:
             file.write(toml_str)
 
         with patch.object(
@@ -493,7 +495,7 @@ class TestGameLauncherPlugins(unittest.TestCase):
 
         Path(toml_path).touch()
 
-        with Path(toml_path).open(mode="w") as file:
+        with Path(toml_path).open(mode="w", encoding="utf-8") as file:
             file.write(toml_str)
 
         with patch.object(
@@ -529,7 +531,7 @@ class TestGameLauncherPlugins(unittest.TestCase):
 
         Path(toml_path).touch()
 
-        with Path(toml_path).open(mode="w") as file:
+        with Path(toml_path).open(mode="w", encoding="utf-8") as file:
             file.write(toml_str)
 
         with patch.object(
@@ -648,7 +650,7 @@ class TestGameLauncherPlugins(unittest.TestCase):
 
         Path(toml_path).touch()
 
-        with Path(toml_path).open(mode="w") as file:
+        with Path(toml_path).open(mode="w", encoding="utf-8") as file:
             file.write(toml_str)
 
         with patch.object(
@@ -718,7 +720,7 @@ class TestGameLauncherPlugins(unittest.TestCase):
 
         Path(toml_path).touch()
 
-        with Path(toml_path).open(mode="w") as file:
+        with Path(toml_path).open(mode="w", encoding="utf-8") as file:
             file.write(toml_str)
 
         with patch.object(

--- a/umu/umu_test_plugins.py
+++ b/umu/umu_test_plugins.py
@@ -209,7 +209,7 @@ class TestGameLauncherPlugins(unittest.TestCase):
             # Env
             umu_run.set_env(self.env, result)
             # Game drive
-            umu_plugins.enable_steam_game_drive(self.env)
+            umu_run.enable_steam_game_drive(self.env)
 
         # Mock setting up the runtime
         # Don't copy _v2-entry-point
@@ -277,7 +277,7 @@ class TestGameLauncherPlugins(unittest.TestCase):
             # Env
             umu_run.set_env(self.env, result)
             # Game drive
-            umu_plugins.enable_steam_game_drive(self.env)
+            umu_run.enable_steam_game_drive(self.env)
 
         # Mock setting up the runtime
         with (
@@ -348,7 +348,7 @@ class TestGameLauncherPlugins(unittest.TestCase):
             # Env
             umu_run.set_env(self.env, result)
             # Game drive
-            umu_plugins.enable_steam_game_drive(self.env)
+            umu_run.enable_steam_game_drive(self.env)
 
         # Mock setting up the runtime
         with (


### PR DESCRIPTION
Fixes library paths for Steam game drive and updates ruff.toml to enforce the `encoding` argument when opening files. As a result, the STEAM_RUNTIME_LIBRARY_PATH variable should be represented accurately across distributions as long as the filesystem is FHS compliant and are officially supported by the runtime container framework.
