### PR TITLE
Remove incorrect libc check

### DIFF
--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -279,8 +279,7 @@ def enable_steam_game_drive(env: dict[str, str]) -> dict[str, str]:
         paths.add(env["STEAM_COMPAT_INSTALL_PATH"])
 
     for path in steamrt_paths:
-        if not Path(path).is_symlink() and Path(path, libc).is_file():
-            paths.add(path)
+        paths.add(path)
     env["STEAM_RUNTIME_LIBRARY_PATH"] = ":".join(list(paths))
 
     return env


### PR DESCRIPTION
This commit removes an incorrect libc check. Testing has shown that the application runs without issues when these lines are omitted. The commit message in 6c6ec71 acknowledges the problem, stating:

"... While this currently works and has not been reported to cause any issues, this is still wrong since distributions like Debian or Fedora use different paths (e.g., /usr/lib64 and /usr/lib). To reliably find the user's library paths, we need to use the ldconfig binary."

However, using ldconfig is also not entirely correct. Instead of attempting to implement the use of ldconfig, this PR reverts that change.

Fixes #106 