### PR TITLE
Replace PurePath.as_posix with f-string expressions

### DIFF
--- a/umu/umu_plugins.py
+++ b/umu/umu_plugins.py
@@ -27,9 +27,7 @@ def set_env_toml(
         raise ModuleNotFoundError(err)
 
     toml: dict[str, Any] = None
-    path_config: str = (
-        Path(getattr(args, "config", None)).expanduser().as_posix()
-    )
+    path_config: str = f"{Path(getattr(args, 'config', None)).expanduser()}"
     opts: list[str] = []
 
     if not Path(path_config).is_file():
@@ -98,7 +96,7 @@ def _check_env_toml(toml: dict[str, Any]) -> dict[str, Any]:
             key == "prefix"
             and not Path(toml[table][key]).expanduser().is_dir()
         ):
-            dir: str = Path(toml[table][key]).expanduser().as_posix()
+            dir: str = f"{Path(toml[table][key]).expanduser()}"
             err: str = (
                 f"Value for key '{key}' in TOML is not a directory: {dir}"
             )

--- a/umu/umu_plugins.py
+++ b/umu/umu_plugins.py
@@ -27,7 +27,7 @@ def set_env_toml(
         raise ModuleNotFoundError(err)
 
     toml: dict[str, Any] = None
-    path_config: str = f"{Path(getattr(args, 'config', None)).expanduser()}"
+    path_config: str = str(Path(getattr(args, "config", None)).expanduser())
     opts: list[str] = []
 
     if not Path(path_config).is_file():
@@ -96,7 +96,7 @@ def _check_env_toml(toml: dict[str, Any]) -> dict[str, Any]:
             key == "prefix"
             and not Path(toml[table][key]).expanduser().is_dir()
         ):
-            dir: str = f"{Path(toml[table][key]).expanduser()}"
+            dir: str = str(Path(toml[table][key]).expanduser())
             err: str = (
                 f"Value for key '{key}' in TOML is not a directory: {dir}"
             )

--- a/umu/umu_proton.py
+++ b/umu/umu_proton.py
@@ -163,7 +163,7 @@ def _fetch_proton(
             "--silent",
             proton_url,
             "--output-dir",
-            f"{tmp}",
+            str(tmp),
         ]
         msg: str = f"Downloading {proton_dir}..."
         ret = run_zenity(bin, opts, msg)
@@ -237,7 +237,7 @@ def _cleanup(tarball: str, proton: str, tmp: Path, steam_compat: Path) -> None:
         tmp.joinpath(tarball).unlink()
     if steam_compat.joinpath(proton).is_dir():
         log.console(f"Purging '{proton}' in '{steam_compat}'...")
-        rmtree(f"{steam_compat.joinpath(proton)}")
+        rmtree(str(steam_compat.joinpath(proton)))
 
 
 def _get_from_steamcompat(
@@ -263,7 +263,7 @@ def _get_from_steamcompat(
         )
         log.console(f"{latest.name} found in: '{steam_compat}'")
         log.console(f"Using {latest.name}")
-        environ["PROTONPATH"] = f"{latest}"
+        environ["PROTONPATH"] = str(latest)
         env["PROTONPATH"] = environ["PROTONPATH"]
     except ValueError:
         return None
@@ -311,7 +311,7 @@ def _get_latest(
         log.console(f"{version} is up to date")
         steam_compat.joinpath("UMU-Latest").unlink(missing_ok=True)
         steam_compat.joinpath("UMU-Latest").symlink_to(proton)
-        environ["PROTONPATH"] = f"{steam_compat.joinpath(proton)}"
+        environ["PROTONPATH"] = str(steam_compat.joinpath(proton))
         env["PROTONPATH"] = environ["PROTONPATH"]
         return env
 
@@ -332,7 +332,7 @@ def _get_latest(
             future.result()
         else:
             _extract_dir(tmp.joinpath(tarball), steam_compat)
-        environ["PROTONPATH"] = f"{steam_compat.joinpath(proton)}"
+        environ["PROTONPATH"] = str(steam_compat.joinpath(proton))
         env["PROTONPATH"] = environ["PROTONPATH"]
         log.debug("Removing: %s", tarball)
         thread_pool.submit(tmp.joinpath(tarball).unlink, True)
@@ -382,7 +382,7 @@ def _update_proton(
         if proton.is_dir():
             log.debug("Previous stable build found")
             log.debug("Removing: %s", proton)
-            futures.append(thread_pool.submit(rmtree, f"{proton}"))
+            futures.append(thread_pool.submit(rmtree, str(proton)))
 
     for _ in futures:
         _.result()

--- a/umu/umu_proton.py
+++ b/umu/umu_proton.py
@@ -163,7 +163,7 @@ def _fetch_proton(
             "--silent",
             proton_url,
             "--output-dir",
-            tmp.as_posix(),
+            f"{tmp}",
         ]
         msg: str = f"Downloading {proton_dir}..."
         ret = run_zenity(bin, opts, msg)
@@ -237,7 +237,7 @@ def _cleanup(tarball: str, proton: str, tmp: Path, steam_compat: Path) -> None:
         tmp.joinpath(tarball).unlink()
     if steam_compat.joinpath(proton).is_dir():
         log.console(f"Purging '{proton}' in '{steam_compat}'...")
-        rmtree(steam_compat.joinpath(proton).as_posix())
+        rmtree(f"{steam_compat.joinpath(proton)}")
 
 
 def _get_from_steamcompat(
@@ -263,7 +263,7 @@ def _get_from_steamcompat(
         )
         log.console(f"{latest.name} found in: '{steam_compat}'")
         log.console(f"Using {latest.name}")
-        environ["PROTONPATH"] = latest.as_posix()
+        environ["PROTONPATH"] = f"{latest}"
         env["PROTONPATH"] = environ["PROTONPATH"]
     except ValueError:
         return None
@@ -311,7 +311,7 @@ def _get_latest(
         log.console(f"{version} is up to date")
         steam_compat.joinpath("UMU-Latest").unlink(missing_ok=True)
         steam_compat.joinpath("UMU-Latest").symlink_to(proton)
-        environ["PROTONPATH"] = steam_compat.joinpath(proton).as_posix()
+        environ["PROTONPATH"] = f"{steam_compat.joinpath(proton)}"
         env["PROTONPATH"] = environ["PROTONPATH"]
         return env
 
@@ -332,7 +332,7 @@ def _get_latest(
             future.result()
         else:
             _extract_dir(tmp.joinpath(tarball), steam_compat)
-        environ["PROTONPATH"] = steam_compat.joinpath(proton).as_posix()
+        environ["PROTONPATH"] = f"{steam_compat.joinpath(proton)}"
         env["PROTONPATH"] = environ["PROTONPATH"]
         log.debug("Removing: %s", tarball)
         thread_pool.submit(tmp.joinpath(tarball).unlink, True)
@@ -382,7 +382,7 @@ def _update_proton(
         if proton.is_dir():
             log.debug("Previous stable build found")
             log.debug("Removing: %s", proton)
-            futures.append(thread_pool.submit(rmtree, proton.as_posix()))
+            futures.append(thread_pool.submit(rmtree, f"{proton}"))
 
     for _ in futures:
         _.result()

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -243,16 +243,18 @@ def set_env(
             # Ensure executable path is absolute, otherwise Proton will fail
             # when creating the subprocess.
             # e.g., Games/umu/umu-0 -> $HOME/Games/umu/umu-0
-            env["EXE"] = f"{Path(args[0]).expanduser().resolve(strict=True)}"
-            env["STEAM_COMPAT_INSTALL_PATH"] = f"{Path(env['EXE']).parent}"
+            exe: Path = Path(args[0]).expanduser().resolve(strict=True)
+            env["EXE"] = f"{exe}"
+            env["STEAM_COMPAT_INSTALL_PATH"] = f"{exe.parent}"
         except FileNotFoundError:
             # Assume that the executable will be inside prefix or container
             env["EXE"] = f"{args[0]}"
             env["STEAM_COMPAT_INSTALL_PATH"] = ""
             log.warning("Executable not found: %s", env["EXE"])
     else:  # Configuration file usage
-        env["EXE"] = f"{Path(env['EXE']).expanduser()}"
-        env["STEAM_COMPAT_INSTALL_PATH"] = f"{Path(env['EXE']).parent}"
+        exe: Path = Path(env["EXE"]).expanduser()
+        env["EXE"] = f"{exe}"
+        env["STEAM_COMPAT_INSTALL_PATH"] = f"{exe.parent}"
 
     env["STORE"] = os.environ.get("STORE") or ""
 

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -232,12 +232,12 @@ def set_env(
         # Make an absolute path to winetricks within GE-Proton or UMU-Proton.
         # The launcher will change to the winetricks parent directory before
         # creating the subprocess
-        winetricks: Path = Path(
-            protonpath, "protonfixes", "winetricks"
-        ).resolve(strict=True)
-        env["EXE"] = f"{winetricks}"
+        exe: Path = Path(protonpath, "protonfixes", "winetricks").resolve(
+            strict=True
+        )
+        env["EXE"] = f"{exe}"
         args = (env["EXE"], args[1])
-        env["STEAM_COMPAT_INSTALL_PATH"] = f"{winetricks.parent}"
+        env["STEAM_COMPAT_INSTALL_PATH"] = f"{exe.parent}"
     elif is_cmd:
         try:
             # Ensure executable path is absolute, otherwise Proton will fail

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -209,10 +209,12 @@ def set_env(
     )
     # Command execution usage
     is_cmd: bool = isinstance(args, tuple)
+
     # Command execution usage, but client wants to create a prefix. When an
-    # empty string is the executable, Proton will create the prefix but will
-    # fail to find the command
+    # empty string is the executable, Proton is expected to create the prefix
+    # but will fail because the executable is not found
     is_createpfx: bool = is_cmd and isinstance(args[0], str) and not args[0]
+
     # Command execution usage, but client wants to run winetricks verbs
     is_winetricks: bool = is_cmd and args[0] == "winetricks"
 

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -157,14 +157,13 @@ def check_env(env: set[str, str]) -> dict[str, str] | dict[str, Any]:
         err: str = "Environment variable is empty: WINEPREFIX"
         raise ValueError(err)
     if "WINEPREFIX" not in os.environ:
-        id: str = env["GAMEID"]
-        pfx: Path = Path.home().joinpath("Games", "umu", f"{id}")
+        pfx: Path = Path.home().joinpath("Games", "umu", env["GAMEID"])
         pfx.mkdir(parents=True, exist_ok=True)
-        os.environ["WINEPREFIX"] = pfx.as_posix()
+        os.environ["WINEPREFIX"] = f"{pfx}"
     if not Path(os.environ["WINEPREFIX"]).expanduser().is_dir():
         pfx: Path = Path(os.environ["WINEPREFIX"])
         pfx.mkdir(parents=True, exist_ok=True)
-        os.environ["WINEPREFIX"] = pfx.as_posix()
+        os.environ["WINEPREFIX"] = f"{pfx}"
     env["WINEPREFIX"] = os.environ["WINEPREFIX"]
 
     # Proton Version
@@ -173,9 +172,9 @@ def check_env(env: set[str, str]) -> dict[str, str] | dict[str, Any]:
         and Path(STEAM_COMPAT, os.environ.get("PROTONPATH")).is_dir()
     ):
         log.debug("Proton version selected")
-        os.environ["PROTONPATH"] = STEAM_COMPAT.joinpath(
-            os.environ["PROTONPATH"]
-        ).as_posix()
+        os.environ["PROTONPATH"] = (
+            f"{STEAM_COMPAT.joinpath(os.environ['PROTONPATH'])}"
+        )
 
     # GE-Proton
     if os.environ.get("PROTONPATH") == "GE-Proton":
@@ -222,33 +221,24 @@ def set_env(
         # UMU-Proton, which includes the dependencies bundled within the
         # protonfixes directory. Fixes exit 3 status codes after applying
         # winetricks verbs
-        bin: str = (
-            Path(env["PROTONPATH"], "protonfixes", "winetricks")
-            .expanduser()
-            .resolve(strict=True)
-            .as_posix()
-        )
+        bin: str = f"{Path(env['PROTONPATH'], 'protonfixes', 'winetricks').expanduser().resolve(strict=True)}"
         log.debug("EXE: %s -> %s", args[0], bin)
         args: tuple[str, list[str]] = (bin, args[1])
         env["EXE"] = bin
-        env["STEAM_COMPAT_INSTALL_PATH"] = Path(env["EXE"]).parent.as_posix()
+        env["STEAM_COMPAT_INSTALL_PATH"] = f"{Path(env['EXE']).parent}"
     elif isinstance(args, tuple):
         try:
-            env["EXE"] = (
-                Path(args[0]).expanduser().resolve(strict=True).as_posix()
-            )
-            env["STEAM_COMPAT_INSTALL_PATH"] = Path(
-                env["EXE"]
-            ).parent.as_posix()
+            env["EXE"] = f"{Path(args[0]).expanduser().resolve(strict=True)}"
+            env["STEAM_COMPAT_INSTALL_PATH"] = f"{Path(env['EXE']).parent}"
         except FileNotFoundError:
             # Assume that the executable will be inside prefix or container
-            env["EXE"] = Path(args[0]).as_posix()
+            env["EXE"] = f"{Path(args[0])}"
             env["STEAM_COMPAT_INSTALL_PATH"] = ""
             log.warning("Executable not found: %s", env["EXE"])
     else:
         # Config branch
-        env["EXE"] = Path(env["EXE"]).expanduser().as_posix()
-        env["STEAM_COMPAT_INSTALL_PATH"] = Path(env["EXE"]).parent.as_posix()
+        env["EXE"] = f"{Path(env['EXE']).expanduser()}"
+        env["STEAM_COMPAT_INSTALL_PATH"] = f"{Path(env['EXE']).parent}"
 
     env["STORE"] = os.environ.get("STORE") or ""
 
@@ -266,18 +256,16 @@ def set_env(
 
     # PATHS
     env["WINEPREFIX"] = (
-        Path(env["WINEPREFIX"]).expanduser().resolve(strict=True).as_posix()
+        f"{Path(env['WINEPREFIX']).expanduser().resolve(strict=True)}"
     )
     env["PROTONPATH"] = (
-        Path(env["PROTONPATH"]).expanduser().resolve(strict=True).as_posix()
+        f"{Path(env['PROTONPATH']).expanduser().resolve(strict=True)}"
     )
     env["STEAM_COMPAT_DATA_PATH"] = env["WINEPREFIX"]
     env["STEAM_COMPAT_SHADER_PATH"] = (
-        env["STEAM_COMPAT_DATA_PATH"] + "/shadercache"
+        f"{env['STEAM_COMPAT_DATA_PATH']}/shadercache"
     )
-    env["STEAM_COMPAT_TOOL_PATHS"] = (
-        env["PROTONPATH"] + ":" + UMU_LOCAL.as_posix()
-    )
+    env["STEAM_COMPAT_TOOL_PATHS"] = f"{env['PROTONPATH']}:{UMU_LOCAL}"
     env["STEAM_COMPAT_MOUNTS"] = env["STEAM_COMPAT_TOOL_PATHS"]
 
     # Zenity
@@ -350,12 +338,10 @@ def enable_steam_game_drive(env: dict[str, str]) -> dict[str, str]:
         if path.is_mount() and path != root:
             if os.environ.get("STEAM_COMPAT_LIBRARY_PATHS"):
                 env["STEAM_COMPAT_LIBRARY_PATHS"] = (
-                    os.environ["STEAM_COMPAT_LIBRARY_PATHS"]
-                    + ":"
-                    + path.as_posix()
+                    f"{os.environ['STEAM_COMPAT_LIBRARY_PATHS']}:{path}"
                 )
             else:
-                env["STEAM_COMPAT_LIBRARY_PATHS"] = path.as_posix()
+                env["STEAM_COMPAT_LIBRARY_PATHS"] = f"{path}"
             break
 
     if os.environ.get("LD_LIBRARY_PATH"):
@@ -421,7 +407,7 @@ def build_command(
     if env.get("UMU_NO_RUNTIME") == "pressure-vessel":
         command.extend(
             [
-                proton.as_posix(),
+                f"{proton}",
                 env["PROTON_VERB"],
                 env["EXE"],
                 *opts,
@@ -444,11 +430,11 @@ def build_command(
 
     command.extend(
         [
-            entry_point.as_posix(),
+            f"{entry_point}",
             "--verb",
             env["PROTON_VERB"],
             "--",
-            proton.as_posix(),
+            f"{proton}",
             env["PROTON_VERB"],
             env["EXE"],
             *opts,
@@ -480,9 +466,9 @@ def run_command(command: list[str]) -> int:
 
     # For winetricks, change directory to $PROTONPATH/protonfixes
     if os.environ.get("EXE").endswith("winetricks"):
-        cwd = Path(os.environ.get("PROTONPATH"), "protonfixes").as_posix()
+        cwd = f"{os.environ['PROTONPATH']}/protonfixes"
     else:
-        cwd = Path.cwd().as_posix()
+        cwd = f"{Path.cwd()}"
 
     # Create a subprocess but do not set it as subreaper
     # Unnecessary in a Flatpak and prctl() will fail if libc could not be found

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -159,11 +159,11 @@ def check_env(env: set[str, str]) -> dict[str, str] | dict[str, Any]:
     if "WINEPREFIX" not in os.environ:
         pfx: Path = Path.home().joinpath("Games", "umu", env["GAMEID"])
         pfx.mkdir(parents=True, exist_ok=True)
-        os.environ["WINEPREFIX"] = f"{pfx}"
+        os.environ["WINEPREFIX"] = str(pfx)
     if not Path(os.environ["WINEPREFIX"]).expanduser().is_dir():
         pfx: Path = Path(os.environ["WINEPREFIX"])
         pfx.mkdir(parents=True, exist_ok=True)
-        os.environ["WINEPREFIX"] = f"{pfx}"
+        os.environ["WINEPREFIX"] = str(pfx)
     env["WINEPREFIX"] = os.environ["WINEPREFIX"]
 
     # Proton Version
@@ -172,8 +172,8 @@ def check_env(env: set[str, str]) -> dict[str, str] | dict[str, Any]:
         and Path(STEAM_COMPAT, os.environ.get("PROTONPATH")).is_dir()
     ):
         log.debug("Proton version selected")
-        os.environ["PROTONPATH"] = (
-            f"{STEAM_COMPAT.joinpath(os.environ['PROTONPATH'])}"
+        os.environ["PROTONPATH"] = str(
+            STEAM_COMPAT.joinpath(os.environ["PROTONPATH"])
         )
 
     # GE-Proton
@@ -235,26 +235,26 @@ def set_env(
         exe: Path = Path(protonpath, "protonfixes", "winetricks").resolve(
             strict=True
         )
-        env["EXE"] = f"{exe}"
+        env["EXE"] = str(exe)
         args = (env["EXE"], args[1])
-        env["STEAM_COMPAT_INSTALL_PATH"] = f"{exe.parent}"
+        env["STEAM_COMPAT_INSTALL_PATH"] = str(exe.parent)
     elif is_cmd:
         try:
             # Ensure executable path is absolute, otherwise Proton will fail
             # when creating the subprocess.
             # e.g., Games/umu/umu-0 -> $HOME/Games/umu/umu-0
             exe: Path = Path(args[0]).expanduser().resolve(strict=True)
-            env["EXE"] = f"{exe}"
-            env["STEAM_COMPAT_INSTALL_PATH"] = f"{exe.parent}"
+            env["EXE"] = str(exe)
+            env["STEAM_COMPAT_INSTALL_PATH"] = str(exe.parent)
         except FileNotFoundError:
             # Assume that the executable will be inside prefix or container
-            env["EXE"] = f"{args[0]}"
+            env["EXE"] = args[0]
             env["STEAM_COMPAT_INSTALL_PATH"] = ""
             log.warning("Executable not found: %s", env["EXE"])
     else:  # Configuration file usage
         exe: Path = Path(env["EXE"]).expanduser()
-        env["EXE"] = f"{exe}"
-        env["STEAM_COMPAT_INSTALL_PATH"] = f"{exe.parent}"
+        env["EXE"] = str(exe)
+        env["STEAM_COMPAT_INSTALL_PATH"] = str(exe.parent)
 
     env["STORE"] = os.environ.get("STORE") or ""
 
@@ -271,8 +271,8 @@ def set_env(
     env["SteamGameId"] = env["SteamAppId"]
 
     # PATHS
-    env["WINEPREFIX"] = f"{pfx}"
-    env["PROTONPATH"] = f"{protonpath}"
+    env["WINEPREFIX"] = str(pfx)
+    env["PROTONPATH"] = str(protonpath)
     env["STEAM_COMPAT_DATA_PATH"] = env["WINEPREFIX"]
     env["STEAM_COMPAT_SHADER_PATH"] = (
         f"{env['STEAM_COMPAT_DATA_PATH']}/shadercache"
@@ -353,7 +353,7 @@ def enable_steam_game_drive(env: dict[str, str]) -> dict[str, str]:
                     f"{os.environ['STEAM_COMPAT_LIBRARY_PATHS']}:{path}"
                 )
             else:
-                env["STEAM_COMPAT_LIBRARY_PATHS"] = f"{path}"
+                env["STEAM_COMPAT_LIBRARY_PATHS"] = str(path)
             break
 
     if os.environ.get("LD_LIBRARY_PATH"):
@@ -419,7 +419,7 @@ def build_command(
     if env.get("UMU_NO_RUNTIME") == "pressure-vessel":
         command.extend(
             [
-                f"{proton}",
+                str(proton),
                 env["PROTON_VERB"],
                 env["EXE"],
                 *opts,
@@ -442,11 +442,11 @@ def build_command(
 
     command.extend(
         [
-            f"{entry_point}",
+            str(entry_point),
             "--verb",
             env["PROTON_VERB"],
             "--",
-            f"{proton}",
+            str(proton),
             env["PROTON_VERB"],
             env["EXE"],
             *opts,
@@ -480,7 +480,7 @@ def run_command(command: list[str]) -> int:
     if os.environ.get("EXE").endswith("winetricks"):
         cwd = f"{os.environ['PROTONPATH']}/protonfixes"
     else:
-        cwd = f"{Path.cwd()}"
+        cwd = str(Path.cwd())
 
     # Create a subprocess but do not set it as subreaper
     # Unnecessary in a Flatpak and prctl() will fail if libc could not be found

--- a/umu/umu_runtime.py
+++ b/umu/umu_runtime.py
@@ -55,7 +55,7 @@ def _install_umu(
             "-O",
             f"{base_url}/{archive}",
             "--output-dir",
-            f"{tmp}",
+            str(tmp),
         ]
         msg: str = "Downloading umu runtime, please wait..."
         ret = run_zenity(bin, opts, msg)
@@ -300,7 +300,7 @@ def _update_umu(
         log.console("Updating steamrt to latest...")
         _install_umu(json, thread_pool)
         log.debug("Removing: %s", runtime)
-        rmtree(f"{runtime}")
+        rmtree(str(runtime))
         return
     log.console("steamrt is up to date")
 
@@ -363,7 +363,7 @@ def _move(file: Path, src: Path, dst: Path) -> None:
 
     if dest_file.is_dir():
         log.debug("Removing directory: %s", dest_file)
-        rmtree(f"{dest_file}")
+        rmtree(str(dest_file))
 
     if src.is_file() or src.is_dir():
         log.debug("Moving: %s -> %s", src_file, dest_file)
@@ -400,10 +400,10 @@ def check_runtime(src: Path, json: dict[str, Any]) -> int:
     log.console(f"Verifying integrity of {runtime.name}...")
     ret = run(
         [
-            f"{pv_verify}",
+            str(pv_verify),
             "--quiet",
             "--minimized-runtime",
-            f"{runtime.joinpath('files')}",
+            str(runtime.joinpath("files")),
         ],
         check=False,
     ).returncode

--- a/umu/umu_runtime.py
+++ b/umu/umu_runtime.py
@@ -55,7 +55,7 @@ def _install_umu(
             "-O",
             f"{base_url}/{archive}",
             "--output-dir",
-            tmp.as_posix(),
+            f"{tmp}",
         ]
         msg: str = "Downloading umu runtime, please wait..."
         ret = run_zenity(bin, opts, msg)
@@ -300,7 +300,7 @@ def _update_umu(
         log.console("Updating steamrt to latest...")
         _install_umu(json, thread_pool)
         log.debug("Removing: %s", runtime)
-        rmtree(runtime.as_posix())
+        rmtree(f"{runtime}")
         return
     log.console("steamrt is up to date")
 
@@ -363,7 +363,7 @@ def _move(file: Path, src: Path, dst: Path) -> None:
 
     if dest_file.is_dir():
         log.debug("Removing directory: %s", dest_file)
-        rmtree(dest_file.as_posix())
+        rmtree(f"{dest_file}")
 
     if src.is_file() or src.is_dir():
         log.debug("Moving: %s -> %s", src_file, dest_file)
@@ -400,10 +400,10 @@ def check_runtime(src: Path, json: dict[str, Any]) -> int:
     log.console(f"Verifying integrity of {runtime.name}...")
     ret = run(
         [
-            pv_verify.as_posix(),
+            f"{pv_verify}",
             "--quiet",
             "--minimized-runtime",
-            runtime.joinpath("files").as_posix(),
+            f"{runtime.joinpath('files')}",
         ],
         check=False,
     ).returncode


### PR DESCRIPTION
The launcher interacts with filesystem paths via `pathlib` and uses `PurePath.as_posix` to convert the object back to a string to set the string value to an appropriate environment variable. However, using `PurePath.as_posix` is inefficient. Please see commit message for details. 

Instead of `PurePath.as_posix`, the launcher can simply use f-strings which is more efficient and succinct.
