### PR TITLE
Fix system call failures when running winetricks verbs

### DIFF
--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -296,20 +296,6 @@ def set_env(
 
     # Winetricks
     if env.get("EXE", "").endswith("winetricks"):
-        # Proton directory with the last segment being subdirectory containing
-        # the Proton libraries and binaries. In upstream Proton 9 the subdir
-        # is 'files', while in other versions it may be 'dist'.
-        proton_dist: str = (
-            f"{env['PROTONPATH']}/files"
-            if Path(env["PROTONPATH"], "files").is_dir()
-            else f"{env['PROTONPATH']}/dist"
-        )
-
-        env["WINE"] = f"{proton_dist}/bin/wine"
-        env["WINELOADER"] = env["WINE"]
-        env["WINESERVER"] = f"{proton_dist}/bin/wineserver"
-        env["WINETRICKS_LATEST_VERSION_CHECK"] = "disabled"
-        env["LD_PRELOAD"] = ""
         env["WINETRICKS_SUPER_QUIET"] = (
             "" if os.environ.get("UMU_LOG") == "debug" else "1"
         )

--- a/umu/umu_test.py
+++ b/umu/umu_test.py
@@ -2091,16 +2091,6 @@ class TestGameLauncher(unittest.TestCase):
             )
 
             # Winetricks
-            self.assertTrue(self.env["WINE"], "WINE is not set")
-            self.assertTrue(self.env["WINELOADER"], "WINELOADER is not set")
-            self.assertTrue(self.env["WINESERVER"], "WINESERVER is not set")
-            self.assertTrue(
-                self.env["WINETRICKS_LATEST_VERSION_CHECK"],
-                "WINETRICKS_LATEST_VERSION_CHECK is not set",
-            )
-            self.assertTrue(
-                self.env["LD_PRELOAD"] == "", "LD_PRELOAD is not set"
-            )
             self.assertTrue(
                 self.env["WINETRICKS_SUPER_QUIET"],
                 "WINETRICKS_SUPER_QUIET is not set",


### PR DESCRIPTION
Intended to be merged before 0.1 release, fixes system call failures when applying winetricks verbs to the WINE prefix, in favor of patching the 'proton' script and setting the required environment variables from there. 

As a result, the launcher will only guard against invalid winetricks verbs and the reapplication of them.

Depends on https://github.com/Open-Wine-Components/umu-proton/pull/1 being merged and the release of UMU-Proton9-2
