### PR TITLE
make rule to generate standalone python zippapp application

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -178,4 +178,14 @@ user-install:
 	$(info :: To run you need to make sure "$(BINDIR)" is in your PATH )
 
 
+ZIPAPP := $(OBJDIR)/umu-run-$(shell git describe --always --long --tags)
+ZIPAPP_STAGING := $(OBJDIR)/umu-run_staging
+
+.PHONY: zipapp
+zipapp: version | $(OBJDIR)
+	@$(PYTHON_INTERPRETER) -m pip install -t "$(ZIPAPP_STAGING)" --upgrade .
+	cp umu/umu_version.json "$(ZIPAPP_STAGING)"/umu
+	@$(PYTHON_INTERPRETER) -m zipapp $(ZIPAPP_STAGING) -m "umu.__main__:main" -o $(ZIPAPP) -p "$(PYTHON_INTERPRETER)" -c
+	@echo "Standalone application created: $(ZIPAPP))"
+
 # vim: ft=make

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -4,6 +4,7 @@ import os
 import sys
 import threading
 import time
+import zipfile
 from _ctypes import CFuncPtr
 from argparse import ArgumentParser, Namespace, RawTextHelpFormatter
 from concurrent.futures import Future, ThreadPoolExecutor
@@ -691,7 +692,15 @@ def main() -> int:  # noqa: D103
     }
     command: list[AnyPath] = []
     opts: list[str] = []
-    root: Path = Path(__file__).resolve(strict=True).parent
+    root: Path
+    try:
+        root = Path(__file__).resolve(strict=True).parent
+    except NotADirectoryError:
+        # raised when whithin a zipapp. Try again in non-strict mode, root
+        # should be zipapp.pyz/umu. Split and set root to /umu within zip.
+        root = Path(__file__).resolve().parent
+        root = zipfile.Path(root.parent, root.name)
+
     args: Namespace | tuple[str, list[str]] = parse_args()
 
     if os.geteuid() == 0:


### PR DESCRIPTION
This adds a `zipapp` rule that bundles umu-run and its dependencies in a standalone executable (a python zipapp), ideal for clients like heroic or lutris.

This can also be used from python code by adding the file to PYTHONPATH (or sys.path) as in:

PYTHONPATH=~/.local/bin/umu-run python -m umu

No additional build deps are required. I could add a config variable to exclude dependencies for clients that manage that themselves.
