### PR TITLE
fix: detect gamescope displays before performing window setup

### DIFF
--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -48,7 +48,7 @@ from umu.umu_runtime import setup_umu
 from umu.umu_util import (
     get_libc,
     is_installed_verb,
-    is_steamos,
+    get_osrelease_id,
     is_winetricks_verb,
 )
 
@@ -742,7 +742,10 @@ def run_command(command: list[AnyPath]) -> int:
     # game window brought to the foreground due to the base layer being out of
     # order. Ensure we're in a steamos gamescope session before fixing them
     # See https://github.com/ValveSoftware/gamescope/issues/1341
-    if is_steamos() and os.environ.get("XDG_CURRENT_DESKTOP") == "gamescope":
+    if (
+        get_osrelease_id() == "steamos"
+        and os.environ.get("XDG_CURRENT_DESKTOP") == "gamescope"
+    ):
         log.debug("SteamOS gamescope session detected")
         # Currently, steamos creates two xwayland servers at :0 and :1
         # Despite the socket for display :0 being hidden at /tmp/.x11-unix in

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -642,9 +642,7 @@ def monitor_windows(
 
 def discover_gamescope_displays() -> list[display.Display]:
     """Find all gamescope displays."""
-    sockets: list[Path] = [
-        path for path in Path("/tmp/.X11-unix").glob("*") if path.is_socket()
-    ]
+    sockets: list[Path] = list(Path("/tmp/.X11-unix").glob("*"))
     displays: list[display.Display] = []
 
     for sock in sockets:

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -47,8 +47,8 @@ from umu.umu_proton import get_umu_proton
 from umu.umu_runtime import setup_umu
 from umu.umu_util import (
     get_libc,
-    is_installed_verb,
     get_osrelease_id,
+    is_installed_verb,
     is_winetricks_verb,
 )
 

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -703,7 +703,6 @@ def run_command(command: list[AnyPath]) -> int:
     d_secondary: display.Display | None = None
     # GAMESCOPECTRL_BASELAYER_APPID value on the primary's window
     gamescope_baselayer_sequence: list[int] | None = None
-    gamescope_displays: list[display.Display] = []
 
     if not command:
         err: str = f"Command list is empty or None: {command}"

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -743,7 +743,7 @@ def run_command(command: list[AnyPath]) -> int:
     # game window brought to the foreground due to the base layer being out of
     # order. Ensure we're in a steamos gamescope session fixing them
     # See https://github.com/ValveSoftware/gamescope/issues/1341
-    if is_steamos() and os.environ.get("XDG_CURRENT_DESKTOP") == "gamescope":
+    if os.environ.get("XDG_CURRENT_DESKTOP") == "gamescope":
         log.debug("SteamOS gamescope session detected")
         gamescope_displays = discover_gamescope_displays()
         d_primary = get_gamescope_xwayland_primary(gamescope_displays)

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -640,56 +640,6 @@ def monitor_windows(
             set_steam_game_property(d_secondary, diff, steam_assigned_layer_id)
 
 
-def discover_gamescope_displays() -> list[display.Display]:
-    """Find all gamescope displays."""
-    sockets: list[Path] = list(Path("/tmp/.X11-unix").glob("*"))
-    displays: list[display.Display] = []
-
-    for sock in sockets:
-        log.debug("Socket: %s", sock)
-        display_no = f":{sock.name.removeprefix('X')}"
-
-        try:
-            d: display.Display = display.Display(display_no)
-        except Exception as e:
-            log.exception(e)
-            continue
-
-        if (
-            d.get_atom(
-                "GAMESCOPE_CURSOR_VISIBLE_FEEDBACK", only_if_exists=True
-            )
-            != X.NONE
-        ):
-            log.debug("Gamescope display found: %s", d.get_display_name())
-            displays.append(d)
-            continue
-
-        d.close()
-
-    return displays
-
-
-def get_gamescope_xwayland_primary(
-    gamescope_displays: list[display.Display],
-) -> display.Display | None:
-    """Get the primary gamescope xwayland server."""
-    if not gamescope_displays:
-        return None
-
-    for d in gamescope_displays:
-        if (
-            d.get_atom("GAMESCOPE_FOCUSED_WINDOW", only_if_exists=True)
-            != X.NONE
-        ):
-            log.debug(
-                "Primary gamescope display found: %s", d.get_display_name()
-            )
-            return d
-
-    return None
-
-
 def run_command(command: list[AnyPath]) -> int:
     """Run the executable using Proton within the Steam Runtime."""
     prctl: CFuncPtr

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -630,6 +630,57 @@ def monitor_windows(
             set_steam_game_property(d_secondary, diff, steam_assigned_layer_id)
 
 
+def discover_gamescope_displays() -> list[display.Display]:
+    """Find all gamescope displays."""
+    sockets: list[Path] = [
+        path for path in Path("/tmp/.X11-unix").glob("*") if path.is_socket()
+    ]
+    displays: list[display.Display] = []
+
+    for sock in sockets:
+        display_no = f":{sock.name.removeprefix('X')}"
+
+        try:
+            d: display.Display = display.Display(display_no)
+        except Exception as e:
+            log.exception(e)
+            continue
+
+        if (
+            d.get_atom(
+                "GAMESCOPE_CURSOR_VISIBLE_FEEDBACK", only_if_exists=True
+            )
+            != X.NONE
+        ):
+            log.debug("Gamescope display found: %s", d.get_display_name())
+            displays.append(d)
+            continue
+
+        d.close()
+
+    return displays
+
+
+def get_gamescope_xwayland_primary(
+    gamescope_displays: list[display.Display],
+) -> display.Display | None:
+    """Get the primary gamescope xwayland server."""
+    if not gamescope_displays:
+        return None
+
+    for d in gamescope_displays:
+        if (
+            d.get_atom("GAMESCOPE_FOCUSED_WINDOW", only_if_exists=True)
+            != X.NONE
+        ):
+            log.debug(
+                "Primary gamescope display found: %s", d.get_display_name()
+            )
+            return d
+
+    return None
+
+
 def run_command(command: list[AnyPath]) -> int:
     """Run the executable using Proton within the Steam Runtime."""
     prctl: CFuncPtr

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -744,11 +744,14 @@ def run_command(command: list[AnyPath]) -> int:
     # See https://github.com/ValveSoftware/gamescope/issues/1341
     if is_steamos() and os.environ.get("XDG_CURRENT_DESKTOP") == "gamescope":
         log.debug("SteamOS gamescope session detected")
+        # Currently, steamos creates two xwayland servers at :0 and :1
+        # Despite the socket for display :0 being hidden at /tmp/.x11-unix in
+        # the Flatpak, it is still possible to connect to it.
         d_primary = display.Display(":0")
         gamescope_baselayer_sequence = get_gamescope_baselayer_order(d_primary)
 
-    # Currently, steamos creates two xwayland servers
-    # Ensure that there are exactly two before connecting to the second display
+    # Connect to the display associated with the game
+    # Display :1 will be visible in the Flatpak
     if d_primary and os.environ.get("STEAM_MULTIPLE_XWAYLANDS") == "1":
         d_secondary = display.Display(":1")
 

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -507,12 +507,9 @@ def set_steam_game_property(
 
 
 def get_gamescope_baselayer_order(
-    d: display.Display | None,
+    d: display.Display,
 ) -> list[int] | None:
     """Get the gamescope base layer seq on the primary root window."""
-    if not d:
-        return None
-
     try:
         root_primary: Window = d.screen().root
 

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -740,7 +740,7 @@ def run_command(command: list[AnyPath]) -> int:
 
     # Currently, Flatpak apps that use umu as their runtime will not have their
     # game window brought to the foreground due to the base layer being out of
-    # order. Ensure we're in a steamos gamescope session fixing them
+    # order. Ensure we're in a steamos gamescope session before fixing them
     # See https://github.com/ValveSoftware/gamescope/issues/1341
     if is_steamos() and os.environ.get("XDG_CURRENT_DESKTOP") == "gamescope":
         log.debug("SteamOS gamescope session detected")

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -742,25 +742,15 @@ def run_command(command: list[AnyPath]) -> int:
     # game window brought to the foreground due to the base layer being out of
     # order. Ensure we're in a steamos gamescope session fixing them
     # See https://github.com/ValveSoftware/gamescope/issues/1341
-    if os.environ.get("XDG_CURRENT_DESKTOP") == "gamescope":
+    if is_steamos() and os.environ.get("XDG_CURRENT_DESKTOP") == "gamescope":
         log.debug("SteamOS gamescope session detected")
-        gamescope_displays = discover_gamescope_displays()
-        log.debug("Gamescope displays: %s", gamescope_displays)
-        d_primary = get_gamescope_xwayland_primary(gamescope_displays)
-        log.debug("Gamescope primary display: %s", d_primary)
+        d_primary = display.Display(":0")
         gamescope_baselayer_sequence = get_gamescope_baselayer_order(d_primary)
 
     # Currently, steamos creates two xwayland servers
     # Ensure that there are exactly two before connecting to the second display
-    if (
-        d_primary
-        and os.environ.get("STEAM_MULTIPLE_XWAYLANDS") == "1"
-        and gamescope_displays
-        and len(gamescope_displays) == 2
-    ):
-        d_secondary = next(
-            (d for d in gamescope_displays if d != d_primary), None
-        )
+    if d_primary and os.environ.get("STEAM_MULTIPLE_XWAYLANDS") == "1":
+        d_secondary = display.Display(":1")
 
     # Dont do window fuckery if we're not inside gamescope
     if (

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -648,6 +648,7 @@ def discover_gamescope_displays() -> list[display.Display]:
     displays: list[display.Display] = []
 
     for sock in sockets:
+        log.debug("Socket: %s", sock)
         display_no = f":{sock.name.removeprefix('X')}"
 
         try:
@@ -746,7 +747,9 @@ def run_command(command: list[AnyPath]) -> int:
     if os.environ.get("XDG_CURRENT_DESKTOP") == "gamescope":
         log.debug("SteamOS gamescope session detected")
         gamescope_displays = discover_gamescope_displays()
+        log.debug("Gamescope displays: %s", gamescope_displays)
         d_primary = get_gamescope_xwayland_primary(gamescope_displays)
+        log.debug("Gamescope primary display: %s", d_primary)
         gamescope_baselayer_sequence = get_gamescope_baselayer_order(d_primary)
 
     # Currently, steamos creates two xwayland servers

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -804,8 +804,10 @@ def run_command(command: list[AnyPath]) -> int:
     except KeyboardInterrupt:
         raise
     finally:
-        for d in gamescope_displays:
-            d.close()
+        if d_primary:
+            d_primary.close()
+        if d_secondary:
+            d_secondary.close()
 
     return ret
 

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -506,8 +506,13 @@ def set_steam_game_property(
             log.exception(e)
 
 
-def get_gamescope_baselayer_order(d: display.Display) -> list[int] | None:
+def get_gamescope_baselayer_order(
+    d: display.Display | None,
+) -> list[int] | None:
     """Get the gamescope base layer seq on the primary root window."""
+    if not d:
+        return None
+
     try:
         root_primary: Window = d.screen().root
 

--- a/umu/umu_util.py
+++ b/umu/umu_util.py
@@ -179,6 +179,7 @@ def get_osrelease_id() -> str:
         for line in file:
             if line.startswith("ID="):
                 osid = line.removeprefix("ID=").strip()
+                log.debug("os-release: ID=%s", osid)
                 break
 
     return osid

--- a/umu/umu_util.py
+++ b/umu/umu_util.py
@@ -158,3 +158,16 @@ def find_obsolete() -> None:
     # $HOME/.local/share
     if (ulwgl := home.joinpath(".local", "share", "ULWGL")).is_dir():
         log.warning("'%s' is obsolete", ulwgl)
+
+
+def is_steamos() -> bool:
+    """Check if the current OS is steamos."""
+    release: Path = Path("/etc/os-release")
+
+    if not release.is_file():
+        log.debug("File '%s' could not be found", release)
+        log.debug("Will assume OS is not steamos")
+        return False
+
+    with release.open(mode="r", encoding="utf-8") as file:
+        return any(line.startswith("ID=steamos") for line in file)

--- a/umu/umu_util.py
+++ b/umu/umu_util.py
@@ -1,3 +1,4 @@
+import os
 from ctypes.util import find_library
 from functools import lru_cache
 from pathlib import Path
@@ -162,7 +163,12 @@ def find_obsolete() -> None:
 
 def is_steamos() -> bool:
     """Check if the current OS is steamos."""
-    release: Path = Path("/etc/os-release")
+    release: Path
+
+    if os.environ.get("container") == "flatpak":  # noqa: SIM112
+        release = Path("/run/host/os-release")
+    else:
+        release = Path("/etc/os-release")
 
     if not release.is_file():
         log.debug("File '%s' could not be found", release)

--- a/umu/umu_util.py
+++ b/umu/umu_util.py
@@ -162,7 +162,7 @@ def find_obsolete() -> None:
 
 
 def get_osrelease_id() -> str:
-    """Get the identity of the OS."""
+    """Get the identity of the host OS."""
     release: Path
     osid: str = ""
 

--- a/umu/umu_util.py
+++ b/umu/umu_util.py
@@ -161,9 +161,10 @@ def find_obsolete() -> None:
         log.warning("'%s' is obsolete", ulwgl)
 
 
-def is_steamos() -> bool:
-    """Check if the current OS is steamos."""
+def get_osrelease_id() -> str:
+    """Get the identity of the OS."""
     release: Path
+    osid: str = ""
 
     if os.environ.get("container") == "flatpak":  # noqa: SIM112
         release = Path("/run/host/os-release")
@@ -172,8 +173,12 @@ def is_steamos() -> bool:
 
     if not release.is_file():
         log.debug("File '%s' could not be found", release)
-        log.debug("Will assume OS is not steamos")
-        return False
+        return osid
 
     with release.open(mode="r", encoding="utf-8") as file:
-        return any(line.startswith("ID=steamos") for line in file)
+        for line in file:
+            if line.startswith("ID="):
+                osid = line.removeprefix("ID=").strip()
+                break
+
+    return osid

--- a/umu/umu_util.py
+++ b/umu/umu_util.py
@@ -179,7 +179,7 @@ def get_osrelease_id() -> str:
         for line in file:
             if line.startswith("ID="):
                 osid = line.removeprefix("ID=").strip()
-                log.debug("os-release: ID=%s", osid)
+                log.debug("OS: %s", osid)
                 break
 
     return osid

--- a/umu/umu_util.py
+++ b/umu/umu_util.py
@@ -166,6 +166,8 @@ def get_osrelease_id() -> str:
     release: Path
     osid: str = ""
 
+    # Flatpak follows the Container Interface outlined by systemd
+    # See https://systemd.io/CONTAINER_INTERFACE
     if os.environ.get("container") == "flatpak":  # noqa: SIM112
         release = Path("/run/host/os-release")
     else:


### PR DESCRIPTION
Closes https://github.com/Open-Wine-Components/umu-launcher/issues/169

Limits the scope of the window setup logic to SteamOS gamescope sessions instead of gamescope sessions.

TODO:

- [x] Sanity check on the Steam Deck
