### PR TITLE
Add standard path for dependencies

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "reaper"]
-	path = subprojects/reaper
-	url = https://github.com/Plagman/reaper.git
 [submodule "subprojects/python-xlib"]
 	path = subprojects/python-xlib
 	url = https://github.com/python-xlib/python-xlib.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "reaper"]
 	path = subprojects/reaper
 	url = https://github.com/Plagman/reaper.git
+[submodule "subprojects/python-xlib"]
+	path = subprojects/python-xlib
+	url = https://github.com/python-xlib/python-xlib.git

--- a/Makefile.in
+++ b/Makefile.in
@@ -124,7 +124,7 @@ umu-launcher-install: umu-launcher-dist-install umu-launcher-bin-install
 
 $(OBJDIR)/.build-python-xlib: | $(OBJDIR)
 	$(info :: Building python-xlib )
-	git submodule update --recursive
+	git submodule update --init --filter=tree:0 --recursive
 	cd subprojects/python-xlib && python setup.py build
 
 .PHONY: python-xlib

--- a/Makefile.in
+++ b/Makefile.in
@@ -5,11 +5,12 @@ INSTALLDIR ?= umu
 
 OBJDIR := builddir
 
-PREFIX  ?= /usr
-BINDIR  := $(PREFIX)/bin
-LIBDIR  := $(PREFIX)/lib
-DATADIR := $(PREFIX)/share
-MANDIR  := $(DATADIR)/man
+PREFIX      ?= /usr
+BINDIR      := $(PREFIX)/bin
+LIBDIR      := $(PREFIX)/lib
+DATADIR     := $(PREFIX)/share
+MANDIR      := $(DATADIR)/man
+VENDOREDIR  := $(PREFIX)/lib/umu/python/site-packages
 
 DESTDIR ?=
 USERINSTALL ?= xfalse
@@ -25,7 +26,7 @@ endif
 
 .PHONY: install
 ifeq ($(USERINSTALL), xtrue)
-install: umu-install umu-launcher-install user-install
+install: umu-install umu-launcher-install user-install python-xlib-install
 else
 install: umu-install umu-launcher-install
 endif
@@ -119,6 +120,20 @@ umu-launcher-dist-install:
 	install -Dm 644 umu/umu-launcher/toolmanifest.vdf      -t $(DESTDIR)$(DATADIR)/steam/compatibilitytools.d/umu-launcher
 
 umu-launcher-install: umu-launcher-dist-install umu-launcher-bin-install
+
+
+$(OBJDIR)/.build-python-xlib: | $(OBJDIR)
+	$(info :: Building python-xlib )
+	git submodule update --recursive
+	cd subprojects/python-xlib && python setup.py build
+
+.PHONY: python-xlib
+python-xlib: $(OBJDIR)/.build-python-xlib
+
+python-xlib-install:
+	$(info :: Installing python-xlib )
+	install -d $(DESTDIR)$(VENDOREDIR)
+	cp      -r subprojects/python-xlib/build/lib/Xlib $(DESTDIR)$(VENDOREDIR)
 
 
 $(OBJDIR):

--- a/Makefile.in
+++ b/Makefile.in
@@ -26,7 +26,7 @@ endif
 
 .PHONY: install
 ifeq ($(USERINSTALL), xtrue)
-install: umu-install umu-launcher-install user-install python-xlib-install
+install: umu-install umu-launcher-install user-install
 else
 install: umu-install umu-launcher-install
 endif

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Borderlands 3 from EGS store.
 
 
 ## Building
-Building umu-launcher currently requires `bash`, `make`, and `scdoc`
+Building umu-launcher currently requires `bash`, `make`, `scdoc` and the setuptools package to, optionally, build `python-xlib`.
 
 To build umu-launcher, after downloading and extracting the source code from this repository, change into the newly extracted directory
 ```shell

--- a/umu/umu_consts.py
+++ b/umu/umu_consts.py
@@ -45,6 +45,6 @@ UMU_LOCAL: Path = FLATPAK_PATH or Path.home().joinpath(
     ".local", "share", "umu"
 )
 
-# Constants defined in prctl.h
+# Constant defined in prctl.h
 # See prctl(2) for more details
 PR_SET_CHILD_SUBREAPER = 36

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -26,6 +26,9 @@ from umu_consts import (
     STEAM_COMPAT,
     UMU_LOCAL,
 )
+
+sys.path.append(str(UMU_LOCAL.joinpath("python", "site-packages")))
+
 from umu_log import CustomFormatter, console_handler, log
 from umu_plugins import set_env_toml
 from umu_proton import get_umu_proton

--- a/umu/umu_runtime.py
+++ b/umu/umu_runtime.py
@@ -182,7 +182,9 @@ def setup_umu(
         log.console(
             "Setting up Unified Launcher for Windows Games on Linux..."
         )
-        local.mkdir(parents=True, exist_ok=True)
+        local.joinpath("python", "site-packages").mkdir(
+            parents=True, exist_ok=True
+        )
         _install_umu(json, thread_pool)
         return
 


### PR DESCRIPTION
Adds the new path `$HOME/.local/share/umu/python/site-packages` to install Python modules for umu clients such as Lutris. Also, `python-xlib` is added a git submodule and the Makefile.in has been updated to build/install python-xlib.

cc @loathingKernel 