### PR TITLE
Add functionality to use winetricks

### DIFF
--- a/docs/umu.1.scd
+++ b/docs/umu.1.scd
@@ -118,6 +118,12 @@ $ WINEPREFIX=~/.wine GAMEID=0 PROTONPATH=GE-Proton9-1 umu-run ~/foo.exe
 $ WINEPREFIX=~/.wine GAMEID=0 PROTONPATH=GE-Proton umu-run ~/foo.exe
 ```
 
+*Example 11. Install winetricks verbs*
+
+```
+$ GAMEID=0 PROTONPATH=GE-Proton umu-run winetricks quartz wmp11 qasf
+```
+
 # SEE ALSO
 
 _umu_(5)

--- a/docs/umu.1.scd
+++ b/docs/umu.1.scd
@@ -118,7 +118,7 @@ $ WINEPREFIX=~/.wine GAMEID=0 PROTONPATH=GE-Proton9-1 umu-run ~/foo.exe
 $ WINEPREFIX=~/.wine GAMEID=0 PROTONPATH=GE-Proton umu-run ~/foo.exe
 ```
 
-*Example 11. Install winetricks verbs*
+*Example 11. Run winetricks verbs*
 
 ```
 $ GAMEID=0 PROTONPATH=GE-Proton umu-run winetricks quartz wmp11 qasf

--- a/umu/umu_proton.py
+++ b/umu/umu_proton.py
@@ -38,8 +38,6 @@ class Proton:
         self.wine_bin = self.bin_dir + "wine"
         self.wine64_bin = self.bin_dir + "wine64"
         self.wineserver_bin = self.bin_dir + "wineserver"
-        self.protonfixes = self.base_dir + "protonfixes"
-        self.winetricks_bin = self.base_dir + "protonfixes/winetricks"
 
     def path(self, dir: str) -> str:  # noqa: D102
         return self.base_dir + dir

--- a/umu/umu_proton.py
+++ b/umu/umu_proton.py
@@ -25,6 +25,26 @@ except ImportError:
     tar_filter: Callable[[str, str], TarInfo] = None
 
 
+class Proton:
+    """Model paths to relevant files and directories for Proton."""
+
+    def __init__(self, base_dir: str) -> None:  # noqa: D107
+        self.base_dir = base_dir + "/"
+        self.dist_dir = self.path("files/")
+        self.bin_dir = self.path("files/bin/")
+        self.lib_dir = self.path("files/lib/")
+        self.lib64_dir = self.path("files/lib64/")
+        self.version_file = self.path("version")
+        self.wine_bin = self.bin_dir + "wine"
+        self.wine64_bin = self.bin_dir + "wine64"
+        self.wineserver_bin = self.bin_dir + "wineserver"
+        self.protonfixes = self.base_dir + "protonfixes"
+        self.winetricks_bin = self.base_dir + "protonfixes/winetricks"
+
+    def path(self, dir: str) -> str:  # noqa: D102
+        return self.base_dir + dir
+
+
 def get_umu_proton(
     env: dict[str, str], thread_pool: ThreadPoolExecutor
 ) -> dict[str, str]:

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -66,11 +66,8 @@ def parse_args() -> Namespace | tuple[str, list[str]]:  # noqa: D103
 
     # Exit if argument is not a verb
     if sys.argv[1].endswith("winetricks") and not is_winetricks_verb(
-        sys.argv[2:][0]
+        " ".join(sys.argv[2:])
     ):
-        verb: str = sys.argv[2:][0]
-        err: str = f"Value is not a winetricks verb: '{verb}'"
-        log.error(err)
         sys.exit(1)
 
     if sys.argv[1:][0] in opt_args:
@@ -588,13 +585,8 @@ def main() -> int:  # noqa: D103
 
     # Exit if the winetricks verb is already installed to avoid reapplying it
     if env.get("EXE").endswith("winetricks") and is_installed_verb(
-        opts[0], Path(env.get("WINEPREFIX"))
+        " ".join(opts), Path(env.get("WINEPREFIX"))
     ):
-        pfx: str = os.environ["WINEPREFIX"]
-        err: str = (
-            f"winetricks verb '{opts[0]}' is already installed in '{pfx}'"
-        )
-        log.error(err)
         sys.exit(1)
 
     # Run

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -96,8 +96,6 @@ def set_log() -> None:
         log.addHandler(console_handler)
         log.setLevel(level=DEBUG)
 
-    os.environ.pop("UMU_LOG")
-
 
 def setup_pfx(path: str) -> None:
     """Create a symlink to the WINE prefix and tracked_files file."""
@@ -272,6 +270,18 @@ def set_env(
 
     # Game drive
     enable_steam_game_drive(env)
+
+    # Winetricks
+    if env.get("EXE").endswith("winetricks"):
+        proton: Proton = Proton(os.environ["PROTONPATH"])
+        env["WINE"] = proton.wine_bin
+        env["WINELOADER"] = proton.wine_bin
+        env["WINESERVER"] = proton.wineserver_bin
+        env["WINETRICKS_LATEST_VERSION_CHECK"] = "disabled"
+        env["LD_PRELOAD"] = ""
+        env["WINETRICKS_SUPER_QUIET"] = (
+            "" if os.environ.get("UMU_LOG") == "debug" else "1"
+        )
 
     return env
 

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -224,9 +224,10 @@ def set_env(
         env["STEAM_COMPAT_INSTALL_PATH"] = ""
         env["PROTON_VERB"] = "waitforexitandrun"
     elif isinstance(args, tuple) and args[0] == "winetricks":
-        # Make an absolute path to winetricks that is within our Proton, which
-        # includes the dependencies bundled within the protonfix directory.
-        # Fixes exit 3 status codes after applying verbs
+        # Make an absolute path to winetricks that is within GE-Proton or
+        # UMU-Proton, which includes the dependencies bundled within the
+        # protonfixes directory. Fixes exit 3 status codes after applying
+        # winetricks verbs
         bin: str = (
             Path(env["PROTONPATH"], "protonfixes", "winetricks")
             .expanduser()

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -386,13 +386,9 @@ def build_command(
 
     # Configure winetricks to not be prompted for any windows
     if env.get("EXE").endswith("winetricks") and opts:
-        opts.append("-q")
-        # Swap the option and the last verb because the position of arguments
-        # matter for winetricks.
-        # Usage: winetricks [options] [command|verb|path-to-verb] ...
-        # When swapping, assuming that order of verbs does not matter and will
-        # yield the same result
-        opts[0], opts[-1] = opts[-1], opts[0]
+        # The position of arguments matter for winetricks
+        # Usage: ./winetricks [options] [command|verb|path-to-verb] ...
+        opts.insert(0, "-q")
 
     if opts:
         command.extend(

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -364,6 +364,13 @@ def build_command(
         err: str = "The following file was not found in PROTONPATH: proton"
         raise FileNotFoundError(err)
 
+    # Configure winetricks to not be prompted for any windows
+    if env.get("EXE").endswith("winetricks") and opts:
+        opts.append("-q")
+        # The position of the arguments matter for winetricks
+        # Usage: winetricks [options] [command|verb|path-to-verb] ...
+        opts[0], opts[1] = opts[1], opts[0]
+
     if opts:
         command.extend(
             [

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -387,9 +387,12 @@ def build_command(
     # Configure winetricks to not be prompted for any windows
     if env.get("EXE").endswith("winetricks") and opts:
         opts.append("-q")
-        # Swap the option and verb because the position of the arguments matter
+        # Swap the option and the last verb because the position of arguments
+        # matter for winetricks.
         # Usage: winetricks [options] [command|verb|path-to-verb] ...
-        opts[0], opts[1] = opts[1], opts[0]
+        # When swapping, assuming that order of verbs does not matter and will
+        # yield the same result
+        opts[0], opts[-1] = opts[-1], opts[0]
 
     if opts:
         command.extend(

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -53,7 +53,7 @@ def parse_args() -> Namespace | tuple[str, list[str]]:  # noqa: D103
 
     # Winetricks
     # Exit if no winetricks verbs were passed
-    if sys.argv[1].endswith("winetricks") and not sys.argv[2:][0]:
+    if sys.argv[1].endswith("winetricks") and not sys.argv[2:]:
         err: str = "No winetricks verb specified"
         log.error(err)
         sys.exit(1)

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -395,7 +395,7 @@ def build_command(
     if env.get("EXE").endswith("winetricks") and opts:
         # The position of arguments matter for winetricks
         # Usage: ./winetricks [options] [command|verb|path-to-verb] ...
-        opts.insert(0, "-q")
+        opts = ["-q", *opts]
 
     if opts:
         command.extend(

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -69,7 +69,7 @@ def parse_args() -> Namespace | tuple[str, list[str]]:  # noqa: D103
         sys.argv[2:][0]
     ):
         verb: str = sys.argv[2:][0]
-        err: str = f"Value is not a winetricks verb: {verb}"
+        err: str = f"Value is not a winetricks verb: '{verb}'"
         log.error(err)
         sys.exit(1)
 

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -66,7 +66,7 @@ def parse_args() -> Namespace | tuple[str, list[str]]:  # noqa: D103
 
     # Exit if argument is not a verb
     if sys.argv[1].endswith("winetricks") and not is_winetricks_verb(
-        " ".join(sys.argv[2:])
+        sys.argv[2:]
     ):
         sys.exit(1)
 
@@ -585,7 +585,7 @@ def main() -> int:  # noqa: D103
 
     # Exit if the winetricks verb is already installed to avoid reapplying it
     if env.get("EXE").endswith("winetricks") and is_installed_verb(
-        " ".join(opts), Path(env.get("WINEPREFIX"))
+        opts, Path(env.get("WINEPREFIX"))
     ):
         sys.exit(1)
 

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -229,6 +229,8 @@ def set_env(
         )
         log.debug("EXE: %s -> %s", args[0], bin)
         args: tuple[str, list[str]] = (bin, args[1])
+        env["EXE"] = bin
+        env["STEAM_COMPAT_INSTALL_PATH"] = Path(env["EXE"]).parent.as_posix()
     elif isinstance(args, tuple):
         try:
             env["EXE"] = (

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -385,7 +385,7 @@ def build_command(
     # Configure winetricks to not be prompted for any windows
     if env.get("EXE").endswith("winetricks") and opts:
         opts.append("-q")
-        # The position of the arguments matter for winetricks
+        # Swap the option and verb because the position of the arguments matter
         # Usage: winetricks [options] [command|verb|path-to-verb] ...
         opts[0], opts[1] = opts[1], opts[0]
 
@@ -578,6 +578,7 @@ def main() -> int:  # noqa: D103
         future.result()
     THREAD_POOL.shutdown()
 
+    # Exit if the winetricks verb is already installed to avoid reapplying it
     if env.get("EXE").endswith("winetricks") and is_installed_verb(
         opts[0], Path(env.get("WINEPREFIX"))
     ):

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -46,6 +46,12 @@ def parse_args() -> Namespace | tuple[str, list[str]]:  # noqa: D103
     parser.add_argument(
         "--config", help=("path to TOML file (requires Python 3.11+)")
     )
+    parser.add_argument(
+        "winetricks",
+        help=("run winetricks (requires UMU-Proton or GE-Proton)"),
+        nargs="?",
+        default=None,
+    )
 
     if not sys.argv[1:]:
         parser.print_help(sys.stderr)

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -279,6 +279,12 @@ def set_env(
         env["WINESERVER"] = proton.wineserver_bin
         env["WINETRICKS_LATEST_VERSION_CHECK"] = "disabled"
         env["LD_PRELOAD"] = ""
+        env["WINEDLLPATH"] = ":".join(
+            [
+                Path(proton.lib_dir, "wine").as_posix(),
+                Path(proton.lib64_dir, "wine").as_posix(),
+            ]
+        )
         env["WINETRICKS_SUPER_QUIET"] = (
             "" if os.environ.get("UMU_LOG") == "debug" else "1"
         )

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -217,6 +217,18 @@ def set_env(
         env["EXE"] = ""
         env["STEAM_COMPAT_INSTALL_PATH"] = ""
         env["PROTON_VERB"] = "waitforexitandrun"
+    elif isinstance(args, tuple) and args[0] == "winetricks":
+        # Make an absolute path to winetricks that is within our Proton, which
+        # includes the dependencies bundled within the protonfix directory.
+        # Fixes exit 3 status codes after applying verbs
+        bin: str = (
+            Path(env["PROTONPATH"], "protonfixes", "winetricks")
+            .expanduser()
+            .resolve(strict=True)
+            .as_posix()
+        )
+        log.debug("EXE: %s -> %s", args[0], bin)
+        args: tuple[str, list[str]] = (bin, args[1])
     elif isinstance(args, tuple):
         try:
             env["EXE"] = (

--- a/umu/umu_test.py
+++ b/umu/umu_test.py
@@ -225,6 +225,36 @@ class TestGameLauncher(unittest.TestCase):
 
         result = umu_util.is_installed_verb(verb, self.test_winepfx)
         self.assertTrue(result, "winetricks verb was not installed")
+
+    def test_is_not_winetricks_verb(self):
+        """Test is_winetricks_verb when not passed a valid verb."""
+        verbs = ["--help", "; bash", "-q list-all"]
+        result = False
+        err = []
+
+        for verb in verbs:
+            if umu_util.is_winetricks_verb(verb):
+                result = True
+                err.append(f"'{verb}' is a winetricks verb")
+
+        self.assertFalse(result, err)
+
+    def test_is_winetricks_verb(self):
+        """Test is_winetricks_verb when passed a valid verb.
+
+        Expects winetricks verbs to follow ^[a-zA-Z_0-9]+(=[a-zA-Z0-9]+)?$.
+        """
+        verbs = ["foo", "foo bar baz", "foo=bar baz=qux"]
+        result = True
+        err = []
+
+        for verb in verbs:
+            if not umu_util.is_winetricks_verb(verb):
+                result = True
+                err.append(f"'{verb}' is not a winetricks verb")
+
+        self.assertTrue(result, err)
+
     def test_check_runtime(self):
         """Test check_runtime when pv-verify does not exist.
 

--- a/umu/umu_test.py
+++ b/umu/umu_test.py
@@ -181,14 +181,14 @@ class TestGameLauncher(unittest.TestCase):
 
     def test_is_installed_verb_noverb(self):
         """Test is_installed_verb when passed an empty verb."""
-        verb = ""
+        verb = []
 
         with self.assertRaises(ValueError):
             umu_util.is_installed_verb(verb, self.test_winepfx)
 
     def test_ist_installed_verb_nopfx(self):
         """Test is_installed_verb when passed a non-existent pfx."""
-        verb = "foo"
+        verb = ["foo"]
         result = True
 
         # Handle the None type
@@ -204,7 +204,7 @@ class TestGameLauncher(unittest.TestCase):
 
     def test_is_installed_verb_nofile(self):
         """Test is_installed_verb when the log file is absent."""
-        verb = "foo"
+        verb = ["foo"]
         result = True
 
         result = umu_util.is_installed_verb(verb, self.test_winepfx)
@@ -216,14 +216,12 @@ class TestGameLauncher(unittest.TestCase):
         Reads the winetricks.log file within the wine prefix to find the verb
         that was passed from the command line.
         """
-        verb = "foo"
+        verbs = ["foo", "bar"]
         wt_log = self.test_winepfx.joinpath("winetricks.log")
         result = False
 
-        with wt_log.open(mode="w", encoding="utf-8") as file:
-            file.write(verb)
-
-        result = umu_util.is_installed_verb(verb, self.test_winepfx)
+        wt_log.write_text("\n".join(verbs))
+        result = umu_util.is_installed_verb(verbs, self.test_winepfx)
         self.assertTrue(result, "winetricks verb was not installed")
 
     def test_is_not_winetricks_verb(self):

--- a/umu/umu_test.py
+++ b/umu/umu_test.py
@@ -228,32 +228,29 @@ class TestGameLauncher(unittest.TestCase):
 
     def test_is_not_winetricks_verb(self):
         """Test is_winetricks_verb when not passed a valid verb."""
-        verbs = ["--help", "; bash", "-q list-all"]
+        verbs = ["--help", ";bash", "list-all"]
         result = False
-        err = []
 
-        for verb in verbs:
-            if umu_util.is_winetricks_verb(verb):
-                result = True
-                err.append(f"'{verb}' is a winetricks verb")
+        result = umu_util.is_winetricks_verb(verbs)
+        self.assertFalse(result, f"{verbs} contains a winetricks verb")
 
-        self.assertFalse(result, err)
+        # Handle None and empty cases
+        result = umu_util.is_winetricks_verb(None)
+        self.assertFalse(result, f"{verbs} contains a winetricks verb")
+
+        result = umu_util.is_winetricks_verb([])
+        self.assertFalse(result, f"{verbs} contains a winetricks verb")
 
     def test_is_winetricks_verb(self):
-        """Test is_winetricks_verb when passed a valid verb.
+        """Test is_winetricks_verb when passed valid verbs.
 
         Expects winetricks verbs to follow ^[a-zA-Z_0-9]+(=[a-zA-Z0-9]+)?$.
         """
-        verbs = ["foo", "foo bar baz", "foo=bar baz=qux"]
+        verbs = ["foo", "foo=bar", "baz=qux"]
         result = True
-        err = []
 
-        for verb in verbs:
-            if not umu_util.is_winetricks_verb(verb):
-                result = True
-                err.append(f"'{verb}' is not a winetricks verb")
-
-        self.assertTrue(result, err)
+        result = umu_util.is_winetricks_verb(verbs)
+        self.assertTrue(result, f"'{verbs}' is not a winetricks verb")
 
     def test_check_runtime(self):
         """Test check_runtime when pv-verify does not exist.

--- a/umu/umu_util.py
+++ b/umu/umu_util.py
@@ -75,7 +75,7 @@ def _parse_winetricks_verbs(verb: str, pfx: Path) -> bool:
 
     with wt_log.open(mode="r", encoding="utf-8") as file:
         for line in file:
-            _ = line.strip()
+            _: str = line.strip()
             if is_winetricks_verb(_) and _.startswith(verb):
                 is_installed = True
                 break

--- a/umu/umu_util.py
+++ b/umu/umu_util.py
@@ -1,5 +1,7 @@
 from ctypes.util import find_library
 from functools import lru_cache
+from pathlib import Path
+from re import match
 from shutil import which
 from subprocess import PIPE, STDOUT, Popen, TimeoutExpired
 
@@ -61,3 +63,34 @@ def run_zenity(command: str, opts: list[str], msg: str) -> int:
         log.warning("zenity exited with the status code: %s", ret)
 
     return ret
+
+
+def _parse_winetricks_verbs(verb: str, pfx: Path) -> bool:
+    """Parse the winetricks.log file."""
+    wt_log: Path = pfx.joinpath("winetricks.log")
+    is_installed: bool = False
+
+    if not wt_log.is_file():
+        return is_installed
+
+    with wt_log.open(mode="r", encoding="utf-8") as file:
+        for line in file:
+            _ = line.strip()
+            if is_winetricks_verb(_) and _.startswith(verb):
+                is_installed = True
+                break
+
+    return is_installed
+
+
+@lru_cache
+def is_winetricks_verb(
+    verb: str, pattern: str = r"^[a-zA-Z_0-9]+(=[a-zA-Z0-9]+)?$"
+) -> bool:
+    """Check if a string is a winetricks verb."""
+    return match(pattern, verb) is not None
+
+
+def is_installed_verb(verb: str, pfx: Path) -> bool:
+    """Check if a winetricks verb is installed in the umu prefix."""
+    return _parse_winetricks_verbs(verb, pfx)

--- a/umu/umu_util.py
+++ b/umu/umu_util.py
@@ -72,6 +72,7 @@ def is_installed_verb(verb: str, pfx: Path) -> bool:
     """
     wt_log: Path = None
     is_installed: bool = False
+    verbs: set[str] = {}
 
     if not pfx:
         err: str = f"Value is '{pfx}' for WINE prefix"
@@ -82,6 +83,7 @@ def is_installed_verb(verb: str, pfx: Path) -> bool:
         raise ValueError(err)
 
     wt_log = pfx.joinpath("winetricks.log")
+    verbs = {_ for _ in verb.split()}
 
     if not wt_log.is_file():
         return is_installed
@@ -89,8 +91,12 @@ def is_installed_verb(verb: str, pfx: Path) -> bool:
     with wt_log.open(mode="r", encoding="utf-8") as file:
         for line in file:
             _: str = line.strip()
-            if is_winetricks_verb(_) and _.startswith(verb):
+            if _ in verbs:
                 is_installed = True
+                err: str = (
+                    f"winetricks verb '{_}' is already installed in '{pfx}'"
+                )
+                log.error(err)
                 break
 
     return is_installed

--- a/umu/umu_util.py
+++ b/umu/umu_util.py
@@ -1,7 +1,7 @@
 from ctypes.util import find_library
 from functools import lru_cache
 from pathlib import Path
-from re import Pattern, compile, match
+from re import Pattern, compile
 from shutil import which
 from subprocess import PIPE, STDOUT, Popen, TimeoutExpired
 

--- a/umu/umu_util.py
+++ b/umu/umu_util.py
@@ -90,7 +90,7 @@ def is_winetricks_verb(
     """Check if a string is a winetricks verb."""
     if verbs.find(" ") != -1:
         regex: Pattern = compile(pattern)
-        return all(regex.match(verb) for verb in verbs)
+        return all([regex.match(verb) for verb in verbs.split()])
     return match(pattern, verbs) is not None
 
 

--- a/umu/umu_util.py
+++ b/umu/umu_util.py
@@ -1,7 +1,7 @@
 from ctypes.util import find_library
 from functools import lru_cache
 from pathlib import Path
-from re import match
+from re import compile, match, Pattern
 from shutil import which
 from subprocess import PIPE, STDOUT, Popen, TimeoutExpired
 
@@ -85,10 +85,13 @@ def _parse_winetricks_verbs(verb: str, pfx: Path) -> bool:
 
 @lru_cache
 def is_winetricks_verb(
-    verb: str, pattern: str = r"^[a-zA-Z_0-9]+(=[a-zA-Z0-9]+)?$"
+    verbs: str, pattern: str = r"^[a-zA-Z_0-9]+(=[a-zA-Z0-9]+)?$"
 ) -> bool:
     """Check if a string is a winetricks verb."""
-    return match(pattern, verb) is not None
+    if verbs.find(" ") != -1:
+        regex: Pattern = compile(pattern)
+        return all(regex.match(verb) for verb in verbs)
+    return match(pattern, verbs) is not None
 
 
 def is_installed_verb(verb: str, pfx: Path) -> bool:

--- a/umu/umu_util.py
+++ b/umu/umu_util.py
@@ -88,7 +88,7 @@ def is_winetricks_verb(
     verbs: str, pattern: str = r"^[a-zA-Z_0-9]+(=[a-zA-Z0-9]+)?$"
 ) -> bool:
     """Check if a string is a winetricks verb."""
-    if verbs.find(" ") != -1:
+    if " " in verbs:
         regex: Pattern = compile(pattern)
         return all([regex.match(verb) for verb in verbs.split()])
     return match(pattern, verbs) is not None

--- a/umu/umu_util.py
+++ b/umu/umu_util.py
@@ -65,7 +65,7 @@ def run_zenity(command: str, opts: list[str], msg: str) -> int:
     return ret
 
 
-def is_installed_verb(verb: str, pfx: Path) -> bool:
+def is_installed_verb(verb: list[str], pfx: Path) -> bool:
     """Check if a winetricks verb is installed in the umu prefix.
 
     Determines the installation of verbs by reading winetricks.log file.
@@ -83,7 +83,7 @@ def is_installed_verb(verb: str, pfx: Path) -> bool:
         raise ValueError(err)
 
     wt_log = pfx.joinpath("winetricks.log")
-    verbs = {_ for _ in verb.split()}
+    verbs = {_ for _ in verb}
 
     if not wt_log.is_file():
         return is_installed

--- a/umu/umu_util.py
+++ b/umu/umu_util.py
@@ -65,9 +65,11 @@ def run_zenity(command: str, opts: list[str], msg: str) -> int:
     return ret
 
 
-def _parse_winetricks_verbs(verb: str, pfx: Path) -> bool:
-    """Parse the winetricks.log file."""
-    wt_log: Path = pfx.joinpath("winetricks.log")
+def is_installed_verb(verb: str, pfx: Path) -> bool:
+    """Check if a winetricks verb is installed in the umu prefix.
+
+    Determines the installation of verbs by reading winetricks.log file.
+    """
     is_installed: bool = False
 
     if not wt_log.is_file():
@@ -92,8 +94,3 @@ def is_winetricks_verb(
         regex: Pattern = compile(pattern)
         return all([regex.match(verb) for verb in verbs.split()])
     return match(pattern, verbs) is not None
-
-
-def is_installed_verb(verb: str, pfx: Path) -> bool:
-    """Check if a winetricks verb is installed in the umu prefix."""
-    return _parse_winetricks_verbs(verb, pfx)

--- a/umu/umu_util.py
+++ b/umu/umu_util.py
@@ -102,28 +102,21 @@ def is_installed_verb(verb: str, pfx: Path) -> bool:
     return is_installed
 
 
-@lru_cache
 def is_winetricks_verb(
-    verbs: str, pattern: str = r"^[a-zA-Z_0-9]+(=[a-zA-Z0-9]+)?$"
+    verbs: list[str], pattern: str = r"^[a-zA-Z_0-9]+(=[a-zA-Z0-9]+)?$"
 ) -> bool:
     """Check if a string is a winetricks verb."""
-    is_verb = True
+    regex: Pattern = None
+
+    if not verbs:
+        return False
 
     # When passed a sequence, check each verb and log the non-verbs
-    if " " in verbs:
-        regex: Pattern = compile(pattern)
-        is_verb = True
-        for verb in verbs.split():
-            if not regex.match(verb):
-                is_verb = False
-                err: str = f"Value is not a winetricks verb: '{verb}'"
-                log.error(err)
-                break
-        return is_verb
+    regex = compile(pattern)
+    for verb in verbs:
+        if not regex.match(verb):
+            err: str = f"Value is not a winetricks verb: '{verb}'"
+            log.error(err)
+            return False
 
-    if match(pattern, verbs) is None:
-        is_verb = False
-        err: str = f"Value is not a winetricks verb: '{verbs}'"
-        log.error(err)
-
-    return is_verb
+    return True

--- a/umu/umu_util.py
+++ b/umu/umu_util.py
@@ -1,7 +1,7 @@
 from ctypes.util import find_library
 from functools import lru_cache
 from pathlib import Path
-from re import compile, match, Pattern
+from re import Pattern, compile, match
 from shutil import which
 from subprocess import PIPE, STDOUT, Popen, TimeoutExpired
 

--- a/umu/umu_util.py
+++ b/umu/umu_util.py
@@ -70,7 +70,18 @@ def is_installed_verb(verb: str, pfx: Path) -> bool:
 
     Determines the installation of verbs by reading winetricks.log file.
     """
+    wt_log: Path = None
     is_installed: bool = False
+
+    if not pfx:
+        err: str = f"Value is '{pfx}' for WINE prefix"
+        raise FileNotFoundError(err)
+
+    if not verb:
+        err: str = "winetricks was passed an empty verb"
+        raise ValueError(err)
+
+    wt_log = pfx.joinpath("winetricks.log")
 
     if not wt_log.is_file():
         return is_installed

--- a/umu/umu_util.py
+++ b/umu/umu_util.py
@@ -107,7 +107,23 @@ def is_winetricks_verb(
     verbs: str, pattern: str = r"^[a-zA-Z_0-9]+(=[a-zA-Z0-9]+)?$"
 ) -> bool:
     """Check if a string is a winetricks verb."""
+    is_verb = True
+
+    # When passed a sequence, check each verb and log the non-verbs
     if " " in verbs:
         regex: Pattern = compile(pattern)
-        return all([regex.match(verb) for verb in verbs.split()])
-    return match(pattern, verbs) is not None
+        is_verb = True
+        for verb in verbs.split():
+            if not regex.match(verb):
+                is_verb = False
+                err: str = f"Value is not a winetricks verb: '{verb}'"
+                log.error(err)
+                break
+        return is_verb
+
+    if match(pattern, verbs) is None:
+        is_verb = False
+        err: str = f"Value is not a winetricks verb: '{verbs}'"
+        log.error(err)
+
+    return is_verb


### PR DESCRIPTION
Add initial support for executing winetricks without writing a protonfix module or using the winetricks GUI via GAMEID=winetricks-gui.

Example Usages:

> GAMEID=0 umu-run winetricks quartz
> GAMEID=0 umu-run winetricks quartz wmp11 qasf

Edit: Changing the layout of the filesystem via bwrap to use the system winetricks needs more discussion and exploration. This case is only relevant when using Valve's Proton builds, and it'll require having Steam running in the background and writing a file that contains an app ID in a folder. Of course, this is not good as it will probably require installing Steam which is contrary to goals of this project. GE-Proton and UMU-Proton builds are not effected by this, and have patches that solve those problems. Launchers such as Heroic or Lutris can workaround this issue but for umu, unless there's a way to workaround those two problems without installing Steam, this feature will need to wait.