### PR TITLE
fix: ensure no symbolic links in STEAM_RUNTIME_LIBRARY_PATH

### DIFF
--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -366,7 +366,7 @@ def enable_steam_game_drive(env: dict[str, str]) -> dict[str, str]:
         return env
 
     # Set the shared library paths of the system after finding libc.so
-    set_steamrt_paths(steamrt_path_candidates, paths)
+    set_steamrt_paths(steamrt_path_candidates, paths, libc)
 
     env["STEAM_RUNTIME_LIBRARY_PATH"] = ":".join(paths)
 
@@ -376,10 +376,9 @@ def enable_steam_game_drive(env: dict[str, str]) -> dict[str, str]:
 def set_steamrt_paths(
     steamrt_path_candidiates: tuple[str],
     steamrt_paths: set[str],
+    libc: str,
 ) -> set[str]:
     """Set the shared library paths for the Steam Runtime."""
-    libc: str = get_libc()
-
     for rtpath in steamrt_path_candidiates:
         if (libc_path := Path(rtpath, libc).resolve()).is_file():
             steamrt_paths.add(str(libc_path.parent))

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -329,7 +329,7 @@ def enable_steam_game_drive(env: dict[str, str]) -> dict[str, str]:
     # All library paths that are currently supported by the container framework
     # See https://gitlab.steamos.cloud/steamrt/steam-runtime-tools/-/blob/main/docs/distro-assumptions.md#filesystem-layout
     # Non-FHS filesystems should run in a FHS chroot to comply
-    steamrt_path_candidates: tuple[str] = (
+    steamrt_path_candidates: tuple[str, ...] = (
         "/usr/lib64",
         "/usr/lib32",
         "/usr/lib",
@@ -374,7 +374,7 @@ def enable_steam_game_drive(env: dict[str, str]) -> dict[str, str]:
 
 
 def set_steamrt_paths(
-    steamrt_path_candidiates: tuple[str],
+    steamrt_path_candidiates: tuple[str, ...],
     steamrt_paths: set[str],
     libc: str,
 ) -> set[str]:

--- a/umu/umu_test.py
+++ b/umu/umu_test.py
@@ -1363,7 +1363,9 @@ class TestGameLauncher(unittest.TestCase):
         self.assertTrue(str1 in libpaths, f"Expected a path in: {libpaths}")
         self.assertTrue(str2 in libpaths, f"Expected a path in: {libpaths}")
 
-        # Ensure there are no symbolic links
+        # Ensure that umu sets the resolved shared library paths. The only time
+        # this variable will contain links is from the LD_LIBRARY_PATH set in
+        # the user's environment or client
         for path in self.env["STEAM_RUNTIME_LIBRARY_PATH"].split(":"):
             if Path(path).is_symlink():
                 err = f"Symbolic link found: {path}"

--- a/umu/umu_test.py
+++ b/umu/umu_test.py
@@ -241,7 +241,6 @@ class TestGameLauncher(unittest.TestCase):
         result = umu_run.set_steamrt_paths(
             steamrt_path_candidates, set(), libc
         )
-        print(f"result: {result}")
 
         # Ensure the resolved shared library paths is not the unresolved paths
         self.assertNotEqual(
@@ -1363,6 +1362,12 @@ class TestGameLauncher(unittest.TestCase):
         str1, str2 = self.env["STEAM_RUNTIME_LIBRARY_PATH"].split(":")
         self.assertTrue(str1 in libpaths, f"Expected a path in: {libpaths}")
         self.assertTrue(str2 in libpaths, f"Expected a path in: {libpaths}")
+
+        # Ensure there are no symbolic links
+        for path in self.env["STEAM_RUNTIME_LIBRARY_PATH"].split(":"):
+            if Path(path).is_symlink():
+                err = f"Symbolic link found: {path}"
+                raise AssertionError(err)
 
         # Both of these values should be empty still after calling
         # enable_steam_game_drive


### PR DESCRIPTION
Commit https://github.com/Open-Wine-Components/umu-launcher/commit/db063a02caaaea1ad8ed7ce1133c028c18d47fa2 fixed a bug for environments with a `/usr/lib/i386-linux-gnu` path not being included in `STEAM_RUNTIME_LIBRARY_PATH`. Since then, umu will set both the resolved and unresolved shared library paths of the system to that environment variable.

This PR makes it so umu will only set the resolved shared library paths for `STEAM_RUNTIME_LIBRARY_PATH` so it  matches the behavior of Steam, which invokes `/sbin/ldconfig -XNv` and parses the result for the resolved paths.