### PR TITLE
Build all dependencies for umu clients

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -126,14 +126,14 @@ umu-launcher-install: umu-launcher-dist-install umu-launcher-bin-install
 
 
 $(OBJDIR)/.build-umu-subprojects: | $(OBJDIR)
-	$(info :: Building subproject dependencies )
+	$(info :: Building subprojects )
 	pip install -r requirements.in -t $(OBJDIR)
 
 .PHONY: umu-subprojects
 umu-subprojects: $(OBJDIR)/.build-umu-subprojects
 
 umu-subprojects-install:
-	$(info :: Installing subproject dependencies )
+	$(info :: Installing subprojects )
 	install -d $(DESTDIR)$(PYTHONDIR)
 	cp      -r $(OBJDIR)/*-info $(DESTDIR)$(PYTHONDIR)
 	cp      -r $(OBJDIR)/Xlib   $(DESTDIR)$(PYTHONDIR)

--- a/Makefile.in
+++ b/Makefile.in
@@ -125,18 +125,19 @@ umu-launcher-dist-install:
 umu-launcher-install: umu-launcher-dist-install umu-launcher-bin-install
 
 
-$(OBJDIR)/.build-python-xlib: | $(OBJDIR)
-	$(info :: Building python-xlib )
-	cd subprojects/python-xlib && \
-	$(PYTHON_INTERPRETER) setup.py build
+$(OBJDIR)/.build-umu-subprojects: | $(OBJDIR)
+	$(info :: Building subproject dependencies )
+	pip install -r requirements.in -t $(OBJDIR)
 
-.PHONY: python-xlib
-python-xlib: $(OBJDIR)/.build-python-xlib
+.PHONY: umu-subprojects
+umu-subprojects: $(OBJDIR)/.build-umu-subprojects
 
-python-xlib-install:
-	$(info :: Installing python-xlib )
+umu-subprojects-install:
+	$(info :: Installing subproject dependencies )
 	install -d $(DESTDIR)$(PYTHONDIR)
-	cp      -r subprojects/python-xlib/build/lib/Xlib $(DESTDIR)$(PYTHONDIR)
+	cp      -r $(OBJDIR)/*-info $(DESTDIR)$(PYTHONDIR)
+	cp      -r $(OBJDIR)/Xlib   $(DESTDIR)$(PYTHONDIR)
+	cp         $(OBJDIR)/six.py $(DESTDIR)$(PYTHONDIR)
 
 $(OBJDIR):
 	@mkdir -p $(@)

--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ Borderlands 3 from EGS store.
 ## Building
 Building umu-launcher currently requires `bash`, `make`, and `scdoc`, as well as the following Python build tools: [build](https://github.com/pypa/build), [hatchling](https://github.com/pypa/hatch), and [installer](https://github.com/pypa/installer).
 
+Optionally, for building umu-launcher's Python dependencies, [pip](https://github.com/pypa/pip) is required.
+
 To build umu-launcher, after downloading and extracting the source code from this repository, change into the newly extracted directory
 ```shell
 cd umu-launcher

--- a/README.md
+++ b/README.md
@@ -109,6 +109,11 @@ or if you are packaging umu-launcher
 make DESTDIR=<packaging_directory> install
 ```
 
+**Note**: For umu clients, to install all of its dependencies, run:
+```shell
+make DESTDIR=<packaging_directory> umu-subprojects-install
+```
+
 ### Installing as user
 If you want to install umu just for your user, or for quickly testing, you can configure umu with the following command
 ```shell

--- a/README.md
+++ b/README.md
@@ -79,8 +79,6 @@ Borderlands 3 from EGS store.
 ## Building
 Building umu-launcher currently requires `bash`, `make`, and `scdoc`, as well as the following Python build tools: [build](https://github.com/pypa/build), [hatchling](https://github.com/pypa/hatch), and [installer](https://github.com/pypa/installer).
 
-Optionally, for building umu-launcher's Python dependencies, [pip](https://github.com/pypa/pip) is required.
-
 To build umu-launcher, after downloading and extracting the source code from this repository, change into the newly extracted directory
 ```shell
 cd umu-launcher
@@ -93,6 +91,13 @@ To configure the installation `PREFIX` (this is not related to wine's `WINEPREFI
 Change the `--prefix` as fit for your distribution, for example `/usr/local`, or `/app` for packaging through Flatpak.
 
 Then run `make` to build. After a successful build the resulting files should be available in the `./builddir` directory
+
+**Note**: For umu clients, [pip](https://github.com/pypa/pip) is required to build its Python dependencies and they will need to be put within same directory as the runtime directory (e.g., `$HOME/.config/heroic/tools/runtimes/umu`).
+
+To build all dependencies:
+```shell
+make DESTDIR=<packaging_directory> umu-subprojects
+```
 
 ### Installing 
 To install umu-launcher run the following command after completing the steps described above


### PR DESCRIPTION
This pull request updates the Makefile to properly build all umu's Python dependencies for umu clients. Currently, [python-xlib](https://github.com/python-xlib/python-xlib) would be built, however the [six](https://github.com/benjaminp/six) module wouldn't which may cause Lutris users to crash due to the missing dependency. 

To build all dependencies for clients like Lutris, we need to use a tool resolve all of the dependencies such as [pip](https://github.com/pypa/pip) or [uv](https://github.com/astral-sh/uv) and have them built in the Makefile.