### PR TITLE
Log warnings for obsoleted files

### DIFF
--- a/umu/umu_runtime.py
+++ b/umu/umu_runtime.py
@@ -14,7 +14,7 @@ from typing import Any
 
 from umu.umu_consts import CONFIG, UMU_LOCAL
 from umu.umu_log import log
-from umu.umu_util import run_zenity
+from umu.umu_util import find_obsolete, run_zenity
 
 client_session: HTTPSConnection = HTTPSConnection(
     "repo.steampowered.com",
@@ -186,6 +186,7 @@ def setup_umu(
         _install_umu(json, thread_pool)
         return
 
+    find_obsolete()
     _update_umu(local, json, thread_pool)
 
 

--- a/umu/umu_util.py
+++ b/umu/umu_util.py
@@ -5,6 +5,7 @@ from re import Pattern, compile
 from shutil import which
 from subprocess import PIPE, STDOUT, Popen, TimeoutExpired
 
+from umu.umu_consts import STEAM_COMPAT, UMU_LOCAL
 from umu.umu_log import log
 
 
@@ -124,3 +125,38 @@ def is_winetricks_verb(
             return False
 
     return True
+
+
+def find_obsolete() -> None:
+    """Find obsoleted launcher files and log them."""
+    # Obsoleted files in $HOME/.local/share/umu from RC4 and below
+    obsoleted: set[str] = {
+        "reaper",
+        "sniper_platform_0.20240125.75305",
+        "BUILD_ID.txt",
+        "umu_version.json",
+        "sniper_platform_0.20231211.70175",
+    }
+
+    for file in UMU_LOCAL.glob("*"):
+        if (
+            file.name.endswith(".py")
+            and file.name.startswith(("umu", "ulwgl"))
+            or file.name in obsoleted
+        ):
+            log.warning("'%s' is obsolete", file)
+
+    # $HOME/.local/share/Steam/compatibilitytool.d
+    if (launcher := STEAM_COMPAT.joinpath("umu-launcher")).is_dir():
+        log.warning("'%s' is obsolete", launcher)
+
+    if (launcher := STEAM_COMPAT.joinpath("ULWGL-Launcher")).is_dir():
+        log.warning("'%s' is obsolete", launcher)
+
+    # $HOME/.cache
+    if (cache := Path.home().joinpath(".cache", "ULWGL")).is_dir():
+        log.warning("'%s' is obsolete", cache)
+
+    # $HOME/.local/share
+    if (ulwgl := Path.home().joinpath(".local", "share", "ULWGL")).is_dir():
+        log.warning("'%s' is obsolete", ulwgl)

--- a/umu/umu_util.py
+++ b/umu/umu_util.py
@@ -142,8 +142,7 @@ def find_obsolete() -> None:
         if (
             file.name.endswith(".py")
             and file.name.startswith(("umu", "ulwgl"))
-            or file.name in obsoleted
-        ):
+        ) or file.name in obsoleted:
             log.warning("'%s' is obsolete", file)
 
     # $HOME/.local/share/Steam/compatibilitytool.d

--- a/umu/umu_util.py
+++ b/umu/umu_util.py
@@ -147,9 +147,6 @@ def find_obsolete() -> None:
             log.warning("'%s' is obsolete", file)
 
     # $HOME/.local/share/Steam/compatibilitytool.d
-    if (launcher := STEAM_COMPAT.joinpath("umu-launcher")).is_dir():
-        log.warning("'%s' is obsolete", launcher)
-
     if (launcher := STEAM_COMPAT.joinpath("ULWGL-Launcher")).is_dir():
         log.warning("'%s' is obsolete", launcher)
 

--- a/umu/umu_util.py
+++ b/umu/umu_util.py
@@ -130,6 +130,7 @@ def is_winetricks_verb(
 def find_obsolete() -> None:
     """Find obsoleted launcher files and log them."""
     # Obsoleted files in $HOME/.local/share/umu from RC4 and below
+    home: Path = Path.home()
     obsoleted: set[str] = {
         "reaper",
         "sniper_platform_0.20240125.75305",
@@ -150,9 +151,9 @@ def find_obsolete() -> None:
         log.warning("'%s' is obsolete", launcher)
 
     # $HOME/.cache
-    if (cache := Path.home().joinpath(".cache", "ULWGL")).is_dir():
+    if (cache := home.joinpath(".cache", "ULWGL")).is_dir():
         log.warning("'%s' is obsolete", cache)
 
     # $HOME/.local/share
-    if (ulwgl := Path.home().joinpath(".local", "share", "ULWGL")).is_dir():
+    if (ulwgl := home.joinpath(".local", "share", "ULWGL")).is_dir():
         log.warning("'%s' is obsolete", ulwgl)

--- a/umu/umu_util.py
+++ b/umu/umu_util.py
@@ -129,7 +129,6 @@ def is_winetricks_verb(
 
 def find_obsolete() -> None:
     """Find obsoleted launcher files and log them."""
-    # Obsoleted files in $HOME/.local/share/umu from RC4 and below
     home: Path = Path.home()
     obsoleted: set[str] = {
         "reaper",
@@ -139,6 +138,7 @@ def find_obsolete() -> None:
         "sniper_platform_0.20231211.70175",
     }
 
+    # Obsoleted files in $HOME/.local/share/umu from RC4 and below
     for file in UMU_LOCAL.glob("*"):
         is_umu_file: bool = file.name.endswith(".py") and (
             file.name.startswith(("umu", "ulwgl"))

--- a/umu/umu_util.py
+++ b/umu/umu_util.py
@@ -139,10 +139,10 @@ def find_obsolete() -> None:
     }
 
     for file in UMU_LOCAL.glob("*"):
-        if (
-            file.name.endswith(".py")
-            and file.name.startswith(("umu", "ulwgl"))
-        ) or file.name in obsoleted:
+        is_umu_file: bool = file.name.endswith(".py") and (
+            file.name.startswith(("umu", "ulwgl"))
+        )
+        if is_umu_file or file.name in obsoleted:
             log.warning("'%s' is obsolete", file)
 
     # $HOME/.local/share/Steam/compatibilitytool.d


### PR DESCRIPTION
Intended to be merged before the next release, the launcher will warn of all obsoleted launcher files from RC4 and below. Users will be responsible of manually deleting them after being warned.