### PR TITLE
Move handling of umu_version.json to pyproject.toml

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -22,9 +22,9 @@ FLATPAK ?= xfalse
 
 .PHONY: all
 ifeq ($(FLATPAK), xtrue)
-all: version umu umu-launcher
+all: umu umu-launcher
 else
-all: version umu umu-docs umu-launcher
+all: umu umu-docs umu-launcher
 endif
 
 .PHONY: install
@@ -44,22 +44,6 @@ fix_shebangs:
 	find $(DESTDIR) -type f -name "umu-run" -exec sed -i '1s|^#!/usr/bin/env python\b|#!/usr/bin/env $(PYTHON_INTERPRETER)|' {} \;
 	find $(DESTDIR) -type f -name "*.sh" -exec sed -i '1s|^#!/usr/bin/env sh|#!$(SHELL_INTERPRETER)|' {} \;
 	find $(DESTDIR) -type f -name "umu-run" -exec sed -i '1s|^#!/usr/bin/env sh|#!$(SHELL_INTERPRETER)|' {} \;
-
-# Special case, do this inside the source directory for release distribution
-umu/umu_version.json: umu/umu_version.json.in
-	$(info :: Updating $(@) )
-	cp $(<) $(<).tmp
-	sed 's|##UMU_VERSION##|$(shell git describe --always --long --tags)|g' -i $(<).tmp
-	mv $(<).tmp $(@)
-
-.PHONY: version
-version: umu/umu_version.json
-
-version-install: version
-	$(info :: Installing umu_version.json )
-	install -d $(DESTDIR)$(PYTHONDIR)/$(INSTALLDIR)
-	install -Dm 644 umu/umu_version.json -t $(DESTDIR)$(PYTHONDIR)/$(INSTALLDIR)
-
 
 $(OBJDIR)/.build-umu-docs: | $(OBJDIR)
 	$(info :: Building umu man pages )
@@ -92,9 +76,9 @@ umu-dist-install: umu-dist
 	$(PYTHON_INTERPRETER)  -m installer --destdir=$(DESTDIR) $(OBJDIR)/*.whl
 
 ifeq ($(FLATPAK), xtrue)
-umu-install: version-install umu-dist-install
+umu-install: umu-dist-install
 else
-umu-install: version-install umu-dist-install umu-docs-install
+umu-install: umu-dist-install umu-docs-install
 endif
 
 ifeq ($(FLATPAK), xtrue)
@@ -154,7 +138,7 @@ $(RELEASEDIR):
 	mkdir -p $(@)
 
 .PHONY: release
-release: $(RELEASEDIR) | version
+release: $(RELEASEDIR)
 	$(info :: Creating source distribution for release )
 	mkdir -p $(<)
 	rm -rf umu/__pycache__

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
 
 [project]
@@ -42,7 +42,20 @@ dependencies = ["python-xlib>=0.33"]
 umu-run = "umu.__main__:main"
 
 [tool.hatch.version]
-path = "umu/__init__.py"
+source = "vcs"
+fallback-version = "0.0.1"
+
+[tool.hatch.build.hooks.vcs]
+version-file = "umu/umu_version.json"
+template = '''{{
+  "umu": {{
+    "versions": {{
+      "launcher": "{version}",
+      "runner": "{version}",
+      "runtime_platform": "sniper"
+    }}
+  }}
+}}'''
 
 [tool.hatch.build.targets.sdist]
 exclude = [
@@ -63,6 +76,9 @@ exclude = [
   "/umu/umu-run.in",
   "/umu/umu_test.py",
   "/umu/umu_test_plugins.py",
+]
+artifacts = [
+  "umu/umu_version.json",
 ]
 
 [tool.mypy]

--- a/umu/umu_version.json.in
+++ b/umu/umu_version.json.in
@@ -1,9 +1,0 @@
-{
-  "umu": {
-    "versions": {
-      "launcher": "##UMU_VERSION##",
-      "runner": "##UMU_VERSION##",
-      "runtime_platform": "sniper"
-    }
-  }
-}


### PR DESCRIPTION
New build dependency: hatch vcs

Removed the version* targets from the Makefile.

The generated version is more convoluted than before though: `"launcher": "0.1rc5.dev234+g9cbd15d.d20240719"`
