### PR TITLE
Fix base layer rearrangement in Steam beta

### DIFF
--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -593,22 +593,24 @@ def monitor_windows(
     window_client_list: list[str],
 ) -> None:
     """Monitor for new windows and assign them Steam's layer ID."""
+    window_client_set: set[str] = set(window_client_list)
     steam_assigned_layer_id: int = gamescope_baselayer_sequence[-1]
 
     log.debug("Monitoring windows")
 
     while True:
         # Check if the window sequence has changed
-        current_window_list = get_window_client_ids(d_secondary)
+        current_window_list: list[str] = get_window_client_ids(d_secondary)
 
         if not current_window_list:
             continue
 
-        if current_window_list != window_client_list:
+        if diff := window_client_set.symmetric_difference(
+            set(current_window_list)
+        ):
             log.debug("New windows detected")
-            set_steam_game_property(
-                d_secondary, current_window_list, steam_assigned_layer_id
-            )
+            window_client_set |= diff
+            set_steam_game_property(d_secondary, diff, steam_assigned_layer_id)
 
 
 def run_command(command: list[AnyPath]) -> int:

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -513,24 +513,11 @@ def rearrange_gamescope_baselayer_order(
     sequence: list[int],
 ) -> tuple[list[int], int]:
     """Rearrange a gamescope base layer sequence retrieved from a window."""
-    seq_len = len(sequence)
+    rearranged: list[int] = [sequence[0], sequence[-1], *sequence[1:-1]]
+    log.debug("Rearranging base layer sequence")
+    log.debug("'%s' -> '%s'", sequence, rearranged)
 
-    if seq_len == 3:
-        rearranged = [sequence[0], sequence[2], sequence[1]]
-        log.debug("Rearranging 3 element base layer sequence")
-        log.debug("'%s' -> '%s'", sequence, rearranged)
-        return rearranged, rearranged[1]
-
-    if seq_len == 4:
-        # Rearrange the sequence
-        rearranged = [sequence[0], sequence[3], sequence[1], sequence[2]]
-        log.debug("Rearranging 4 element base layer sequence")
-        log.debug("'%s' -> '%s'", sequence, rearranged)
-        # Return the rearranged sequence and the second element
-        return rearranged, rearranged[1]
-
-    err = f"Unexpected number of elements in sequence: {sequence}"
-    raise ValueError(err)
+    return rearranged, rearranged[1]
 
 
 def set_gamescope_baselayer_order(

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -591,26 +591,25 @@ def monitor_baselayer(
 def monitor_windows(
     d_secondary: display.Display,
     gamescope_baselayer_sequence: list[int],
-    window_client_list: list[str],
+    game_window_ids: set[str],
 ) -> None:
     """Monitor for new windows and assign them Steam's layer ID."""
-    window_client_set: set[str] = set(window_client_list)
+    window_ids: set[str] = game_window_ids.copy()
     steam_assigned_layer_id: int = gamescope_baselayer_sequence[-1]
 
     log.debug("Monitoring windows")
 
+    # Check if the window sequence has changed
     while True:
-        # Check if the window sequence has changed
-        current_window_list: set[str] | None = get_window_client_ids(
+        current_window_ids: set[str] | None = get_window_client_ids(
             d_secondary
         )
 
-        if not current_window_list:
+        if not current_window_ids:
             continue
 
-        if diff := window_client_set.symmetric_difference(current_window_list):
-            log.debug("New windows detected")
-            window_client_set |= diff
+        if diff := window_ids.symmetric_difference(current_window_ids):
+            window_ids |= diff
             set_steam_game_property(d_secondary, diff, steam_assigned_layer_id)
 
 

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -458,7 +458,9 @@ def get_window_client_ids(d: display.Display) -> list[str]:
 
 
 def set_steam_game_property(
-    d: display.Display, window_ids: list[str], steam_assigned_layer_id: int
+    d: display.Display,
+    window_ids: list[str] | set[str],
+    steam_assigned_layer_id: int,
 ) -> None:
     """Set Steam's assigned layer ID on a list of windows."""
     try:

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -447,7 +447,6 @@ def get_window_client_ids(d: display.Display) -> set[str] | None:
         event: AnyEvent = d.next_event()
 
         if event.type == X.CreateNotify:
-            log.debug("Found new child windows")
             return {
                 child.id for child in d.screen().root.query_tree().children
             }
@@ -609,6 +608,7 @@ def monitor_windows(
             continue
 
         if diff := window_ids.symmetric_difference(current_window_ids):
+            log.debug("New windows detected")
             window_ids |= diff
             set_steam_game_property(d_secondary, diff, steam_assigned_layer_id)
 

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -515,7 +515,6 @@ def rearrange_gamescope_baselayer_order(
     """Rearrange a gamescope base layer sequence retrieved from a window."""
     seq_len = len(sequence)
 
-    # Ensure there are exactly 4 numbers
     if seq_len == 3:
         rearranged = [sequence[0], sequence[2], sequence[1]]
         log.debug("Rearranging 3 element base layer sequence")

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -466,7 +466,6 @@ def set_steam_game_property(
     try:
         log.debug("steam_layer: %s", steam_assigned_layer_id)
         for window_id in window_ids:
-            log.debug("window_id: %s", window_id)
             try:
                 window: Window = d.create_resource_object(
                     "window", int(window_id)

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -513,18 +513,25 @@ def rearrange_gamescope_baselayer_order(
     sequence: list[int],
 ) -> tuple[list[int], int]:
     """Rearrange a gamescope base layer sequence retrieved from a window."""
+    seq_len = len(sequence)
+
     # Ensure there are exactly 4 numbers
-    if len(sequence) != 4:
-        err = "Unexpected number of elements in sequence"
-        raise ValueError(err)
+    if seq_len == 3:
+        rearranged = [sequence[0], sequence[2], sequence[1]]
+        log.debug("Rearranging 3 element base layer sequence")
+        log.debug("'%s' -> '%s'", sequence, rearranged)
+        return rearranged, rearranged[1]
 
-    # Rearrange the sequence
-    rearranged = [sequence[0], sequence[3], sequence[1], sequence[2]]
-    log.debug("Rearranging base layer sequence")
-    log.debug("'%s' -> '%s'", sequence, rearranged)
+    if seq_len == 4:
+        # Rearrange the sequence
+        rearranged = [sequence[0], sequence[3], sequence[1], sequence[2]]
+        log.debug("Rearranging 4 element base layer sequence")
+        log.debug("'%s' -> '%s'", sequence, rearranged)
+        # Return the rearranged sequence and the second element
+        return rearranged, rearranged[1]
 
-    # Return the rearranged sequence and the second element
-    return rearranged, rearranged[1]
+    err = f"Unexpected number of elements in sequence: {sequence}"
+    raise ValueError(err)
 
 
 def set_gamescope_baselayer_order(


### PR DESCRIPTION
In the Steam client beta 07/19 release, umu's gamescope window setup routine would fail when using the umu Flatpak because the window property GAMESCOPECTRL_BASELAYER_APPID was no longer a 4 element sequence. As a result, a ValueError would be raised, making the game window not appear in the foreground again.

This PR fixes the problem by always rearranging the base layer sequence in a way that assumes a variable length. It also makes it so the launcher does not redundantly set Steam's assigned layer ID for windows that already had it set.