### PR TITLE
refactor: detect flatpak via container interface guidelines

### DIFF
--- a/umu/umu_consts.py
+++ b/umu/umu_consts.py
@@ -36,7 +36,7 @@ PROTON_VERBS = {
 }
 
 # Installation path of the runtime files
-# Flatpak will be detected via the Container Interface outlined by systemd
+# Flatpak will be detected as outlined by systemd
 # See https://systemd.io/CONTAINER_INTERFACE
 UMU_LOCAL: Path = (
     Path.home().joinpath(
@@ -45,6 +45,7 @@ UMU_LOCAL: Path = (
     if os.environ.get("container") == "flatpak"  # noqa: SIM112
     else Path.home().joinpath(".local", "share", "umu")
 )
+
 # Constant defined in prctl.h
 # See prctl(2) for more details
 PR_SET_CHILD_SUBREAPER = 36

--- a/umu/umu_consts.py
+++ b/umu/umu_consts.py
@@ -45,6 +45,6 @@ UMU_LOCAL: Path = (
     if os.environ.get("container") == "flatpak"  # noqa: SIM112
     else Path.home().joinpath(".local", "share", "umu")
 )
-# Constants defined in prctl.h
+# Constant defined in prctl.h
 # See prctl(2) for more details
 PR_SET_CHILD_SUBREAPER = 36

--- a/umu/umu_consts.py
+++ b/umu/umu_consts.py
@@ -35,20 +35,16 @@ PROTON_VERBS = {
     "getnativepath",
 }
 
-FLATPAK_ID = os.environ.get("FLATPAK_ID") or ""
-
-FLATPAK_PATH: Path | None = (
+# Installation path of the runtime files
+# Flatpak will be detected via the Container Interface outlined by systemd
+# See https://systemd.io/CONTAINER_INTERFACE
+UMU_LOCAL: Path = (
     Path.home().joinpath(
         ".var", "app", "org.openwinecomponents.umu.umu-launcher", "data", "umu"
     )
-    if FLATPAK_ID
-    else None
+    if os.environ.get("container") == "flatpak"  # noqa: SIM112
+    else Path.home().joinpath(".local", "share", "umu")
 )
-
-UMU_LOCAL: Path = FLATPAK_PATH or Path.home().joinpath(
-    ".local", "share", "umu"
-)
-
 # Constants defined in prctl.h
 # See prctl(2) for more details
 PR_SET_CHILD_SUBREAPER = 36

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -34,8 +34,6 @@ from Xlib.xobject.drawable import Window
 
 from umu.umu_consts import (
     DEBUG_FORMAT,
-    FLATPAK_ID,
-    FLATPAK_PATH,
     PR_SET_CHILD_SUBREAPER,
     PROTON_VERBS,
     STEAM_COMPAT,
@@ -664,8 +662,8 @@ def run_command(command: list[AnyPath]) -> int:
     else:
         cwd = Path.cwd()
 
-    # Create a subprocess but do not set it as subreaper
-    if FLATPAK_PATH or not libc:
+    if os.environ.get("container") == "flatpak" or not libc:  # noqa: SIM112
+        # Create a subprocess but do not set it as subreaper
         proc = Popen(command, start_new_session=True, cwd=cwd)
     else:
         prctl = CDLL(libc).prctl

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -809,11 +809,6 @@ def main() -> int:  # noqa: D103
 
     log.debug("Arguments: %s", args)
 
-    if FLATPAK_PATH and root.is_relative_to("/app"):
-        log.debug("Flatpak environment detected")
-        log.debug("FLATPAK_ID: %s", FLATPAK_ID)
-        log.debug("Runtime path: %s", FLATPAK_PATH)
-
     # Setup the launcher and runtime files
     # An internet connection is required for new setups
     try:


### PR DESCRIPTION
Updates the Flatpak detection logic to conform with systemd's container interface guidelines, which Flatpak and Pressure Vessel conform to (as well as Docker or Podman if I am not mistaken).

See https://systemd.io/CONTAINER_INTERFACE/ 
