### PR TITLE
Allow skipping runtime updates

### DIFF
--- a/docs/umu.1.scd
+++ b/docs/umu.1.scd
@@ -164,7 +164,7 @@ _UMU_ZENITY_
 	Optional. Creates a *zenity*[5] popup window when downloading large files.
 
 _UMU_RUNTIME_UPDATE_
-	Optional. Disables automatic updates to the Steam Runtime platform.
+	Optional. Disables automatic updates to the *Steam Linux Runtime*[6].
 
 	Set _0_ to disable updates.
 

--- a/docs/umu.1.scd
+++ b/docs/umu.1.scd
@@ -163,6 +163,11 @@ _PROTON_VERB_
 _UMU_ZENITY_
 	Optional. Creates a *zenity*[5] popup window when downloading large files.
 
+_UMU_RUNTIME_UPDATE_
+	Optional. Disables automatic updates to the Steam Runtime platform.
+
+	Set _0_ to disable updates.
+
 # SEE ALSO
 
 _umu_(5), _winetricks_(1), _zenity_(1)

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -315,6 +315,7 @@ def set_env(
 
     # Runtime
     env["UMU_NO_RUNTIME"] = os.environ.get("UMU_NO_RUNTIME") or ""
+    env["UMU_RUNTIME_UPDATE"] = os.environ.get("UMU_RUNTIME_UPDATE") or ""
 
     return env
 
@@ -750,6 +751,7 @@ def main() -> int:  # noqa: D103
         "ULWGL_ID": "",
         "UMU_ZENITY": "",
         "UMU_NO_RUNTIME": "",
+        "UMU_RUNTIME_UPDATE": "",
     }
     command: list[AnyPath] = []
     opts: list[str] = []

--- a/umu/umu_runtime.py
+++ b/umu/umu_runtime.py
@@ -184,11 +184,11 @@ def setup_umu(
         _install_umu(json, thread_pool)
         return
 
-    find_obsolete()
-
     if os.environ.get("UMU_RUNTIME_UPDATE") == "0":
         log.debug("Runtime Platform updates disabled")
         return
+
+    find_obsolete()
 
     _update_umu(local, json, thread_pool)
 

--- a/umu/umu_runtime.py
+++ b/umu/umu_runtime.py
@@ -147,12 +147,10 @@ def _install_umu(
         log.debug("Destination: %s", UMU_LOCAL)
 
         # Move each file to the destination directory, overwriting if it exists
-        futures.extend(
-            [
-                thread_pool.submit(_move, file, source_dir, UMU_LOCAL)
-                for file in source_dir.glob("*")
-            ]
-        )
+        futures.extend([
+            thread_pool.submit(_move, file, source_dir, UMU_LOCAL)
+            for file in source_dir.glob("*")
+        ])
 
         # Remove the archive
         futures.append(thread_pool.submit(tmp.joinpath(archive).unlink, True))
@@ -187,6 +185,11 @@ def setup_umu(
         return
 
     find_obsolete()
+
+    if os.environ.get("UMU_RUNTIME_UPDATE") == "0":
+        log.debug("Runtime Platform updates disabled")
+        return
+
     _update_umu(local, json, thread_pool)
 
 

--- a/umu/umu_test.py
+++ b/umu/umu_test.py
@@ -51,6 +51,7 @@ class TestGameLauncher(unittest.TestCase):
             "LD_PRELOAD": "",
             "WINETRICKS_SUPER_QUIET": "",
             "UMU_NO_RUNTIME": "",
+            "UMU_RUNTIME_UPDATE": "",
         }
         self.user = getpwuid(os.getuid()).pw_name
         self.test_opts = "-foo -bar"
@@ -243,7 +244,6 @@ class TestGameLauncher(unittest.TestCase):
                 umu_run, "get_gamescope_baselayer_order", return_value=None
             ),
         ):
-            # TODO: Mock the call
             umu_run.run_command(mock_command)
             proc.assert_called_once()
 
@@ -1865,6 +1865,7 @@ class TestGameLauncher(unittest.TestCase):
             os.environ["GAMEID"] = test_str
             os.environ["STORE"] = test_str
             os.environ["PROTON_VERB"] = self.test_verb
+            os.environ["UMU_RUNTIME_UPDATE"] = "0"
             # Args
             result = umu_run.parse_args()
             # Check
@@ -1964,6 +1965,13 @@ class TestGameLauncher(unittest.TestCase):
                 self.env["STEAM_COMPAT_MOUNTS"],
                 self.env["STEAM_COMPAT_TOOL_PATHS"],
                 "Expected STEAM_COMPAT_MOUNTS to be set",
+            )
+
+            # Runtime
+            self.assertEqual(
+                os.environ.get("UMU_RUNTIME_UPDATE"),
+                self.env["UMU_RUNTIME_UPDATE"],
+                "Expected UMU_RUNTIME_UPDATE to be '0'",
             )
 
     def test_set_env_winetricks(self):


### PR DESCRIPTION
Closes https://github.com/Open-Wine-Components/umu-launcher/issues/134

Each launch, umu will automatically update the Steam Runtime to the latest public beta. This is good, however, there are instances this behavior should be disabled. For instance, when a client wants to run winetricks verbs, they will need to run `GAMEID=foo ... umu-run winetricks ...` but when a new runtime update gets pushed, the client will be blocked by the runtime update process before running the winetricks verbs. 

For cases like the above, runtime updates should be disabled by setting `UMU_RUNTIME_UPDATE=0`.
