### PR TITLE
fix: do not shadow python built-ins

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -171,7 +171,9 @@ lint.select = [
     # Sort imports
     "I",
     # Ensure we're smart when using list comprehensions
-    "C4"
+    "C4",
+    # Ensure we do not shadow any Python built-in functionality
+    "A"
 ]
 lint.ignore = [
     # Format

--- a/umu/umu_proton.py
+++ b/umu/umu_proton.py
@@ -128,15 +128,19 @@ def _fetch_proton(
     assets: tuple[tuple[str, str], tuple[str, str]],
 ) -> dict[str, str]:
     """Download the latest UMU-Proton or GE-Proton."""
-    proton_hash, hash_url = assets[0]
+    proton_hash, proton_hash_url = assets[0]
     tarball, tar_url = assets[1]
     proton: str = tarball.removesuffix(".tar.gz")
     ret: int = 0  # Exit code from zenity
     digest: str = ""  # Digest of the Proton archive
 
     # Verify the scheme from Github for resources
-    if not tar_url.startswith("https:") or not hash_url.startswith("https:"):
-        err: str = f"Scheme in URLs is not 'https:': {(tar_url, hash_url)}"
+    if not tar_url.startswith("https:") or not proton_hash_url.startswith(
+        "https:"
+    ):
+        err: str = (
+            f"Scheme in URLs is not 'https:': {(tar_url, proton_hash_url)}"
+        )
         raise ValueError(err)
 
     # Digest file
@@ -144,7 +148,7 @@ def _fetch_proton(
     # See https://github.com/astral-sh/ruff/issues/7918
     log.console(f"Downloading {proton_hash}...")
     with (
-        urlopen(hash_url, context=ssl_default_context) as resp,  # noqa: S310
+        urlopen(proton_hash_url, context=ssl_default_context) as resp,  # noqa: S310
     ):
         if resp.status != 200:
             err: str = (

--- a/umu/umu_proton.py
+++ b/umu/umu_proton.py
@@ -128,7 +128,7 @@ def _fetch_proton(
     assets: tuple[tuple[str, str], tuple[str, str]],
 ) -> dict[str, str]:
     """Download the latest UMU-Proton or GE-Proton."""
-    hash, hash_url = assets[0]
+    proton_hash, hash_url = assets[0]
     tarball, tar_url = assets[1]
     proton: str = tarball.removesuffix(".tar.gz")
     ret: int = 0  # Exit code from zenity
@@ -142,13 +142,13 @@ def _fetch_proton(
     # Digest file
     # Since the URLs are not hardcoded links, Ruff will flag the urlopen call
     # See https://github.com/astral-sh/ruff/issues/7918
-    log.console(f"Downloading {hash}...")
+    log.console(f"Downloading {proton_hash}...")
     with (
         urlopen(hash_url, context=ssl_default_context) as resp,  # noqa: S310
     ):
         if resp.status != 200:
             err: str = (
-                f"Unable to download {hash}\n"
+                f"Unable to download {proton_hash}\n"
                 f"github.com returned the status: {resp.status}"
             )
             raise HTTPException(err)
@@ -160,7 +160,7 @@ def _fetch_proton(
     # Proton
     # Create a popup with zenity when the env var is set
     if os.environ.get("UMU_ZENITY") == "1":
-        bin: str = "curl"
+        curl: str = "curl"
         opts: list[str] = [
             "-LJO",
             "--silent",
@@ -169,7 +169,7 @@ def _fetch_proton(
             str(tmp),
         ]
         msg: str = f"Downloading {proton}..."
-        ret = run_zenity(bin, opts, msg)
+        ret = run_zenity(curl, opts, msg)
 
     if ret:
         tmp.joinpath(tarball).unlink(missing_ok=True)

--- a/umu/umu_runtime.py
+++ b/umu/umu_runtime.py
@@ -75,7 +75,7 @@ def _install_umu(
             f"/steamrt-images-{codename}"
             "/snapshots/latest-container-runtime-public-beta"
         )
-        sha_hash = sha256()
+        hashsum = sha256()
 
         # Get the digest for the runtime archive
         client_session.request("GET", f"{endpoint}/SHA256SUMS")
@@ -111,10 +111,10 @@ def _install_umu(
             view: memoryview = memoryview(buffer)
             while size := resp.readinto(buffer):
                 file.write(view[:size])
-                sha_hash.update(view[:size])
+                hashsum.update(view[:size])
 
         # Verify the runtime digest
-        if sha_hash.hexdigest() != digest:
+        if hashsum.hexdigest() != digest:
             err: str = f"Digest mismatched: {archive}"
             client_session.close()
             raise ValueError(err)

--- a/umu/umu_runtime.py
+++ b/umu/umu_runtime.py
@@ -52,7 +52,7 @@ def _install_umu(
 
     # Download the runtime and optionally create a popup with zenity
     if os.environ.get("UMU_ZENITY") == "1":
-        bin: str = "curl"
+        curl: str = "curl"
         opts: list[str] = [
             "-LJ",
             "--silent",
@@ -62,7 +62,7 @@ def _install_umu(
             str(tmp),
         ]
         msg: str = "Downloading umu runtime, please wait..."
-        ret = run_zenity(bin, opts, msg)
+        ret = run_zenity(curl, opts, msg)
 
     # Handle the exit code from zenity
     if ret:
@@ -75,7 +75,7 @@ def _install_umu(
             f"/steamrt-images-{codename}"
             "/snapshots/latest-container-runtime-public-beta"
         )
-        hash = sha256()
+        sha_hash = sha256()
 
         # Get the digest for the runtime archive
         client_session.request("GET", f"{endpoint}/SHA256SUMS")
@@ -111,10 +111,10 @@ def _install_umu(
             view: memoryview = memoryview(buffer)
             while size := resp.readinto(buffer):
                 file.write(view[:size])
-                hash.update(view[:size])
+                sha_hash.update(view[:size])
 
         # Verify the runtime digest
-        if hash.hexdigest() != digest:
+        if sha_hash.hexdigest() != digest:
             err: str = f"Digest mismatched: {archive}"
             client_session.close()
             raise ValueError(err)

--- a/umu/umu_util.py
+++ b/umu/umu_util.py
@@ -1,7 +1,8 @@
 from ctypes.util import find_library
 from functools import lru_cache
 from pathlib import Path
-from re import Pattern, compile
+from re import Pattern
+from re import compile as re_compile
 from shutil import which
 from subprocess import PIPE, STDOUT, Popen, TimeoutExpired
 
@@ -20,11 +21,11 @@ def run_zenity(command: str, opts: list[str], msg: str) -> int:
 
     Intended to be used for long running operations (e.g. large file downloads)
     """
-    bin: str = which("zenity") or ""
+    zenity: str = which("zenity") or ""
     cmd: str = which(command) or ""
     ret: int = 0  # Exit code returned from zenity
 
-    if not bin:
+    if not zenity:
         log.warning("zenity was not found in system")
         return -1
 
@@ -42,7 +43,7 @@ def run_zenity(command: str, opts: list[str], msg: str) -> int:
     ):
         with Popen(
             [
-                f"{bin}",
+                f"{zenity}",
                 "--progress",
                 "--auto-close",
                 f"--text={msg}",
@@ -117,7 +118,7 @@ def is_winetricks_verb(
         return False
 
     # When passed a sequence, check each verb and log the non-verbs
-    regex = compile(pattern)
+    regex = re_compile(pattern)
     for verb in verbs:
         if not regex.match(verb):
             err: str = f"Value is not a winetricks verb: '{verb}'"


### PR DESCRIPTION
Fixes cases where built-ins such as `hash` or `bin` are shadowed and updates pyproject.toml to enforce not shadowing built-ins in ruff in the CI.
