### PR TITLE
Refactor updates to the runtime platform

### DIFF
--- a/umu/umu_runtime.py
+++ b/umu/umu_runtime.py
@@ -82,6 +82,7 @@ def _install_umu(
             err: str = (
                 f"repo.steampowered.com returned the status: {resp.status}"
             )
+            CLIENT_SESSION.close()
             raise HTTPException(err)
 
         for line in resp.read().decode("utf-8").splitlines():
@@ -97,6 +98,7 @@ def _install_umu(
             err: str = (
                 f"repo.steampowered.com returned the status: {resp.status}"
             )
+            CLIENT_SESSION.close()
             raise HTTPException(err)
 
         log.console(
@@ -115,6 +117,7 @@ def _install_umu(
         # Verify the runtime digest
         if hash.hexdigest() != digest:
             err: str = f"Digest mismatched: {archive}"
+            CLIENT_SESSION.close()
             raise ValueError(err)
 
         log.console(f"steamrt {codename}: SHA256 is OK")

--- a/umu/umu_runtime.py
+++ b/umu/umu_runtime.py
@@ -319,8 +319,6 @@ def _get_json(path: Path, config: str) -> dict[str, Any]:
     # Steam Runtime platform values
     # See https://gitlab.steamos.cloud/steamrt/steamrt/-/wikis/home
     steamrts: set[str] = {
-        "scout",
-        "heavy",
         "soldier",
         "sniper",
         "medic",

--- a/umu/umu_runtime.py
+++ b/umu/umu_runtime.py
@@ -225,11 +225,7 @@ def _update_umu(
     log.debug("Runtime: %s", runtime.name)
     log.debug("Codename: %s", codename)
 
-    if (
-        not runtime
-        or not runtime.is_dir()
-        or not local.joinpath("pressure-vessel").is_dir()
-    ):
+    if not local.joinpath("pressure-vessel").is_dir():
         log.warning("Runtime Platform not found")
         log.console("Restoring Runtime Platform...")
         _install_umu(json, thread_pool)

--- a/umu/umu_runtime.py
+++ b/umu/umu_runtime.py
@@ -158,11 +158,6 @@ def _install_umu(
         for _ in futures:
             _.result()
 
-        # Remove the extracted directory and all its contents
-        log.debug("Removing: %s/SteamLinuxRuntime_sniper", tmp)
-        if source_dir.exists():
-            source_dir.rmdir()
-
         # Rename _v2-entry-point
         log.debug("Renaming: _v2-entry-point -> umu")
         UMU_LOCAL.joinpath("_v2-entry-point").rename(UMU_LOCAL.joinpath("umu"))

--- a/umu/umu_runtime.py
+++ b/umu/umu_runtime.py
@@ -101,10 +101,7 @@ def _install_umu(
             CLIENT_SESSION.close()
             raise HTTPException(err)
 
-        log.console(
-            f"Downloading latest steamrt {codename} (public beta),"
-            "please wait..."
-        )
+        log.console(f"Downloading latest steamrt {codename}, please wait...")
         with tmp.joinpath(archive).open(mode="ab") as file:
             chunk_size: int = 64 * 1024  # 64 KB
             while True:
@@ -120,7 +117,7 @@ def _install_umu(
             CLIENT_SESSION.close()
             raise ValueError(err)
 
-        log.console(f"steamrt {codename}: SHA256 is OK")
+        log.console(f"{archive}: SHA256 is OK")
         CLIENT_SESSION.close()
 
     # Open the tar file and move the files
@@ -222,6 +219,7 @@ def _update_umu(
         log.console("Restoring Runtime Platform...")
         _install_umu(json, thread_pool)
         return
+
     log.debug("Runtime: %s", runtime.name)
     log.debug("Codename: %s", codename)
 
@@ -262,7 +260,6 @@ def _update_umu(
 
         CLIENT_SESSION.request("GET", url)
         resp = CLIENT_SESSION.getresponse()
-        log.debug("Restoring VERSIONS.txt")
 
         # Handle the redirect
         if resp.status == 301:
@@ -301,7 +298,7 @@ def _update_umu(
         sha256(resp.read()).digest()
         != sha256(local.joinpath("VERSIONS.txt").read_bytes()).digest()
     ):
-        log.console(f"Updating {codename} to latest...")
+        log.console("Updating steamrt to latest...")
         _install_umu(json, thread_pool)
         log.debug("Removing: %s", runtime)
         rmtree(runtime.as_posix())
@@ -394,16 +391,16 @@ def check_runtime(src: Path, json: dict[str, Any]) -> int:
             [file for file in src.glob(f"{codename}*") if file.is_dir()]
         )
     except ValueError:
-        log.warning("%s validation failed", codename)
+        log.warning("steamrt validation failed")
         log.warning("Could not find runtime in '%s'", src)
         return ret
 
     if not pv_verify.is_file():
-        log.warning("%s validation failed", codename)
+        log.warning("steamrt validation failed")
         log.warning("File does not exist: '%s'", pv_verify)
         return ret
 
-    log.console(f"Verifying integrity of steamrt {codename}...")
+    log.console(f"Verifying integrity of {runtime.name}...")
     ret = run(
         [
             pv_verify.as_posix(),
@@ -415,9 +412,9 @@ def check_runtime(src: Path, json: dict[str, Any]) -> int:
     ).returncode
 
     if ret:
-        log.warning("%s validation failed", codename)
+        log.warning("steamrt validation failed")
         log.debug("%s exited with the status code: %s", pv_verify.name, ret)
         return ret
-    log.console(f"steamrt {codename}: mtree is OK")
+    log.console(f"{runtime.name}: mtree is OK")
 
     return ret

--- a/umu/umu_runtime.py
+++ b/umu/umu_runtime.py
@@ -38,7 +38,10 @@ def _install_umu(
     codename: str = json["umu"]["versions"]["runtime_platform"]
     # Archive containing the runtime
     archive: str = f"SteamLinuxRuntime_{codename}.tar.xz"
-    base_url: str = f"https://repo.steampowered.com/steamrt-images-{codename}/snapshots/latest-container-runtime-public-beta"
+    base_url: str = (
+        f"https://repo.steampowered.com/steamrt-images-{codename}"
+        "/snapshots/latest-container-runtime-public-beta"
+    )
 
     log.debug("Codename: %s", codename)
     log.debug("URL: %s", base_url)

--- a/umu/umu_runtime.py
+++ b/umu/umu_runtime.py
@@ -319,6 +319,16 @@ def _get_json(path: Path, config: str) -> dict[str, Any]:
     must exist.
     """
     json: dict[str, Any] = None
+    # Steam Runtime platform values
+    # See https://gitlab.steamos.cloud/steamrt/steamrt/-/wikis/home
+    steamrts: set[str] = {
+        "scout",
+        "heavy",
+        "soldier",
+        "sniper",
+        "medic",
+        "steamrt5",
+    }
 
     # umu_version.json in the system path should always exist
     if not path.joinpath(config).is_file():
@@ -336,6 +346,12 @@ def _get_json(path: Path, config: str) -> dict[str, Any]:
         err: str = (
             f"Failed to load {config} or 'umu' or 'versions' not in: {config}"
         )
+        raise ValueError(err)
+
+    # The launcher will use the value runtime_platform to glob files. Attempt
+    # to guard against directory removal attacks for non-system wide installs
+    if json.get("umu").get("versions").get("runtime_platform") not in steamrts:
+        err: str = "Value for 'runtime_platform' is not a steamrt"
         raise ValueError(err)
 
     return json

--- a/umu/umu_test.py
+++ b/umu/umu_test.py
@@ -84,7 +84,7 @@ class TestGameLauncher(unittest.TestCase):
                 "versions": {
                     "launcher": "0.1-RC3",
                     "runner": "0.1-RC3",
-                    "runtime_platform": "steamrt3",
+                    "runtime_platform": "sniper",
                 }
             }
         }
@@ -260,58 +260,44 @@ class TestGameLauncher(unittest.TestCase):
         If the pv-verify binary does not exist, a warning should be logged and
         the function should return
         """
-        build = "0.20240125.75305"
         json_root = umu_runtime._get_json(
             self.test_user_share, "umu_version.json"
         )
         self.test_user_share.joinpath(
             "pressure-vessel", "bin", "pv-verify"
         ).unlink()
-        result = umu_runtime.check_runtime(
-            self.test_user_share, json_root, build
-        )
+        result = umu_runtime.check_runtime(self.test_user_share, json_root)
         self.assertEqual(result, 1, "Expected the exit code 1")
-
-    def test_check_runtime_fail(self):
-        """Test check_runtime when runtime validation fails.
-
-        When passed a Falsey value such as an empty string for the build id,
-        check_runtime will fail early and not search the UMU_LOCAL directory
-        """
-        json_root = umu_runtime._get_json(
-            self.test_user_share, "umu_version.json"
-        )
-        mock = CompletedProcess(["foo"], 1)
-        with patch.object(umu_runtime, "run", return_value=mock):
-            result = umu_runtime.check_runtime(
-                self.test_user_share, json_root, ""
-            )
-            self.assertEqual(result, 1, "Expected the exit code 1")
 
     def test_check_runtime_success(self):
         """Test check_runtime when runtime validation succeeds."""
-        build = "0.20240125.75305"
         json_root = umu_runtime._get_json(
             self.test_user_share, "umu_version.json"
         )
         mock = CompletedProcess(["foo"], 0)
         with patch.object(umu_runtime, "run", return_value=mock):
-            result = umu_runtime.check_runtime(
-                self.test_user_share, json_root, build
-            )
+            result = umu_runtime.check_runtime(self.test_user_share, json_root)
             self.assertEqual(result, 0, "Expected the exit code 0")
 
     def test_check_runtime_dir(self):
         """Test check_runtime when passed a BUILD_ID that does not exist."""
-        build = "foo"
+        runtime = Path(
+            self.test_user_share, "sniper_platform_0.20240125.75305"
+        )
         json_root = umu_runtime._get_json(
             self.test_user_share, "umu_version.json"
         )
+
+        # Mock the removal of the runtime directory
+        # In the real usage when updating the runtime, this should not happen
+        # since the runtime validation will occur directly after extracting
+        # the contents to $HOME/.local/share/umu
+        if runtime.is_dir():
+            rmtree(runtime.as_posix())
+
         mock = CompletedProcess(["foo"], 1)
         with patch.object(umu_runtime, "run", return_value=mock):
-            result = umu_runtime.check_runtime(
-                self.test_user_share, json_root, build
-            )
+            result = umu_runtime.check_runtime(self.test_user_share, json_root)
             self.assertEqual(result, 1, "Expected the exit code 1")
 
     def test_move(self):
@@ -436,7 +422,7 @@ class TestGameLauncher(unittest.TestCase):
                 "versions": {
                     "launcher": "0.1-RC3",
                     "runner": "0.1-RC3",
-                    "runtime_platform": "steamrt3"
+                    "runtime_platform": "sniper"
                 }
             }
         }
@@ -447,7 +433,7 @@ class TestGameLauncher(unittest.TestCase):
                 "foo": {
                     "launcher": "0.1-RC3",
                     "runner": "0.1-RC3",
-                    "runtime_platform": "steamrt3"
+                    "runtime_platform": "sniper"
                 }
             }
         }

--- a/umu/umu_test.py
+++ b/umu/umu_test.py
@@ -471,6 +471,35 @@ class TestGameLauncher(unittest.TestCase):
         with self.assertRaisesRegex(FileNotFoundError, "configuration"):
             umu_runtime._get_json(self.test_user_share, "foo")
 
+    def test_get_json_steamrt(self):
+        """Test _get_json when passed a non-steamrt value.
+
+        This attempts to mitigate against directory removal attacks for user
+        installations in the home directory, since the launcher will remove the
+        old runtime on update. Currently expects runtime_platform value to be
+        'soldier', 'sniper', 'medic' and 'steamrt5'
+        """
+        config = {
+            "umu": {
+                "versions": {
+                    "launcher": "0.1-RC3",
+                    "runner": "0.1-RC3",
+                    "runtime_platform": "foo",
+                }
+            }
+        }
+        test_config = json.dumps(config, indent=4)
+
+        self.test_user_share.joinpath("umu_version.json").unlink(
+            missing_ok=True
+        )
+        self.test_user_share.joinpath("umu_version.json").write_text(
+            test_config, encoding="utf-8"
+        )
+
+        with self.assertRaises(ValueError):
+            umu_runtime._get_json(self.test_user_share, "umu_version.json")
+
     def test_get_json(self):
         """Test _get_json.
 

--- a/umu/umu_test_plugins.py
+++ b/umu/umu_test_plugins.py
@@ -72,7 +72,7 @@ class TestGameLauncherPlugins(unittest.TestCase):
                 "versions": {
                     "launcher": "0.1-RC3",
                     "runner": "0.1-RC3",
-                    "runtime_platform": "sniper_platform_0.20240125.75305",
+                    "runtime_platform": "sniper",
                 }
             }
         }

--- a/umu/umu_version.json.in
+++ b/umu/umu_version.json.in
@@ -3,7 +3,7 @@
     "versions": {
       "launcher": "##UMU_VERSION##",
       "runner": "##UMU_VERSION##",
-      "runtime_platform": "steamrt3"
+      "runtime_platform": "sniper"
     }
   }
 }


### PR DESCRIPTION
Improves the update procedure of the runtime, by simply globbing the runtime alias such as `sniper` in `$HOME/.local/share/umu` and including the runtime alias as part of the hard coded files names and the url of the endpoint containing the Steam Runtime. 

Like before, the value of `runtime_platform` will need to be adjusted in `umu_version.json` for major versions. The end result is that this scales better, as a single change to `runtime_platform` should change the url of the endpoint along with the hard coded files names, assuming Valve doesn't make major changes to file names in the future like it had done with `steam-container-runtime`. This change also deprecates `BUILD_ID.txt` in `$HOME/.local/share/umu`, and the launcher will no longer download it. 
