### PR TITLE
build: make rule to generate standalone python zipapp application

### DIFF
--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -21,6 +21,7 @@ jobs:
     - name: Initialize submodules
       run: |
         git submodule update --init --recursive
+        git fetch --prune --unshallow
     - name: Lint using Shellcheck
       run: |
         shellcheck configure.sh
@@ -30,7 +31,8 @@ jobs:
         sudo make PREFIX=/usr install
     - name: Make release
       run: |
-        make release
+        # TODO: Figure out release without requiring root
+        sudo make release
     - name: Make user install
       run: |
         ./configure.sh --user-install

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -15,13 +15,14 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
     - name: Install dependencies
       run: |
         sudo apt-get install meson shellcheck scdoc python3-hatchling python3-build python3-installer python3-filelock
     - name: Initialize submodules
       run: |
         git submodule update --init --recursive
-        git fetch --prune --unshallow
     - name: Lint using Shellcheck
       run: |
         shellcheck configure.sh

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -31,3 +31,7 @@ jobs:
     - name: Make release
       run: |
         make release
+    - name: Make user install
+      run: |
+        ./configure.sh --user-install
+        make install

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Make system package
       run: |
         ./configure.sh --prefix=/usr
-        sudo make PREFIX=/usr install
+        make DESTDIR=dist install
     - name: Make release
       run: |
         # TODO: Figure out release without requiring root

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -34,4 +34,5 @@ jobs:
     - name: Make user install
       run: |
         ./configure.sh --user-install
-        make install
+        # TODO: Figure out user install without requiring root
+        sudo make install

--- a/Makefile.in
+++ b/Makefile.in
@@ -179,4 +179,14 @@ user-install:
 	$(info :: To run you need to make sure "$(BINDIR)" is in your PATH )
 
 
+ZIPAPP := $(OBJDIR)/umu-run-$(shell git describe --always --long --tags)
+ZIPAPP_STAGING := $(OBJDIR)/umu-run_staging
+
+.PHONY: zipapp
+zipapp: version | $(OBJDIR)
+	@$(PYTHON_INTERPRETER) -m pip install -t "$(ZIPAPP_STAGING)" --upgrade .
+	cp umu/umu_version.json "$(ZIPAPP_STAGING)"/umu
+	@$(PYTHON_INTERPRETER) -m zipapp $(ZIPAPP_STAGING) -m "umu.__main__:main" -o $(ZIPAPP) -p "$(PYTHON_INTERPRETER)" -c
+	@echo "Standalone application created: $(ZIPAPP))"
+
 # vim: ft=make

--- a/Makefile.in
+++ b/Makefile.in
@@ -187,6 +187,7 @@ $(OBJDIR)/.build-zipapp: | $(OBJDIR)
 	cp umu/__main__.py "$(ZIPAPP_STAGING)"
 	# Make zipapp reproducible
 	find "$(ZIPAPP_STAGING)" -exec touch -h -d "$(SOURCE_DATE_EPOCH)" {} +
+	touch -d "$(SOURCE_DATE_EPOCH)" $(ZIPAPP)
 	touch $(@)
 
 .PHONY: zipapp-install
@@ -194,8 +195,6 @@ build-zipapp: $(OBJDIR)/.build-zipapp
 
 zipapp-install: build-zipapp
 	$(info :: Installing umu-launcher as zipapp )
-	$(PYTHON_INTERPRETER) -m zipapp $(ZIPAPP_STAGING) -o $(ZIPAPP) -p "$(PYTHON_INTERPRETER)" -c
-	touch -d "$(SOURCE_DATE_EPOCH)" $(ZIPAPP)
 	install -d $(DESTDIR)$(PREFIX)/bin
 	install -Dm755 $(ZIPAPP) $(DESTDIR)$(PREFIX)/bin/$(ZIPAPP)
 	@echo "Standalone application created: $(ZIPAPP))"

--- a/Makefile.in
+++ b/Makefile.in
@@ -195,7 +195,7 @@ zipapp: $(OBJDIR)/.build-zipapp
 zipapp-install: zipapp
 	$(info :: Installing umu-launcher as zipapp )
 	install -d $(DESTDIR)$(PREFIX)/bin
-	install -Dm755 $(ZIPAPP) $(DESTDIR)$(PREFIX)/bin/$(ZIPAPP)
-	@echo "Standalone application created: $(ZIPAPP))"
+	install -Dm755 $(ZIPAPP) $(DESTDIR)$(PREFIX)/bin
+	@echo "Standalone application 'umu-run' created at '$(DESTDIR)$(PREFIX)/bin'"
 
 # vim: ft=make

--- a/Makefile.in
+++ b/Makefile.in
@@ -176,7 +176,7 @@ uninstall:
 	@rm -rf -v --preserve-root=all $(DESTDIR)$(DATADIR)/$(INSTALLDIR)
 
 
-ZIPAPP := $(OBJDIR)/umu-run-$(shell git describe --always --long --tags)
+ZIPAPP := $(OBJDIR)/umu-run
 ZIPAPP_STAGING := $(OBJDIR)/umu-run_staging
 
 $(OBJDIR)/.build-zipapp: | $(OBJDIR)

--- a/Makefile.in
+++ b/Makefile.in
@@ -185,7 +185,6 @@ $(OBJDIR)/.build-zipapp: | $(OBJDIR) version
 	. $(ZIPAPP_VENV)/bin/activate && python3 -m pip install -t "$(ZIPAPP_STAGING)" -U --no-compile .
 	install -Dm644 umu/umu_version.json "$(ZIPAPP_STAGING)"/umu/umu_version.json
 	cp umu/__main__.py "$(ZIPAPP_STAGING)"
-	# Make zipapp reproducible
 	find "$(ZIPAPP_STAGING)" -exec touch -h -d "$(SOURCE_DATE_EPOCH)" {} +
 	. $(ZIPAPP_VENV)/bin/activate && python3 -m zipapp $(ZIPAPP_STAGING) -o $(ZIPAPP) -p "$(PYTHON_INTERPRETER)" -c
 	touch -d "$(SOURCE_DATE_EPOCH)" $(ZIPAPP)

--- a/Makefile.in
+++ b/Makefile.in
@@ -25,13 +25,15 @@ SOURCE_DATE_EPOCH := $(shell date --date='@1580601600')
 .PHONY: all
 ifeq ($(FLATPAK), xtrue)
 all: version umu umu-launcher
-else
+endif
+
+ifeq ($(USERINSTALL), xfalse)
 all: version umu umu-docs umu-launcher
 endif
 
 .PHONY: install
 ifeq ($(USERINSTALL), xtrue)
-install: umu-install umu-launcher-install user-install fix_shebangs
+install: zipapp-install
 else
 install: umu-install umu-launcher-install fix_shebangs
 endif
@@ -184,16 +186,26 @@ user-install:
 ZIPAPP := $(OBJDIR)/umu-run-$(shell git describe --always --long --tags)
 ZIPAPP_STAGING := $(OBJDIR)/umu-run_staging
 
-.PHONY: zipapp
-zipapp: version | $(OBJDIR)
-	@$(PYTHON_INTERPRETER) -m pip install -t "$(ZIPAPP_STAGING)" -U --no-compile .
+$(OBJDIR)/.build-zipapp: | $(OBJDIR)
+	$(info :: Building umu-launcher as zipapp )
+	$(PYTHON_INTERPRETER) -m pip install -t "$(ZIPAPP_STAGING)" -U --no-compile .
 	cp umu/umu_version.json.in umu/umu_version.json.in.tmp
 	sed 's|##UMU_VERSION##|$(shell git describe --always --long --tags)|g' -i umu/umu_version.json.in.tmp
 	mv umu/umu_version.json.in.tmp "$(ZIPAPP_STAGING)"/umu/umu_version.json
 	cp umu/__main__.py "$(ZIPAPP_STAGING)"
+	# Make zipapp reproducible
 	find "$(ZIPAPP_STAGING)" -exec touch -h -d "$(SOURCE_DATE_EPOCH)" {} +
-	@$(PYTHON_INTERPRETER) -m zipapp $(ZIPAPP_STAGING) -o $(ZIPAPP) -p "$(PYTHON_INTERPRETER)" -c
+	touch $(@)
+
+.PHONY: zipapp-install
+build-zipapp: $(OBJDIR)/.build-zipapp
+
+zipapp-install: build-zipapp
+	$(info :: Installing umu-launcher as zipapp )
+	install -d $(PREFIX)/opt/$(INSTALLDIR)
+	$(PYTHON_INTERPRETER) -m zipapp $(ZIPAPP_STAGING) -o $(ZIPAPP) -p "$(PYTHON_INTERPRETER)" -c
 	touch -d "$(SOURCE_DATE_EPOCH)" $(ZIPAPP)
+	mv $(ZIPAPP) $(PREFIX)/opt/$(INSTALLDIR)/
 	@echo "Standalone application created: $(ZIPAPP))"
 
 # vim: ft=make

--- a/Makefile.in
+++ b/Makefile.in
@@ -171,8 +171,6 @@ release: $(RELEASEDIR) | version zipapp
 uninstall:
 	$(info :: Removing $(INSTALLDIR) files in $(DESTDIR)$(BINDIR) )
 	@rm -rf -v --preserve-root=all $(DESTDIR)$(BINDIR)/umu-run
-	$(info :: Removing $(INSTALLDIR) directory in $(DESTDIR)$(DATADIR) )
-	@rm -rf -v --preserve-root=all $(DESTDIR)$(DATADIR)/$(INSTALLDIR)
 
 
 ZIPAPP := $(OBJDIR)/umu-run

--- a/Makefile.in
+++ b/Makefile.in
@@ -156,12 +156,14 @@ $(RELEASEDIR):
 	mkdir -p $(@)
 
 .PHONY: release
-release: $(RELEASEDIR) | version
+release: $(RELEASEDIR) | version zipapp
 	$(info :: Creating source distribution for release )
 	mkdir -p $(<)
 	rm -rf umu/__pycache__
 	cp -r umu packaging Makefile.in configure.sh README.md LICENSE $(<)
 	tar -cvzf $(<).tar.gz $(<)
+	cp -a $(ZIPAPP) .
+	sha512sum umu-run > umu-run.sha512sum 
 
 
 .PHONY: uninstall

--- a/Makefile.in
+++ b/Makefile.in
@@ -176,13 +176,6 @@ uninstall:
 	@rm -rf -v --preserve-root=all $(DESTDIR)$(DATADIR)/$(INSTALLDIR)
 
 
-.PHONY: user-install
-user-install:
-	$(info :: --- )
-	$(info :: Installed under user-only location "$(DATADIR)/$(INSTALLDIR)" )
-	$(info :: To run you need to make sure "$(BINDIR)" is in your PATH )
-
-
 ZIPAPP := $(OBJDIR)/umu-run-$(shell git describe --always --long --tags)
 ZIPAPP_STAGING := $(OBJDIR)/umu-run_staging
 

--- a/Makefile.in
+++ b/Makefile.in
@@ -20,6 +20,8 @@ DESTDIR ?=
 USERINSTALL ?= xfalse
 FLATPAK ?= xfalse
 
+SOURCE_DATE_EPOCH := $(shell date --date='@1580601600')
+
 .PHONY: all
 ifeq ($(FLATPAK), xtrue)
 all: version umu umu-launcher
@@ -184,9 +186,14 @@ ZIPAPP_STAGING := $(OBJDIR)/umu-run_staging
 
 .PHONY: zipapp
 zipapp: version | $(OBJDIR)
-	@$(PYTHON_INTERPRETER) -m pip install -t "$(ZIPAPP_STAGING)" --upgrade .
-	cp umu/umu_version.json "$(ZIPAPP_STAGING)"/umu
-	@$(PYTHON_INTERPRETER) -m zipapp $(ZIPAPP_STAGING) -m "umu.__main__:main" -o $(ZIPAPP) -p "$(PYTHON_INTERPRETER)" -c
+	@$(PYTHON_INTERPRETER) -m pip install -t "$(ZIPAPP_STAGING)" -U --no-compile .
+	cp umu/umu_version.json.in umu/umu_version.json.in.tmp
+	sed 's|##UMU_VERSION##|$(shell git describe --always --long --tags)|g' -i umu/umu_version.json.in.tmp
+	mv umu/umu_version.json.in.tmp "$(ZIPAPP_STAGING)"/umu/umu_version.json
+	cp umu/__main__.py "$(ZIPAPP_STAGING)"
+	find "$(ZIPAPP_STAGING)" -exec touch -h -d "$(SOURCE_DATE_EPOCH)" {} +
+	@$(PYTHON_INTERPRETER) -m zipapp $(ZIPAPP_STAGING) -o $(ZIPAPP) -p "$(PYTHON_INTERPRETER)" -c
+	touch -d "$(SOURCE_DATE_EPOCH)" $(ZIPAPP)
 	@echo "Standalone application created: $(ZIPAPP))"
 
 # vim: ft=make

--- a/Makefile.in
+++ b/Makefile.in
@@ -20,8 +20,6 @@ DESTDIR ?=
 USERINSTALL ?= xfalse
 FLATPAK ?= xfalse
 
-SOURCE_DATE_EPOCH := $(shell date --date='@1580601600')
-
 .PHONY: all
 ifeq ($(FLATPAK), xtrue)
 all: version umu umu-launcher
@@ -33,6 +31,7 @@ endif
 
 .PHONY: install
 ifeq ($(USERINSTALL), xtrue)
+SOURCE_DATE_EPOCH = $(shell date --date='@1580601600')
 install: zipapp-install
 else
 install: umu-install umu-launcher-install fix_shebangs

--- a/Makefile.in
+++ b/Makefile.in
@@ -195,7 +195,7 @@ zipapp: $(OBJDIR)/.build-zipapp
 zipapp-install: zipapp
 	$(info :: Installing umu-launcher as zipapp )
 	install -d $(DESTDIR)$(PREFIX)/bin
-	install -Dm755 $(ZIPAPP) $(DESTDIR)$(PREFIX)/bin
+	install -Dm755 $(ZIPAPP) $(DESTDIR)$(BINDIR)
 	@echo "Standalone application 'umu-run' created at '$(DESTDIR)$(PREFIX)/bin'"
 
 # vim: ft=make

--- a/Makefile.in
+++ b/Makefile.in
@@ -194,10 +194,10 @@ build-zipapp: $(OBJDIR)/.build-zipapp
 
 zipapp-install: build-zipapp
 	$(info :: Installing umu-launcher as zipapp )
-	install -d $(PREFIX)/opt/$(INSTALLDIR)
 	$(PYTHON_INTERPRETER) -m zipapp $(ZIPAPP_STAGING) -o $(ZIPAPP) -p "$(PYTHON_INTERPRETER)" -c
 	touch -d "$(SOURCE_DATE_EPOCH)" $(ZIPAPP)
-	mv $(ZIPAPP) $(PREFIX)/opt/$(INSTALLDIR)/
+	install -d $(DESTDIR)$(PREFIX)/bin
+	install -Dm755 $(ZIPAPP) $(DESTDIR)$(PREFIX)/bin/$(ZIPAPP)
 	@echo "Standalone application created: $(ZIPAPP))"
 
 # vim: ft=make

--- a/Makefile.in
+++ b/Makefile.in
@@ -163,7 +163,7 @@ release: $(RELEASEDIR) | version zipapp
 	cp -r umu packaging Makefile.in configure.sh README.md LICENSE $(<)
 	tar -cvzf $(<).tar.gz $(<)
 	cp -a $(ZIPAPP) .
-	sha512sum umu-run > umu-run.sha512sum 
+	sha512sum umu-run > umu-run.sha512sum
 
 
 .PHONY: uninstall

--- a/Makefile.in
+++ b/Makefile.in
@@ -22,18 +22,16 @@ FLATPAK ?= xfalse
 
 .PHONY: all
 ifeq ($(FLATPAK), xtrue)
-all: version umu umu-launcher
-endif
-
-ifeq ($(USERINSTALL), xfalse)
-all: version umu umu-docs umu-launcher
+all: umu-dist umu-launcher
 endif
 
 .PHONY: install
 ifeq ($(USERINSTALL), xtrue)
 SOURCE_DATE_EPOCH = $(shell LC_ALL=C date --date='@1580601600')
+all: zipapp
 install: zipapp-install
 else
+all: umu-dist umu-docs umu-launcher
 install: umu-install umu-launcher-install fix_shebangs
 endif
 
@@ -81,7 +79,7 @@ umu-docs-install: umu-docs
 	install -m644 $(OBJDIR)/umu.5 $(DESTDIR)$(MANDIR)/man5/umu.5
 
 
-$(OBJDIR)/.build-umu-dist: | $(OBJDIR)
+$(OBJDIR)/.build-umu-dist: | $(OBJDIR) version
 	$(info :: Building umu )
 	$(PYTHON_INTERPRETER) -m build --wheel --skip-dependency-check --no-isolation --outdir=$(OBJDIR)
 	touch $(@)
@@ -176,24 +174,25 @@ uninstall:
 
 
 ZIPAPP := $(OBJDIR)/umu-run
-ZIPAPP_STAGING := $(OBJDIR)/umu-run_staging
+ZIPAPP_STAGING := $(OBJDIR)/zipapp_staging
+ZIPAPP_VENV := $(OBJDIR)/zipapp_venv
 
-$(OBJDIR)/.build-zipapp: | $(OBJDIR)
+$(OBJDIR)/.build-zipapp: | $(OBJDIR) version
 	$(info :: Building umu-launcher as zipapp )
-	$(PYTHON_INTERPRETER) -m pip install -t "$(ZIPAPP_STAGING)" -U --no-compile .
-	cp umu/umu_version.json.in umu/umu_version.json.in.tmp
-	sed 's|##UMU_VERSION##|$(shell git describe --always --long --tags)|g' -i umu/umu_version.json.in.tmp
-	mv umu/umu_version.json.in.tmp "$(ZIPAPP_STAGING)"/umu/umu_version.json
+	$(PYTHON_INTERPRETER) -m venv $(ZIPAPP_VENV)
+	. $(ZIPAPP_VENV)/bin/activate && python3 -m pip install -t "$(ZIPAPP_STAGING)" -U --no-compile .
+	install -Dm644 umu/umu_version.json "$(ZIPAPP_STAGING)"/umu/umu_version.json
 	cp umu/__main__.py "$(ZIPAPP_STAGING)"
 	# Make zipapp reproducible
 	find "$(ZIPAPP_STAGING)" -exec touch -h -d "$(SOURCE_DATE_EPOCH)" {} +
+	. $(ZIPAPP_VENV)/bin/activate && python3 -m zipapp $(ZIPAPP_STAGING) -o $(ZIPAPP) -p "$(PYTHON_INTERPRETER)" -c
 	touch -d "$(SOURCE_DATE_EPOCH)" $(ZIPAPP)
 	touch $(@)
 
-.PHONY: zipapp-install
-build-zipapp: $(OBJDIR)/.build-zipapp
+.PHONY: zipapp
+zipapp: $(OBJDIR)/.build-zipapp
 
-zipapp-install: build-zipapp
+zipapp-install: zipapp
 	$(info :: Installing umu-launcher as zipapp )
 	install -d $(DESTDIR)$(PREFIX)/bin
 	install -Dm755 $(ZIPAPP) $(DESTDIR)$(PREFIX)/bin/$(ZIPAPP)

--- a/Makefile.in
+++ b/Makefile.in
@@ -31,7 +31,7 @@ endif
 
 .PHONY: install
 ifeq ($(USERINSTALL), xtrue)
-SOURCE_DATE_EPOCH = $(shell date --date='@1580601600')
+SOURCE_DATE_EPOCH = $(shell LC_ALL=C date --date='@1580601600')
 install: zipapp-install
 else
 install: umu-install umu-launcher-install fix_shebangs

--- a/README.md
+++ b/README.md
@@ -75,9 +75,9 @@ Borderlands 3 from EGS store.
 3. In our umu unified database, we create a 'title' column, 'store' column, 'codename' column, 'umu-ID' column. We add a line for Borderlands 3 and fill in the details for each column.
 4. Now the launcher can search 'Catnip' and 'egs' as the codename and store in the database and correlate it with Borderlands 3 and umu-12345. It can then feed umu-12345 to the `umu-run` script.
 
-
 ## Building
-Building umu-launcher currently requires `bash`, `make`, and `scdoc`, as well as the following Python build tools: [build](https://github.com/pypa/build), [hatchling](https://github.com/pypa/hatch), and [installer](https://github.com/pypa/installer).
+
+Building umu-launcher currently requires `bash`, `make`, and `scdoc` for distribution, as well as the following Python build tools: [build](https://github.com/pypa/build), [hatchling](https://github.com/pypa/hatch), and [installer](https://github.com/pypa/installer).
 
 To build umu-launcher, after downloading and extracting the source code from this repository, change into the newly extracted directory
 ```shell
@@ -92,26 +92,36 @@ Change the `--prefix` as fit for your distribution, for example `/usr/local`, or
 
 Then run `make` to build. After a successful build the resulting files should be available in the `./builddir` directory
 
-**Note**: For umu clients, [pip](https://github.com/pypa/pip) is required to build its Python dependencies and they will need to be put within same directory as the runtime directory (e.g., `$HOME/.config/heroic/tools/runtimes/umu`).
 
-To build all dependencies:
-```shell
-make DESTDIR=<packaging_directory> umu-subprojects
-```
+## Installing 
 
-### Installing 
 To install umu-launcher run the following command after completing the steps described above
 ```shell
 make install
 ```
-or if you are packaging umu-launcher
+
+Or if you are packaging umu-launcher
 ```shell
 make DESTDIR=<packaging_directory> install
 ```
 
-**Note**: For umu clients, to install all of its dependencies, run:
+### Installing as user
+
+Additionally, user installations are supported if desired.
+
+First, configure the build for a user installation
 ```shell
-make DESTDIR=<packaging_directory> umu-subprojects-install
+./configure.sh --user-install
+```
+
+Then run `make` install
+```shell
+make install
+```
+
+**Note**: When installing as a user, this will place the executable `umu-run` in `$HOME/.local/bin`. You will need to add `$HOME/.local/bin` in your `$PATH` to be able to run umu-launcher this way by exporting the path in your shell's configuration, for example `$HOME/.bash_profile`
+```shell
+export PATH="$HOME/.local/bin:$PATH"
 ```
 
 ## Packaging

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -10,6 +10,7 @@ from argparse import ArgumentParser, Namespace, RawTextHelpFormatter
 from concurrent.futures import Future, ThreadPoolExecutor
 from ctypes import CDLL, c_int, c_ulong
 from errno import ENETUNREACH
+from importlib.resources.abc import Traversable
 from logging import DEBUG, INFO, WARNING
 from pathlib import Path
 from pwd import getpwuid
@@ -741,11 +742,12 @@ def main() -> int:  # noqa: D103
         "UMU_RUNTIME_UPDATE": "",
     }
     opts: list[str] = []
-    root: Path
+    root: Traversable
+
     try:
         root = Path(__file__).resolve(strict=True).parent
     except NotADirectoryError:
-        # raised when whithin a zipapp. Try again in non-strict mode, root
+        # Raised when within a zipapp. Try again in non-strict mode, root
         # should be zipapp.pyz/umu. Split and set root to /umu within zip.
         root = Path(__file__).resolve().parent
         root = zipfile.Path(root.parent, root.name)

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -10,7 +10,12 @@ from argparse import ArgumentParser, Namespace, RawTextHelpFormatter
 from concurrent.futures import Future, ThreadPoolExecutor
 from ctypes import CDLL, c_int, c_ulong
 from errno import ENETUNREACH
-from importlib.resources.abc import Traversable
+
+try:
+    from importlib.resources.abc import Traversable
+except ModuleNotFoundError:
+    from importlib.abc import Traversable
+
 from logging import DEBUG, INFO, WARNING
 from pathlib import Path
 from pwd import getpwuid

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -742,10 +742,10 @@ def main() -> int:  # noqa: D103
     try:
         root = Path(__file__).resolve(strict=True).parent
     except NotADirectoryError:
-        # Raised when within a zipapp. Try again in non-strict mode, root
-        # should be zipapp.pyz/umu. Split and set root to /umu within zip.
-        root = Path(__file__).resolve().parent
-        root = zipfile.Path(root.parent, root.name)
+        # Raised when within a zipapp. Try again in non-strict mode
+        root = zipfile.Path(
+            Path(__file__).resolve().parent.parent, Path(__file__).parent.name
+        )
 
     if os.geteuid() == 0:
         err: str = "This script should never be run as the root user"

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -4,6 +4,7 @@ import os
 import sys
 import threading
 import time
+import zipfile
 from _ctypes import CFuncPtr
 from argparse import ArgumentParser, Namespace, RawTextHelpFormatter
 from concurrent.futures import Future, ThreadPoolExecutor
@@ -740,7 +741,14 @@ def main() -> int:  # noqa: D103
         "UMU_RUNTIME_UPDATE": "",
     }
     opts: list[str] = []
-    root: Path = Path(__file__).resolve(strict=True).parent
+    root: Path
+    try:
+        root = Path(__file__).resolve(strict=True).parent
+    except NotADirectoryError:
+        # raised when whithin a zipapp. Try again in non-strict mode, root
+        # should be zipapp.pyz/umu. Split and set root to /umu within zip.
+        root = Path(__file__).resolve().parent
+        root = zipfile.Path(root.parent, root.name)
 
     if os.geteuid() == 0:
         err: str = "This script should never be run as the root user"

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -24,16 +24,6 @@ from socket import AF_INET, SOCK_DGRAM, socket
 from subprocess import Popen
 from typing import Any
 
-# Add client's runtime path to PYTHONPATH to find dependencies
-if (this_path := Path(__file__)).is_relative_to(
-    Path.home()
-) and "runtime" in this_path.parent.parent.name:
-    sys.path.append(str(this_path.parent.parent))
-elif this_path.is_relative_to(Path.home()) and os.environ.get(
-    "UMU_CLIENT_RTPATH"
-):
-    sys.path.append(os.environ["UMU_CLIENT_RTPATH"])
-
 from Xlib import X, Xatom, display
 from Xlib.protocol.request import GetProperty
 from Xlib.protocol.rq import Event

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -24,6 +24,16 @@ from socket import AF_INET, SOCK_DGRAM, socket
 from subprocess import Popen
 from typing import Any
 
+# Add client's runtime path to PYTHONPATH to find dependencies
+if (this_path := Path(__file__)).is_relative_to(
+    Path.home()
+) and "runtime" in this_path.parent.parent.name:
+    sys.path.append(str(this_path.parent.parent))
+elif this_path.is_relative_to(Path.home()) and os.environ.get(
+    "UMU_CLIENT_RTPATH"
+):
+    sys.path.append(os.environ["UMU_CLIENT_RTPATH"])
+
 from Xlib import X, Xatom, display
 from Xlib.protocol.request import GetProperty
 from Xlib.protocol.rq import Event

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -25,14 +25,12 @@ from subprocess import Popen
 from typing import Any
 
 # Add client's runtime path to PYTHONPATH to find dependencies
-if (this_path := Path(__file__)).is_relative_to(
-    Path.home()
-) and "runtime" in this_path.parent.parent.name:
-    sys.path.append(str(this_path.parent.parent))
-elif this_path.is_relative_to(Path.home()) and os.environ.get(
-    "UMU_CLIENT_RTPATH"
+# TODO: Remove this after Heroic/Lutris have updated their logic
+if (
+    Path(__file__).is_relative_to(Path.home())
+    and "runtime" in Path(__file__).parent.parent.name
 ):
-    sys.path.append(os.environ["UMU_CLIENT_RTPATH"])
+    sys.path.append(str(Path(__file__).parent.parent))
 
 from Xlib import X, Xatom, display
 from Xlib.protocol.request import GetProperty

--- a/umu/umu_runtime.py
+++ b/umu/umu_runtime.py
@@ -4,6 +4,7 @@ from collections.abc import Callable
 from concurrent.futures import Future, ThreadPoolExecutor
 from hashlib import sha256
 from http.client import HTTPException, HTTPResponse, HTTPSConnection
+from importlib.resources.abc import Traversable
 from json import load
 from pathlib import Path
 from shutil import move, rmtree
@@ -172,12 +173,12 @@ def _install_umu(
 
 
 def setup_umu(
-    root: Path, local: Path, thread_pool: ThreadPoolExecutor
+    root: Traversable, local: Path, thread_pool: ThreadPoolExecutor
 ) -> None:
     """Install or update the runtime for the current user."""
-    json: dict[str, Any] = _get_json(root, CONFIG)
     log.debug("Root: %s", root)
     log.debug("Local: %s", local)
+    json: dict[str, Any] = _get_json(root, CONFIG)
 
     # New install or umu dir is empty
     if not local.exists() or not any(local.iterdir()):
@@ -362,7 +363,7 @@ def _update_umu(
     client_session.close()
 
 
-def _get_json(path: Path, config: str) -> dict[str, Any]:
+def _get_json(path: Traversable, config: str) -> dict[str, Any]:
     """Validate the state of the configuration file umu_version.json in a path.
 
     The configuration file will be used to update the runtime and it reflects

--- a/umu/umu_runtime.py
+++ b/umu/umu_runtime.py
@@ -4,7 +4,12 @@ from collections.abc import Callable
 from concurrent.futures import Future, ThreadPoolExecutor
 from hashlib import sha256
 from http.client import HTTPException, HTTPResponse, HTTPSConnection
-from importlib.resources.abc import Traversable
+
+try:
+    from importlib.resources.abc import Traversable
+except ModuleNotFoundError:
+    from importlib.abc import Traversable
+
 from json import load
 from pathlib import Path
 from shutil import move, rmtree


### PR DESCRIPTION
Supersedes https://github.com/Open-Wine-Components/umu-launcher/pull/149 and closes https://github.com/Open-Wine-Components/umu-launcher/issues/148

Fixes user installs by installing umu-launcher as a reproducible zipapp at `$HOME/.local/bin`. 

Additionally, this feature gives clients another installation option and will come with the advantage of simplifying updates, simplifying client logic, and reducing the likelihood of data corruption.