### PR TITLE
Limit window setup to gamescope sessions

### DIFF
--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -605,6 +605,7 @@ def run_command(command: list[AnyPath]) -> int:
     proc: Popen
     ret: int = 0
     libc: str = get_libc()
+    gamescope_baselayer_sequence: list[int] | None = None
 
     if not command:
         err: str = f"Command list is empty or None: {command}"
@@ -638,7 +639,9 @@ def run_command(command: list[AnyPath]) -> int:
             preexec_fn=lambda: prctl(PR_SET_CHILD_SUBREAPER, 1, 0, 0, 0, 0),
             cwd=cwd,
         )
-    gamescope_baselayer_sequence = get_gamescope_baselayer_order()
+
+    if os.environ.get("XDG_CURRENT_DESKTOP") == "gamescope":
+        gamescope_baselayer_sequence = get_gamescope_baselayer_order()
 
     # Dont do window fuckery if we're not inside gamescope
     if gamescope_baselayer_sequence and not os.environ.get("EXE", "").endswith(


### PR DESCRIPTION
Closes https://github.com/Open-Wine-Components/umu-launcher/issues/145

Before finding the base layer order sequence, in some cases, an exception can be raised when creating the display object because we're passing DISPLAY values that may not exist for the user's session (e.g., :0). For now, only attempt to setup windows when using the Steam Deck and in a gamescope session. This should be fine, as long as Steam Deck users do not create another tty session, in which case DISPLAY=:0 and DISPLAY=:1 would be incorrect. 

In the future, to properly support the general case, somehow find the original DISPLAY or have umu clients pass the original DISPLAY value to us.
