### PR TITLE
Add mypy as static type checker

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     strategy:
       matrix:
-        version: ["3.10", "3.11", "3.12"]
+        version: ["3.10"]
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -1,0 +1,32 @@
+name: mypy
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        version: ["3.10", "3.11", "3.12"]
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.version }}
+    - name: Install dependencies
+      run: |
+        python3 -m pip install --upgrade pip
+    - name: Check types with mypy
+      run: |
+        pip install mypy
+        cd umu && mypy .

--- a/umu/pyproject.toml
+++ b/umu/pyproject.toml
@@ -1,0 +1,15 @@
+[tool.mypy]
+python_version = "3.10"
+warn_return_any = true
+ignore_missing_imports = true
+# strict = true
+
+disable_error_code = [
+    # Allow redefinitions since we redefine an error variable before raising exceptions
+    "no-redef"
+]
+
+exclude = [
+    '^umu_test\.py$',
+    '^umu_test_plugins\.py$',
+]

--- a/umu/pyproject.toml
+++ b/umu/pyproject.toml
@@ -2,7 +2,6 @@
 python_version = "3.10"
 warn_return_any = true
 ignore_missing_imports = true
-# strict = true
 
 disable_error_code = [
     # Allow redefinitions since we redefine an error variable before raising exceptions

--- a/umu/umu_consts.py
+++ b/umu/umu_consts.py
@@ -39,8 +39,8 @@ XDG_DATA_HOME = environ.get("XDG_DATA_HOME")
 
 FLATPAK_ID = environ.get("FLATPAK_ID") or ""
 
-FLATPAK_PATH: Path = (
-    Path(environ.get("XDG_DATA_HOME"), "umu") if FLATPAK_ID else None
+FLATPAK_PATH: Path | None = (
+    Path(XDG_DATA_HOME, "umu") if FLATPAK_ID and XDG_DATA_HOME else None
 )
 
 UMU_LOCAL: Path = FLATPAK_PATH or Path.home().joinpath(

--- a/umu/umu_consts.py
+++ b/umu/umu_consts.py
@@ -38,7 +38,7 @@ PROTON_VERBS = {
 FLATPAK_ID = environ.get("FLATPAK_ID") or ""
 
 FLATPAK_PATH: Path | None = (
-    Path(XDG_DATA_HOME, "umu") if FLATPAK_ID and XDG_DATA_HOME else None
+    Path(environ["XDG_DATA_HOME"], "umu") if FLATPAK_ID else None
 )
 
 UMU_LOCAL: Path = FLATPAK_PATH or Path.home().joinpath(

--- a/umu/umu_consts.py
+++ b/umu/umu_consts.py
@@ -35,8 +35,6 @@ PROTON_VERBS = {
     "getnativepath",
 }
 
-XDG_DATA_HOME = environ.get("XDG_DATA_HOME")
-
 FLATPAK_ID = environ.get("FLATPAK_ID") or ""
 
 FLATPAK_PATH: Path | None = (

--- a/umu/umu_consts.py
+++ b/umu/umu_consts.py
@@ -1,5 +1,5 @@
+import os
 from enum import Enum
-from os import environ
 from pathlib import Path
 
 
@@ -35,10 +35,10 @@ PROTON_VERBS = {
     "getnativepath",
 }
 
-FLATPAK_ID = environ.get("FLATPAK_ID") or ""
+FLATPAK_ID = os.environ.get("FLATPAK_ID") or ""
 
 FLATPAK_PATH: Path | None = (
-    Path(environ["XDG_DATA_HOME"], "umu") if FLATPAK_ID else None
+    Path(os.environ["XDG_DATA_HOME"], "umu") if FLATPAK_ID else None
 )
 
 UMU_LOCAL: Path = FLATPAK_PATH or Path.home().joinpath(

--- a/umu/umu_consts.py
+++ b/umu/umu_consts.py
@@ -35,6 +35,8 @@ PROTON_VERBS = {
     "getnativepath",
 }
 
+XDG_DATA_HOME = environ.get("XDG_DATA_HOME")
+
 FLATPAK_ID = environ.get("FLATPAK_ID") or ""
 
 FLATPAK_PATH: Path = (

--- a/umu/umu_log.py
+++ b/umu/umu_log.py
@@ -10,7 +10,6 @@ from logging import (
     getLogger,
 )
 from sys import stderr
-from typing import TextIO
 
 from umu_consts import SIMPLE_FORMAT, Color
 
@@ -47,6 +46,6 @@ class CustomFormatter(Formatter):  # noqa: D101
 
 log: CustomLogger = CustomLogger(getLogger(__name__))
 
-console_handler: StreamHandler[TextIO] = StreamHandler(stream=stderr)
+console_handler: StreamHandler = StreamHandler(stream=stderr)
 console_handler.setFormatter(CustomFormatter())
 log.addHandler(console_handler)

--- a/umu/umu_log.py
+++ b/umu/umu_log.py
@@ -1,3 +1,4 @@
+import sys
 from logging import (
     DEBUG,
     ERROR,
@@ -9,7 +10,6 @@ from logging import (
     StreamHandler,
     getLogger,
 )
-from sys import stderr
 
 from umu_consts import SIMPLE_FORMAT, Color
 
@@ -24,7 +24,7 @@ class CustomLogger(Logger):  # noqa: D101
         Intended to be used to notify umu setup progress state for command
         line usage
         """
-        print(f"{Color.BOLD.value}{msg}{Color.RESET.value}", file=stderr)
+        print(f"{Color.BOLD.value}{msg}{Color.RESET.value}", file=sys.stderr)
 
 
 class CustomFormatter(Formatter):  # noqa: D101
@@ -46,6 +46,6 @@ class CustomFormatter(Formatter):  # noqa: D101
 
 log: CustomLogger = CustomLogger(getLogger(__name__))
 
-console_handler: StreamHandler = StreamHandler(stream=stderr)
+console_handler: StreamHandler = StreamHandler(stream=sys.stderr)
 console_handler.setFormatter(CustomFormatter())
 log.addHandler(console_handler)

--- a/umu/umu_log.py
+++ b/umu/umu_log.py
@@ -10,6 +10,7 @@ from logging import (
     getLogger,
 )
 from sys import stderr
+from typing import TextIO
 
 from umu_consts import SIMPLE_FORMAT, Color
 
@@ -46,6 +47,6 @@ class CustomFormatter(Formatter):  # noqa: D101
 
 log: CustomLogger = CustomLogger(getLogger(__name__))
 
-console_handler: StreamHandler = StreamHandler(stream=stderr)
+console_handler: StreamHandler[TextIO] = StreamHandler(stream=stderr)
 console_handler.setFormatter(CustomFormatter())
 log.addHandler(console_handler)

--- a/umu/umu_plugins.py
+++ b/umu/umu_plugins.py
@@ -5,7 +5,7 @@ from typing import Any
 
 def set_env_toml(
     env: dict[str, str], args: Namespace
-) -> tuple[dict[str, str], list[str, tuple[str, Path]]]:
+) -> tuple[dict[str, str], list[str]]:
     """Read key/values in a TOML file and map them to umu env. variables.
 
     In the TOML file, certain keys map to environment variables:

--- a/umu/umu_proton.py
+++ b/umu/umu_proton.py
@@ -301,11 +301,11 @@ def _get_latest(
     $HOME/.local/share/Steam/compatibilitytool.d will be used.
     """
     # Name of the Proton archive (e.g., GE-Proton9-7.tar.gz)
-    tarball: str = ""
+    tarball: str
     # Name of the Proton directory (e.g., GE-Proton9-7)
-    proton: str = ""
+    proton: str
     # Name of the Proton version, which is either UMU-Proton or GE-Proton
-    version: str = ""
+    version: str
 
     if not assets:
         return None

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -158,14 +158,17 @@ def check_env(env: dict[str, str]) -> dict[str, str] | dict[str, Any]:
     if os.environ.get("WINEPREFIX") == "":
         err: str = "Environment variable is empty: WINEPREFIX"
         raise ValueError(err)
+
     if "WINEPREFIX" not in os.environ:
         pfx: Path = Path.home().joinpath("Games", "umu", env["GAMEID"])
         pfx.mkdir(parents=True, exist_ok=True)
         os.environ["WINEPREFIX"] = str(pfx)
+
     if not Path(os.environ["WINEPREFIX"]).expanduser().is_dir():
         pfx: Path = Path(os.environ["WINEPREFIX"])
         pfx.mkdir(parents=True, exist_ok=True)
         os.environ["WINEPREFIX"] = str(pfx)
+
     env["WINEPREFIX"] = os.environ["WINEPREFIX"]
 
     # Proton Version
@@ -209,6 +212,7 @@ def set_env(
     protonpath: Path = (
         Path(env["PROTONPATH"]).expanduser().resolve(strict=True)
     )
+
     # Command execution usage
     is_cmd: bool = isinstance(args, tuple)
 
@@ -381,6 +385,7 @@ def enable_steam_game_drive(env: dict[str, str]) -> dict[str, str]:
     for rtpath in steamrt_paths:
         if not Path(rtpath).is_symlink() and Path(rtpath, libc).is_file():
             paths.add(rtpath)
+
     env["STEAM_RUNTIME_LIBRARY_PATH"] = ":".join(list(paths))
 
     return env

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -318,7 +318,7 @@ def set_env(
     if FLATPAK_PATH:
         env["UMU_NO_RUNTIME"] = os.environ.get("UMU_NO_RUNTIME") or ""
 
-    # Currently, running games when using the Steam Runtime in a Flatpak
+    # FIXME: Currently, running games when using the Steam Runtime in a Flatpak
     # environment will cause the game window to not display within the SteamOS
     # gamescope session. Note, this is a workaround until the runtime is built
     # or the issue is fixed upstream.

--- a/umu/umu_runtime.py
+++ b/umu/umu_runtime.py
@@ -187,7 +187,6 @@ def setup_umu(
         return
 
     _update_umu(local, json, thread_pool)
-    return
 
 
 def _update_umu(

--- a/umu/umu_runtime.py
+++ b/umu/umu_runtime.py
@@ -249,7 +249,7 @@ def _update_umu(
                 if line.startswith("BUILD_ID"):
                     # Get the value after 'BUILD_ID=' and strip the quotes
                     build_id: str = (
-                        line.removeprefix("BUILD_ID=").strip('"').rstrip()
+                        line.removeprefix("BUILD_ID=").rstrip().strip('"')
                     )
                     url = (
                         f"/steamrt-images-{codename}" f"/snapshots/{build_id}"

--- a/umu/umu_runtime.py
+++ b/umu/umu_runtime.py
@@ -1,4 +1,3 @@
-from collections.abc import Callable
 from concurrent.futures import Future, ThreadPoolExecutor
 from hashlib import sha256
 from http.client import HTTPException, HTTPResponse, HTTPSConnection

--- a/umu/umu_runtime.py
+++ b/umu/umu_runtime.py
@@ -231,10 +231,9 @@ def _update_umu(
     # When the file is missing, the request for the image will need to be made
     # to the endpoint of the specific snapshot
     if not local.joinpath("VERSIONS.txt").is_file():
+        url: str
         release: Path = runtime.joinpath("files", "lib", "os-release")
         versions: str = f"SteamLinuxRuntime_{codename}.VERSIONS.txt"
-        url: str = ""
-        build_id: str = ""
 
         # Restore the runtime if os-release is missing, otherwise pressure
         # vessel will crash when creating the variable directory
@@ -248,9 +247,10 @@ def _update_umu(
         with release.open(mode="r", encoding="utf-8") as file:
             for line in file:
                 if line.startswith("BUILD_ID"):
-                    _: str = line.strip()
-                    # Get the value after '=' and strip the quotes
-                    build_id = _[_.find("=") + 1 :].strip('"')
+                    # Get the value after 'BUILD_ID=' and strip the quotes
+                    build_id: str = (
+                        line.removeprefix("BUILD_ID=").strip('"').rstrip()
+                    )
                     url = (
                         f"/steamrt-images-{codename}" f"/snapshots/{build_id}"
                     )

--- a/umu/umu_runtime.py
+++ b/umu/umu_runtime.py
@@ -32,6 +32,7 @@ except ImportError:
 def _install_umu(
     json: dict[str, Any], thread_pool: ThreadPoolExecutor
 ) -> None:
+    resp: HTTPResponse
     tmp: Path = Path(mkdtemp())
     ret: int = 0  # Exit code from zenity
     # Codename for the runtime (e.g., 'sniper')
@@ -42,7 +43,6 @@ def _install_umu(
         f"https://repo.steampowered.com/steamrt-images-{codename}"
         "/snapshots/latest-container-runtime-public-beta"
     )
-    resp: HTTPResponse
 
     log.debug("Codename: %s", codename)
     log.debug("URL: %s", base_url)

--- a/umu/umu_util.py
+++ b/umu/umu_util.py
@@ -26,6 +26,7 @@ def run_zenity(command: str, opts: list[str], msg: str) -> int:
     if not bin:
         log.warning("zenity was not found in system")
         return -1
+
     if not cmd:
         log.warning("%s was not found in system", command)
         return -1

--- a/umu/umu_util.py
+++ b/umu/umu_util.py
@@ -19,8 +19,8 @@ def run_zenity(command: str, opts: list[str], msg: str) -> int:
 
     Intended to be used for long running operations (e.g. large file downloads)
     """
-    bin: str = which("zenity")
-    cmd: str = which(command)
+    bin: str = which("zenity") or ""
+    cmd: str = which(command) or ""
     ret: int = 0  # Exit code returned from zenity
 
     if not bin:
@@ -56,7 +56,10 @@ def run_zenity(command: str, opts: list[str], msg: str) -> int:
                 zenity_proc.terminate()
                 log.warning("%s timed out after 5 min.", cmd)
                 raise TimeoutError
-            zenity_proc.stdin.close()
+
+            if zenity_proc.stdin:
+                zenity_proc.stdin.close()
+
             ret = zenity_proc.wait()
 
     if ret:
@@ -70,9 +73,9 @@ def is_installed_verb(verb: list[str], pfx: Path) -> bool:
 
     Determines the installation of verbs by reading winetricks.log file.
     """
-    wt_log: Path = None
+    wt_log: Path
+    verbs: set[str]
     is_installed: bool = False
-    verbs: set[str] = {}
 
     if not pfx:
         err: str = f"Value is '{pfx}' for WINE prefix"
@@ -106,7 +109,7 @@ def is_winetricks_verb(
     verbs: list[str], pattern: str = r"^[a-zA-Z_0-9]+(=[a-zA-Z0-9]*)?$"
 ) -> bool:
     """Check if a string is a winetricks verb."""
-    regex: Pattern = None
+    regex: Pattern
 
     if not verbs:
         return False


### PR DESCRIPTION
Adds the mypy static type checker to the CI to ensure type references for identifiers in launcher files are correct. Type checking for test files are excluded and dynamically typed code will still be valid.