### PR TITLE
Refactor window setup in gamescope sessions

### DIFF
--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -623,7 +623,7 @@ def monitor_windows(
             continue
 
         if current_window_list != window_client_list:
-            log.debug("New window sequence detected")
+            log.debug("New windows detected")
             set_steam_game_property(
                 d_secondary, current_window_list, steam_assigned_layer_id
             )

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -457,9 +457,10 @@ def get_window_client_ids(d: display.Display) -> list[str]:
     return []
 
 
-def set_steam_game_property(  # noqa: D103
+def set_steam_game_property(
     d: display.Display, window_ids: list[str], steam_assigned_layer_id: int
 ) -> None:
+    """Set Steam's assigned layer ID on a list of windows."""
     try:
         log.debug("steam_layer: %s", steam_assigned_layer_id)
         for window_id in window_ids:
@@ -488,7 +489,8 @@ def set_steam_game_property(  # noqa: D103
         log.exception(e)
 
 
-def get_gamescope_baselayer_order(d: display.Display) -> list[int] | None:  # noqa: D103
+def get_gamescope_baselayer_order(d: display.Display) -> list[int] | None:
+    """Get the gamescope base layer seq on the primary root window."""
     try:
         # Intern the atom for GAMESCOPECTRL_BASELAYER_APPID
         atom = d.get_atom("GAMESCOPECTRL_BASELAYER_APPID")
@@ -507,9 +509,10 @@ def get_gamescope_baselayer_order(d: display.Display) -> list[int] | None:  # no
     return None
 
 
-def rearrange_gamescope_baselayer_order(  # noqa
+def rearrange_gamescope_baselayer_order(
     sequence: list[int],
 ) -> tuple[list[int], int]:
+    """Rearrange a gamescope base layer sequence retrieved from a window."""
     # Ensure there are exactly 4 numbers
     if len(sequence) != 4:
         err = "Unexpected number of elements in sequence"
@@ -524,9 +527,10 @@ def rearrange_gamescope_baselayer_order(  # noqa
     return rearranged, rearranged[1]
 
 
-def set_gamescope_baselayer_order(  # noqa
+def set_gamescope_baselayer_order(
     d: display.Display, rearranged: list[int]
 ) -> None:
+    """Set a new gamescope base layer seq on the primary root window."""
     try:
         # Intern the atom for GAMESCOPECTRL_BASELAYER_APPID
         atom = d.get_atom("GAMESCOPECTRL_BASELAYER_APPID")

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -624,6 +624,10 @@ def monitor_windows(
         current_window_list = get_window_client_ids(
             d_secondary, root_secondary
         )
+
+        if not current_window_list:
+            continue
+
         log.debug("Current windows: %s", current_window_list)
         if current_window_list != window_client_list:
             log.debug("New window sequence detected")
@@ -688,8 +692,9 @@ def run_command(command: list[AnyPath]) -> int:
         "winetricks"
     ):
         d_secondary = display.Display(":1")
-        window_client_list: list[str] = []
         root_secondary: Window = d_secondary.screen().root
+        window_client_list: list[str] = []
+
         root_secondary.change_attributes(event_mask=X.SubstructureNotifyMask)
 
         while not window_client_list:

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -646,6 +646,10 @@ def run_command(command: list[AnyPath]) -> int:
     d_primary: display.Display | None = None
     d_secondary: display.Display | None = None
     gamescope_baselayer_sequence: list[int] | None = None
+    # Root window of the primary xwayland server
+    root_primary: Window
+    # Root window of the client application
+    root_secondary: Window
 
     if not command:
         err: str = f"Command list is empty or None: {command}"
@@ -683,8 +687,7 @@ def run_command(command: list[AnyPath]) -> int:
     if os.environ.get("XDG_CURRENT_DESKTOP") == "gamescope":
         # Primary xwayland server on the Steam Deck
         d_primary = display.Display(":0")
-        # Root window of the primary xwayland server
-        root_primary: Window = d_primary.screen().root
+        root_primary = d_primary.screen().root
         gamescope_baselayer_sequence = get_gamescope_baselayer_order(d_primary)
 
     # Dont do window fuckery if we're not inside gamescope
@@ -692,7 +695,7 @@ def run_command(command: list[AnyPath]) -> int:
         "winetricks"
     ):
         d_secondary = display.Display(":1")
-        root_secondary: Window = d_secondary.screen().root
+        root_secondary = d_secondary.screen().root
         window_client_list: list[str] = []
 
         root_secondary.change_attributes(event_mask=X.SubstructureNotifyMask)

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -449,7 +449,9 @@ def get_window_client_ids(d: display.Display) -> list[str]:
 
         if event.type == X.CreateNotify:
             log.debug("Found new child windows")
-            return [child.id for child in root.query_tree().children]
+            return [
+                child.id for child in d.screen().root.query_tree().children
+            ]
     except Exception as e:
         log.exception(e)
 
@@ -489,13 +491,11 @@ def set_steam_game_property(  # noqa: D103
 
 def get_gamescope_baselayer_order(d: display.Display) -> list[int] | None:  # noqa: D103
     try:
-        root: Window = d.screen().root
-
         # Intern the atom for GAMESCOPECTRL_BASELAYER_APPID
         atom = d.get_atom("GAMESCOPECTRL_BASELAYER_APPID")
 
         # Get the property value
-        prop = root.get_full_property(atom, Xatom.CARDINAL)
+        prop = d.screen().root.get_full_property(atom, Xatom.CARDINAL)
 
         if prop:
             # Extract and return the value
@@ -533,7 +533,7 @@ def set_gamescope_baselayer_order(  # noqa
         atom = d.get_atom("GAMESCOPECTRL_BASELAYER_APPID")
 
         # Set the property value
-        root_primary.change_property(atom, Xatom.CARDINAL, 32, rearranged)
+        d.screen().root.change_property(atom, Xatom.CARDINAL, 32, rearranged)
         log.debug(
             "Successfully set GAMESCOPECTRL_BASELAYER_APPID property: %s",
             ", ".join(map(str, rearranged)),

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -628,7 +628,6 @@ def monitor_windows(
         if not current_window_list:
             continue
 
-        log.debug("Current windows: %s", current_window_list)
         if current_window_list != window_client_list:
             log.debug("New window sequence detected")
             set_steam_game_property(

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -547,11 +547,9 @@ def window_setup(  # noqa
     d_primary: display.Display,
     d_secondary: display.Display,
     root_primary: Window,
-    root_secondary: Window,
     gamescope_baselayer_sequence: list[int],
+    game_window_ids: list[str],
 ) -> None:
-    game_window_ids: list[str] = []
-
     if gamescope_baselayer_sequence:
         # Rearrange the sequence
         rearranged_sequence, steam_assigned_layer_id = (
@@ -559,14 +557,10 @@ def window_setup(  # noqa
         )
 
         # Assign our window a STEAM_GAME id
-        while not game_window_ids:
-            game_window_ids = get_window_client_ids(
-                d_secondary, root_secondary
-            )
-
         set_steam_game_property(
             d_secondary, game_window_ids, steam_assigned_layer_id
         )
+
         set_gamescope_baselayer_order(
             d_primary, root_primary, rearranged_sequence
         )
@@ -713,8 +707,8 @@ def run_command(command: list[AnyPath]) -> int:
             d_primary,
             d_secondary,
             root_primary,
-            root_secondary,
             gamescope_baselayer_sequence,
+            window_client_list,
         )
 
         # Monitor the windows

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -460,26 +460,21 @@ def get_window_client_ids(d: display.Display) -> list[str]:
 
 
 def set_steam_game_property(  # noqa: D103
-    window_ids: list[str], steam_assigned_layer_id: int
+    d: display.Display, window_ids: list[str], steam_assigned_layer_id: int
 ) -> None:
-    d = display.Display(":1")
     try:
-        root = d.screen().root
-        log.debug("Root: %s", root)
-
+        log.debug("steam_layer: %s", steam_assigned_layer_id)
         for window_id in window_ids:
             log.debug("window_id: %s", window_id)
-            log.debug("steam_layer: %s", steam_assigned_layer_id)
             try:
-                window = d.create_resource_object("window", int(window_id))
-                window.get_full_property(
-                    d.intern_atom("STEAM_GAME"), Xatom.CARDINAL
+                window: Window = d.create_resource_object(
+                    "window", int(window_id)
                 )
                 window.change_property(
-                    d.intern_atom("STEAM_GAME"),
+                    d.get_atom("STEAM_GAME"),
                     Xatom.CARDINAL,
                     32,
-                    [int(steam_assigned_layer_id)],
+                    [steam_assigned_layer_id],
                 )
                 log.debug(
                     "Successfully set STEAM_GAME property for window ID: %s",
@@ -493,8 +488,6 @@ def set_steam_game_property(  # noqa: D103
                 log.exception(e)
     except Exception as e:
         log.exception(e)
-    finally:
-        d.close()
 
 
 def get_gamescope_baselayer_order() -> list[int] | None:  # noqa: D103

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -528,13 +528,14 @@ def rearrange_gamescope_baselayer_order(  # noqa
     return rearranged, rearranged[1]
 
 
-def set_gamescope_baselayer_order(rearranged: list[int]) -> None:  # noqa
+def set_gamescope_baselayer_order(  # noqa
+    d: display.Display, rearranged: list[int]
+) -> None:
     try:
-        d = display.Display(":0")
-        root = d.screen().root
+        root: Window = d.screen().root
 
         # Intern the atom for GAMESCOPECTRL_BASELAYER_APPID
-        atom = d.intern_atom("GAMESCOPECTRL_BASELAYER_APPID")
+        atom = d.get_atom("GAMESCOPECTRL_BASELAYER_APPID")
 
         # Set the property value
         root.change_property(atom, Xatom.CARDINAL, 32, rearranged)
@@ -545,8 +546,6 @@ def set_gamescope_baselayer_order(rearranged: list[int]) -> None:  # noqa
     except Exception as e:
         log.error("Error setting GAMESCOPECTRL_BASELAYER_APPID property")
         log.exception(e)
-    finally:
-        d.close()
 
 
 def window_setup(gamescope_baselayer_sequence: list[int]) -> None:  # noqa

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -444,7 +444,6 @@ def build_command(
 def get_window_client_ids(d: display.Display) -> list[str]:
     """Get the list of new client windows under the root window."""
     try:
-        log.debug("Waiting for new child windows")
         event: AnyEvent = d.next_event()
 
         if event.type == X.CreateNotify:

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -598,6 +598,7 @@ def monitor_baselayer(
                 set_gamescope_baselayer_order(
                     d_primary, root_primary, rearranged
                 )
+                continue
 
         time.sleep(0.1)
 

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -548,18 +548,27 @@ def set_gamescope_baselayer_order(  # noqa
         log.exception(e)
 
 
-def window_setup(gamescope_baselayer_sequence: list[int]) -> None:  # noqa
+def window_setup(  # noqa
+    d_primary: display.Display,
+    d_secondary: display.Display,
+    gamescope_baselayer_sequence: list[int],
+) -> None:
+    game_window_ids: list[str] = []
+
     if gamescope_baselayer_sequence:
         # Rearrange the sequence
         rearranged_sequence, steam_assigned_layer_id = (
             rearrange_gamescope_baselayer_order(gamescope_baselayer_sequence)
         )
-        # Assign our window a STEAM_GAME id
-        game_window_ids = get_window_client_ids()
-        if game_window_ids:
-            set_steam_game_property(game_window_ids, steam_assigned_layer_id)
 
-        set_gamescope_baselayer_order(rearranged_sequence)
+        # Assign our window a STEAM_GAME id
+        while not game_window_ids:
+            game_window_ids = get_window_client_ids(d_primary)
+
+        set_steam_game_property(
+            d_primary, game_window_ids, steam_assigned_layer_id
+        )
+        set_gamescope_baselayer_order(d_secondary, rearranged_sequence)
 
 
 def monitor_baselayer(

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -490,13 +490,12 @@ def set_steam_game_property(  # noqa: D103
         log.exception(e)
 
 
-def get_gamescope_baselayer_order() -> list[int] | None:  # noqa: D103
-    d = display.Display(":0")
+def get_gamescope_baselayer_order(d: display.Display) -> list[int] | None:  # noqa: D103
     try:
-        root = d.screen().root
+        root: Window = d.screen().root
 
         # Intern the atom for GAMESCOPECTRL_BASELAYER_APPID
-        atom = d.intern_atom("GAMESCOPECTRL_BASELAYER_APPID")
+        atom = d.get_atom("GAMESCOPECTRL_BASELAYER_APPID")
 
         # Get the property value
         prop = root.get_full_property(atom, Xatom.CARDINAL)
@@ -508,8 +507,6 @@ def get_gamescope_baselayer_order() -> list[int] | None:  # noqa: D103
     except Exception as e:
         log.error("Error getting GAMESCOPECTRL_BASELAYER_APPID property")
         log.exception(e)
-    finally:
-        d.close()
 
     return None
 
@@ -524,6 +521,8 @@ def rearrange_gamescope_baselayer_order(  # noqa
 
     # Rearrange the sequence
     rearranged = [sequence[0], sequence[3], sequence[1], sequence[2]]
+    log.debug("Rearranging base layer sequence")
+    log.debug("'%s' -> '%s'", sequence, rearranged)
 
     # Return the rearranged sequence and the second element
     return rearranged, rearranged[1]

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -642,9 +642,9 @@ def run_command(command: list[AnyPath]) -> int:
     d_secondary: display.Display | None = None
     # GAMESCOPECTRL_BASELAYER_APPID value on the primary's window
     gamescope_baselayer_sequence: list[int] | None = None
-    # Root window of the primary xwayland server
+    # Root window of the primary display
     root_primary: Window
-    # Root window of the client application
+    # Root window of the client application's display
     root_secondary: Window
 
     if not command:
@@ -711,7 +711,7 @@ def run_command(command: list[AnyPath]) -> int:
             window_client_list,
         )
 
-        # Monitor the windows
+        # Monitor for new windows
         window_thread = threading.Thread(
             target=monitor_windows,
             args=(
@@ -724,7 +724,7 @@ def run_command(command: list[AnyPath]) -> int:
         window_thread.daemon = True
         window_thread.start()
 
-        # Monitor the baselayer
+        # Monitor for broken baselayers
         baselayer_thread = threading.Thread(
             target=monitor_baselayer,
             args=(

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -617,6 +617,7 @@ def monitor_windows(
     while True:
         # Check if the window sequence has changed
         current_window_list = get_window_client_ids(d_secondary)
+        log.debug("Current windows: %s", current_window_list)
         if current_window_list != window_client_list:
             log.debug("New window sequence detected")
             set_steam_game_property(

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -745,8 +745,8 @@ def run_command(command: list[AnyPath]) -> int:
     try:
         ret = proc.wait()
         log.debug("Child %s exited with wait status: %s", proc.pid, ret)
-    except KeyboardInterrupt as e:
-        raise e
+    except KeyboardInterrupt:
+        raise
     finally:
         if d_primary:
             d_primary.close()

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -587,13 +587,7 @@ def monitor_baselayer(
             log.debug("Property value for atom '%s': %s", atom, prop.value)
             if prop.value == gamescope_baselayer_sequence:
                 log.debug("Broken base layer sequence detected")
-                log.debug("Rearranging base layer sequence")
-                rearranged = [
-                    prop.value[0],
-                    prop.value[3],
-                    prop.value[1],
-                    prop.value[2],
-                ]
+                rearranged, _ = rearrange_gamescope_baselayer_order(prop.value)
                 log.debug("'%s' -> '%s'", prop.value, rearranged)
                 set_gamescope_baselayer_order(d_primary, rearranged)
                 continue


### PR DESCRIPTION
Refactors the window setup a bit to speed up the window setup process by creating separate threads to monitor for broken layer sequences and newly created child windows under each display. Should result in lower the latency, making the game window display faster.

Property setting on child windows and fixing the base layer order would occur in parallel instead serially where one would block the other. Moreover, other improvements were made such as referring to the atom cache whenever possible and minimizing/reusing Xlib objects created throughout the whole window setup process.