### PR TITLE
Add option to disable runtime

### DIFF
--- a/docs/umu.1.scd
+++ b/docs/umu.1.scd
@@ -164,7 +164,7 @@ _UMU_ZENITY_
 	Optional. Creates a *zenity*[5] popup window when downloading large files.
 
 _UMU_NO_RUNTIME_
-	Optional and only applicable Flatpak applications. Disables the usage of the *Steam Linux Runtime*[6] (SLR).
+	Optional and only applicable to Flatpak applications. Disables the usage of the *Steam Linux Runtime*[6] (SLR).
 
 	Set to _1_ to disable the entirety of the SLR or _pressure-vessel_ to only disable Pressure Vessel and the container runtime.
 	

--- a/docs/umu.1.scd
+++ b/docs/umu.1.scd
@@ -163,6 +163,13 @@ _PROTON_VERB_
 _UMU_ZENITY_
 	Optional. Creates a *zenity*[5] popup window when downloading large files.
 
+_UMU_NO_RUNTIME_
+	Optional and only applicable Flatpak applications. Disables the usage of the *Steam Linux Runtime*[6] (SLR).
+
+	Set to _1_ to disable the entirety of the SLR or _pressure-vessel_ to only disable Pressure Vessel and the container runtime.
+	
+	Defaults to _pressure-vessel_.
+
 # SEE ALSO
 
 _umu_(5), _winetricks_(1), _zenity_(1)
@@ -174,6 +181,7 @@ _umu_(5), _winetricks_(1), _zenity_(1)
 . https://github.com/Open-Wine-Components/umu-protonfixes
 . https://github.com/Open-Wine-Components/umu-database
 . https://gitlab.gnome.org/GNOME/zenity
+. https://gitlab.steamos.cloud/steamrt/steam-runtime-tools/-/blob/main/docs/container-runtime.md
 
 # AUTHORS
 

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -400,6 +400,8 @@ def build_command(
     """Build the command to be executed."""
     verb: str = env["PROTON_VERB"]
 
+    # Will run the game w/o Proton, effectively running the game as is. This
+    # option is intended for debugging purposes, and is otherwise useless
     if env.get("UMU_NO_RUNTIME") == "1":
         log.warning("Runtime Platform disabled")
         command.extend(
@@ -410,7 +412,7 @@ def build_command(
         )
         return command
 
-    # Log the warning when running games within SteamOS gamescope session
+    # Only log the warning when running games within SteamOS gamescope session
     if (
         env.get("UMU_NO_RUNTIME") == "pressure-vessel"
         and not is_steamdeck()

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -314,7 +314,8 @@ def set_env(
         )
 
     # Runtime
-    env["UMU_NO_RUNTIME"] = os.environ.get("UMU_NO_RUNTIME") or ""
+    if FLATPAK_PATH:
+        env["UMU_NO_RUNTIME"] = os.environ.get("UMU_NO_RUNTIME") or ""
 
     # Currently, running games when using the Steam Runtime in a Flatpak
     # environment will cause the game window to not display within the SteamOS

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -371,7 +371,7 @@ def build_command(
     env: dict[str, str],
     local: Path,
     command: list[str],
-    opts: list[str] = None,
+    opts: list[str] = [],
 ) -> list[str]:
     """Build the command to be executed."""
     verb: str = env["PROTON_VERB"]
@@ -395,20 +395,6 @@ def build_command(
         # Usage: ./winetricks [options] [command|verb|path-to-verb] ...
         opts = ["-q", *opts]
 
-    if opts:
-        command.extend(
-            [
-                local.joinpath("umu").as_posix(),
-                "--verb",
-                verb,
-                "--",
-                Path(env.get("PROTONPATH")).joinpath("proton").as_posix(),
-                verb,
-                env.get("EXE"),
-                *opts,
-            ],
-        )
-        return command
     command.extend(
         [
             local.joinpath("umu").as_posix(),
@@ -418,6 +404,7 @@ def build_command(
             Path(env.get("PROTONPATH")).joinpath("proton").as_posix(),
             verb,
             env.get("EXE"),
+            *opts,
         ],
     )
 

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -410,8 +410,15 @@ def build_command(
         )
         return command
 
-    if env.get("UMU_NO_RUNTIME") == "pressure-vessel":
+    # Log the warning when running games within SteamOS gamescope session
+    if (
+        env.get("UMU_NO_RUNTIME") == "pressure-vessel"
+        and not is_steamdeck()
+        and os.environ.get("XDG_CURRENT_DESKTOP") != "gamescope"
+    ):
         log.warning("Using Proton without Runtime Platform")
+
+    if env.get("UMU_NO_RUNTIME") == "pressure-vessel":
         command.extend(
             [
                 Path(env.get("PROTONPATH")).joinpath("proton").as_posix(),

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -314,8 +314,7 @@ def set_env(
         )
 
     # Runtime
-    if os.environ.get("UMU_NO_RUNTIME"):
-        env["UMU_NO_RUNTIME"] = os.environ.get("UMU_NO_RUNTIME") or ""
+    env["UMU_NO_RUNTIME"] = os.environ.get("UMU_NO_RUNTIME") or ""
 
     # Currently, running games when using the Steam Runtime in a Flatpak
     # environment will cause the game window to not display within the SteamOS

--- a/umu/umu_test.py
+++ b/umu/umu_test.py
@@ -51,7 +51,6 @@ class TestGameLauncher(unittest.TestCase):
             "LD_PRELOAD": "",
             "WINEDLLPATH": "",
             "WINETRICKS_SUPER_QUIET": "",
-            "UMU_NO_RUNTIME": "",
         }
         self.user = getpwuid(os.getuid()).pw_name
         self.test_opts = "-foo -bar"
@@ -1649,7 +1648,6 @@ class TestGameLauncher(unittest.TestCase):
             os.environ["GAMEID"] = test_str
             os.environ["STORE"] = test_str
             os.environ["PROTON_VERB"] = self.test_verb
-            os.environ["UMU_NO_RUNTIME"] = "pressure-vessel"
             # Args
             result = umu_run.parse_args()
             self.assertIsInstance(result, tuple, "Expected a tuple")
@@ -1762,11 +1760,6 @@ class TestGameLauncher(unittest.TestCase):
                 self.env["STEAM_COMPAT_MOUNTS"],
                 self.env["STEAM_COMPAT_TOOL_PATHS"],
                 "Expected STEAM_COMPAT_MOUNTS to be set",
-            )
-            self.assertEqual(
-                self.env["UMU_NO_RUNTIME"],
-                os.environ["UMU_NO_RUNTIME"],
-                "Expected UMU_NO_RUNTIME to be set",
             )
 
     def test_set_env_winetricks(self):

--- a/umu/umu_test.py
+++ b/umu/umu_test.py
@@ -179,6 +179,12 @@ class TestGameLauncher(unittest.TestCase):
         if self.test_winepfx.exists():
             rmtree(self.test_winepfx.as_posix())
 
+    def test_is_steamdeck(self):
+        """Test is_steamdeck."""
+        self.assertIsInstance(
+            umu_util.is_steamdeck(), bool, "Expected a boolean"
+        )
+
     def test_is_installed_verb_noverb(self):
         """Test is_installed_verb when passed an empty verb."""
         verb = []

--- a/umu/umu_test.py
+++ b/umu/umu_test.py
@@ -51,6 +51,7 @@ class TestGameLauncher(unittest.TestCase):
             "LD_PRELOAD": "",
             "WINEDLLPATH": "",
             "WINETRICKS_SUPER_QUIET": "",
+            "UMU_NO_RUNTIME": "",
         }
         self.user = getpwuid(os.getuid()).pw_name
         self.test_opts = "-foo -bar"
@@ -1648,6 +1649,7 @@ class TestGameLauncher(unittest.TestCase):
             os.environ["GAMEID"] = test_str
             os.environ["STORE"] = test_str
             os.environ["PROTON_VERB"] = self.test_verb
+            os.environ["UMU_NO_RUNTIME"] = "pressure-vessel"
             # Args
             result = umu_run.parse_args()
             self.assertIsInstance(result, tuple, "Expected a tuple")
@@ -1760,6 +1762,11 @@ class TestGameLauncher(unittest.TestCase):
                 self.env["STEAM_COMPAT_MOUNTS"],
                 self.env["STEAM_COMPAT_TOOL_PATHS"],
                 "Expected STEAM_COMPAT_MOUNTS to be set",
+            )
+            self.assertEqual(
+                self.env["UMU_NO_RUNTIME"],
+                os.environ["UMU_NO_RUNTIME"],
+                "Expected UMU_NO_RUNTIME to be set",
             )
 
     def test_set_env_winetricks(self):

--- a/umu/umu_util.py
+++ b/umu/umu_util.py
@@ -120,3 +120,24 @@ def is_winetricks_verb(
             return False
 
     return True
+
+
+@lru_cache
+def is_steamdeck() -> bool:
+    """Determine if the host device is a Steam Deck by its CPU model."""
+    cpu_info: Path = Path("/proc/cpuinfo")
+    is_sd: bool = False
+    sd_models: set[str] = {"AMD Custom APU 0405", "AMD Custom APU 0932"}
+
+    if not cpu_info.is_file():
+        return is_sd
+
+    with cpu_info.open(mode="r", encoding="utf-8") as file:
+        for line in file:
+            if line.startswith("model name"):
+                _: str = line[line.find(":") + 1 :].strip()
+                if _ in sd_models:
+                    is_sd = True
+                    break
+
+    return is_sd


### PR DESCRIPTION
Related to https://github.com/Open-Wine-Components/umu-launcher/issues/92

Workaround for the game window not displaying within the SteamOS gamescope session by disabling the Steam Linux Runtime when inside a Flatpak environment. In the future, [customizing the runtime](https://github.com/Open-Wine-Components/umu-launcher/issues/4) for this environment will be explored.