### PR TITLE
Pass path-like objects as subprocess.run arguments

### DIFF
--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -36,6 +36,7 @@ from umu_util import (
 )
 
 THREAD_POOL: ThreadPoolExecutor = ThreadPoolExecutor()
+AnyPath = os.PathLike | str
 
 
 def parse_args() -> Namespace | tuple[str, list[str]]:  # noqa: D103
@@ -387,7 +388,7 @@ def enable_steam_game_drive(env: dict[str, str]) -> dict[str, str]:
 def build_command(
     env: dict[str, str],
     local: Path,
-    command: list[str],
+    command: list[AnyPath],
     opts: list[str] = [],
 ) -> list[str]:
     """Build the command to be executed."""
@@ -421,7 +422,7 @@ def build_command(
     if env.get("UMU_NO_RUNTIME") == "pressure-vessel":
         command.extend(
             [
-                str(proton),
+                proton,
                 env["PROTON_VERB"],
                 env["EXE"],
                 *opts,
@@ -444,11 +445,11 @@ def build_command(
 
     command.extend(
         [
-            str(entry_point),
+            entry_point,
             "--verb",
             env["PROTON_VERB"],
             "--",
-            str(proton),
+            proton,
             env["PROTON_VERB"],
             env["EXE"],
             *opts,
@@ -458,7 +459,7 @@ def build_command(
     return command
 
 
-def run_command(command: list[str]) -> int:
+def run_command(command: list[AnyPath]) -> int:
     """Run the executable using Proton within the Steam Runtime."""
     # Configure a process via libc prctl()
     # See prctl(2) for more details
@@ -469,7 +470,7 @@ def run_command(command: list[str]) -> int:
     proc: Popen = None
     ret: int = 0
     libc: str = get_libc()
-    cwd: str = ""
+    cwd: AnyPath = ""
 
     if not command:
         err: str = f"Command list is empty or None: {command}"
@@ -482,7 +483,7 @@ def run_command(command: list[str]) -> int:
     if os.environ.get("EXE").endswith("winetricks"):
         cwd = f"{os.environ['PROTONPATH']}/protonfixes"
     else:
-        cwd = str(Path.cwd())
+        cwd = Path.cwd()
 
     # Create a subprocess but do not set it as subreaper
     # Unnecessary in a Flatpak and prctl() will fail if libc could not be found
@@ -542,7 +543,7 @@ def main() -> int:  # noqa: D103
         "UMU_ZENITY": "",
         "UMU_NO_RUNTIME": "",
     }
-    command: list[str] = []
+    command: list[AnyPath] = []
     opts: list[str] = []
     root: Path = Path(__file__).resolve(strict=True).parent
     future: Future = None

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -35,8 +35,9 @@ from umu_util import (
     is_winetricks_verb,
 )
 
-THREAD_POOL: ThreadPoolExecutor = ThreadPoolExecutor()
 AnyPath = os.PathLike | str
+
+thread_pool: ThreadPoolExecutor = ThreadPoolExecutor()
 
 
 def parse_args() -> Namespace | tuple[str, list[str]]:  # noqa: D103
@@ -180,11 +181,11 @@ def check_env(env: set[str, str]) -> dict[str, str] | dict[str, Any]:
     # GE-Proton
     if os.environ.get("PROTONPATH") == "GE-Proton":
         log.debug("GE-Proton selected")
-        get_umu_proton(env, THREAD_POOL)
+        get_umu_proton(env, thread_pool)
 
     if "PROTONPATH" not in os.environ:
         os.environ["PROTONPATH"] = ""
-        get_umu_proton(env, THREAD_POOL)
+        get_umu_proton(env, thread_pool)
 
     env["PROTONPATH"] = os.environ["PROTONPATH"]
 
@@ -575,7 +576,7 @@ def main() -> int:  # noqa: D103
         with socket(AF_INET, SOCK_DGRAM) as sock:
             sock.settimeout(5)
             sock.connect(("1.1.1.1", 53))
-        future = THREAD_POOL.submit(setup_umu, root, UMU_LOCAL, THREAD_POOL)
+        future = thread_pool.submit(setup_umu, root, UMU_LOCAL, thread_pool)
     except TimeoutError:  # Request to a server timed out
         if not UMU_LOCAL.exists() or not any(UMU_LOCAL.iterdir()):
             err: str = (
@@ -620,7 +621,7 @@ def main() -> int:  # noqa: D103
 
     if future:
         future.result()
-    THREAD_POOL.shutdown()
+    thread_pool.shutdown()
 
     # Exit if the winetricks verb is already installed to avoid reapplying it
     if env["EXE"].endswith("winetricks") and is_installed_verb(

--- a/umu/umu_runtime.py
+++ b/umu/umu_runtime.py
@@ -400,10 +400,10 @@ def check_runtime(src: Path, json: dict[str, Any]) -> int:
     log.console(f"Verifying integrity of {runtime.name}...")
     ret = run(
         [
-            str(pv_verify),
+            pv_verify,
             "--quiet",
             "--minimized-runtime",
-            str(runtime.joinpath("files")),
+            runtime.joinpath("files"),
         ],
         check=False,
     ).returncode

--- a/umu/umu_test.py
+++ b/umu/umu_test.py
@@ -1406,8 +1406,13 @@ class TestGameLauncher(unittest.TestCase):
             "Expected 3 element in the list from build_command",
         )
         proton, verb, exe, *_ = [*test_command]
+        self.assertIsInstance(
+            proton, os.PathLike, "Expected proton to be PathLike"
+        )
         self.assertEqual(
-            proton, f"{self.env['PROTONPATH']}/proton", "Expected PROTONPATH"
+            proton,
+            Path(self.env["PROTONPATH"], "proton"),
+            "Expected PROTONPATH",
         )
         self.assertEqual(verb, "waitforexitandrun", "Expected PROTON_VERB")
         self.assertEqual(exe, self.env["EXE"], "Expected EXE")
@@ -1525,12 +1530,18 @@ class TestGameLauncher(unittest.TestCase):
         entry_point, opt1, verb, opt2, proton, verb2, exe = [*test_command]
         # The entry point dest could change. Just check if there's a value
         self.assertTrue(entry_point, "Expected an entry point")
+        self.assertIsInstance(
+            entry_point, os.PathLike, "Expected entry point to be PathLike"
+        )
         self.assertEqual(opt1, "--verb", "Expected --verb")
         self.assertEqual(verb, self.test_verb, "Expected a verb")
         self.assertEqual(opt2, "--", "Expected --")
+        self.assertIsInstance(
+            proton, os.PathLike, "Expected proton to be PathLike"
+        )
         self.assertEqual(
             proton,
-            Path(self.env.get("PROTONPATH") + "/proton").as_posix(),
+            Path(self.env["PROTONPATH"], "proton"),
             "Expected the proton file",
         )
         self.assertEqual(verb2, self.test_verb, "Expected a verb")

--- a/umu/umu_test_plugins.py
+++ b/umu/umu_test_plugins.py
@@ -414,12 +414,18 @@ class TestGameLauncherPlugins(unittest.TestCase):
         entry_point, opt1, verb, opt2, proton, verb2, exe = [*test_command]
         # The entry point dest could change. Just check if there's a value
         self.assertTrue(entry_point, "Expected an entry point")
+        self.assertIsInstance(
+            entry_point, os.PathLike, "Expected entry point to be PathLike"
+        )
         self.assertEqual(opt1, "--verb", "Expected --verb")
         self.assertEqual(verb, self.test_verb, "Expected a verb")
         self.assertEqual(opt2, "--", "Expected --")
+        self.assertIsInstance(
+            proton, os.PathLike, "Expected proton to be PathLike"
+        )
         self.assertEqual(
             proton,
-            Path(self.env.get("PROTONPATH") + "/proton").as_posix(),
+            Path(self.env["PROTONPATH"], "proton"),
             "Expected the proton file",
         )
         self.assertEqual(verb2, self.test_verb, "Expected a verb")


### PR DESCRIPTION
`subprocess.run` wraps the `subprocess.Popen` constructor, which accepts a sequence that can contain path-like objects since Python 3.6. Since `pathlib.Path` implements `os.PathLike`, the launcher can safely avoid the conversion of all of the sequence's arguments to `str` and instead let Python convert all arguments to bytes before calling `os.posix_spawn`.
