### PR TITLE
feat: support running native Linux executables within SLR

### DIFF
--- a/docs/umu.1.scd
+++ b/docs/umu.1.scd
@@ -168,6 +168,11 @@ _UMU_RUNTIME_UPDATE_
 
 	Set _0_ to disable updates.
 
+_UMU_NO_RUNTIME_
+	Optional. Runs the executable natively within the Steam Linux Runtime. Intended for native Linux games.
+
+	Set _1_ to run the executable natively within the SLR.
+
 # SEE ALSO
 
 _umu_(5), _winetricks_(1), _zenity_(1)

--- a/docs/umu.1.scd
+++ b/docs/umu.1.scd
@@ -152,6 +152,7 @@ _WINEPREFIX_
 _UMU_LOG_
 	Optional. Enables debug logs for the launcher.
 	
+
 	Set _1_ to log environment variables, _warning_ for warning messages, or _debug_ to enable all logs.
 
 _STORE_
@@ -168,7 +169,7 @@ _UMU_RUNTIME_UPDATE_
 
 	Set _0_ to disable updates.
 
-_UMU_NO_RUNTIME_
+_UMU_NO_PROTON_
 	Optional. Runs the executable natively within the Steam Linux Runtime. Intended for native Linux games.
 
 	Set _1_ to run the executable natively within the SLR.

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -341,12 +341,6 @@ def build_command(
     proton: Path = Path(env["PROTONPATH"], "proton")
     entry_point: Path = local.joinpath("umu")
 
-    # Will run the game w/o Proton, effectively running the game as is. This
-    # option is intended for debugging purposes, and is otherwise useless
-    if env.get("UMU_NO_RUNTIME") == "1":
-        log.warning("Runtime Platform disabled")
-        return env["EXE"], *opts
-
     if not proton.is_file():
         err: str = "The following file was not found in PROTONPATH: proton"
         raise FileNotFoundError(err)
@@ -374,6 +368,19 @@ def build_command(
             env["PROTON_VERB"],
             env["EXE"],
             "-q",
+            *opts,
+        )
+
+    # Will run the game within the Steam Runtime w/o Proton
+    # Ideally, for reliability, executables should be compiled within
+    # the Steam Runtime
+    if env.get("UMU_NO_RUNTIME") == "1":
+        return (
+            entry_point,
+            "--verb",
+            env["PROTON_VERB"],
+            "--",
+            env["EXE"],
             *opts,
         )
 

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -296,6 +296,7 @@ def set_env(
     # Runtime
     env["UMU_NO_RUNTIME"] = os.environ.get("UMU_NO_RUNTIME") or ""
     env["UMU_RUNTIME_UPDATE"] = os.environ.get("UMU_RUNTIME_UPDATE") or ""
+    env["UMU_NO_PROTON"] = os.environ.get("UMU_NO_PROTON") or ""
 
     return env
 
@@ -374,7 +375,7 @@ def build_command(
     # Will run the game within the Steam Runtime w/o Proton
     # Ideally, for reliability, executables should be compiled within
     # the Steam Runtime
-    if env.get("UMU_NO_RUNTIME") == "1":
+    if env.get("UMU_NO_PROTON") == "1":
         return (
             entry_point,
             "--verb",
@@ -778,6 +779,7 @@ def main() -> int:  # noqa: D103
         "UMU_ZENITY": "",
         "UMU_NO_RUNTIME": "",
         "UMU_RUNTIME_UPDATE": "",
+        "UMU_NO_PROTON": "",
     }
     opts: list[str] = []
     prereq: bool = False

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -346,7 +346,7 @@ def build_command(
     proton: Path = Path(env["PROTONPATH"], "proton")
     entry_point: Path = local.joinpath("umu")
 
-    if not proton.is_file():
+    if env.get("UMU_NO_PROTON") != "1" and not proton.is_file():
         err: str = "The following file was not found in PROTONPATH: proton"
         raise FileNotFoundError(err)
 

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -386,7 +386,7 @@ def build_command(
         )
 
     # Will run the game outside the Steam Runtime w/ Proton
-    if env.get("UMU_NO_RUNTIME") == "pressure-vessel":
+    if env.get("UMU_NO_RUNTIME") == "1":
         log.warning("Runtime Platform disabled")
         return proton, env["PROTON_VERB"], env["EXE"], *opts
 

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -166,6 +166,10 @@ def check_env(
 
     env["WINEPREFIX"] = os.environ["WINEPREFIX"]
 
+    # Skip Proton if running a native Linux executable
+    if os.environ.get("UMU_NO_PROTON") == "1":
+        return env
+
     # Proton Version
     if (
         os.environ.get("PROTONPATH")

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -351,10 +351,6 @@ def build_command(
         err: str = "The following file was not found in PROTONPATH: proton"
         raise FileNotFoundError(err)
 
-    if env.get("UMU_NO_RUNTIME") == "pressure-vessel":
-        log.warning("Using Proton without Runtime Platform")
-        return proton, env["PROTON_VERB"], env["EXE"], *opts
-
     # Exit if the entry point is missing
     # The _v2-entry-point script and container framework tools are included in
     # the same image, so this can happen if the image failed to download
@@ -365,11 +361,26 @@ def build_command(
         )
         raise FileNotFoundError(err)
 
-    # Configure winetricks to not be prompted for any windows
+    # Winetricks
     if env.get("EXE", "").endswith("winetricks") and opts:
         # The position of arguments matter for winetricks
         # Usage: ./winetricks [options] [command|verb|path-to-verb] ...
-        opts = ["-q", *opts]
+        return (
+            entry_point,
+            "--verb",
+            env["PROTON_VERB"],
+            "--",
+            proton,
+            env["PROTON_VERB"],
+            env["EXE"],
+            "-q",
+            *opts,
+        )
+
+    # Will run the game outside the Steam Runtime w/ Proton
+    if env.get("UMU_NO_RUNTIME") == "pressure-vessel":
+        log.warning("Runtime Platform disabled")
+        return proton, env["PROTON_VERB"], env["EXE"], *opts
 
     return (
         entry_point,

--- a/umu/umu_test.py
+++ b/umu/umu_test.py
@@ -1200,13 +1200,11 @@ class TestGameLauncher(unittest.TestCase):
             self.env["EXE"], "Expected EXE to be empty on empty string"
         )
 
-    def test_build_command_noruntime(self):
-        """Test build_command when disabling the Steam Runtime.
+    def test_build_command_linux_exe(self):
+        """Test build_command when running a Linux executable.
 
-        UMU_NO_RUNTIME=1 disables the Steam Runtime, which is no different than
-        running the executable directly.
-
-        Expects the list to contain one string element.
+        UMU_NO_PROTON=1 disables Proton, running the executable directly in the
+        Steam Linux Runtime.
         """
         result_args = None
         test_command = []
@@ -1222,7 +1220,7 @@ class TestGameLauncher(unittest.TestCase):
             os.environ["PROTONPATH"] = self.test_file
             os.environ["GAMEID"] = self.test_file
             os.environ["STORE"] = self.test_file
-            os.environ["UMU_NO_RUNTIME"] = "1"
+            os.environ["UMU_NO_PROTON"] = "1"
             # Args
             result_args = umu_run.parse_args()
             # Config
@@ -1231,7 +1229,6 @@ class TestGameLauncher(unittest.TestCase):
             umu_run.setup_pfx(self.env["WINEPREFIX"])
             # Env
             umu_run.set_env(self.env, result_args)
-            self.env["UMU_NO_RUNTIME"] = os.environ["UMU_NO_RUNTIME"]
             # Game drive
             umu_run.enable_steam_game_drive(self.env)
 
@@ -1290,7 +1287,7 @@ class TestGameLauncher(unittest.TestCase):
     def test_build_command_nopv(self):
         """Test build_command when disabling Pressure Vessel.
 
-        UMU_NO_RUNTIME=pressure-vessel disables Pressure Vessel, allowing
+        UMU_NO_RUNTIME=1 disables Pressure Vessel, allowing
         the launcher to run Proton on the host -- Flatpak environment.
 
         Expects the list to contain 3 string elements.
@@ -1309,7 +1306,7 @@ class TestGameLauncher(unittest.TestCase):
             os.environ["PROTONPATH"] = self.test_file
             os.environ["GAMEID"] = self.test_file
             os.environ["STORE"] = self.test_file
-            os.environ["UMU_NO_RUNTIME"] = "pressure-vessel"
+            os.environ["UMU_NO_RUNTIME"] = "1"
             # Args
             result_args = umu_run.parse_args()
             # Config


### PR DESCRIPTION
Currently, we were running every executable through Proton (wine). However, Proton is a mechanism that is intended for running **Windows**  executables in predictable environment, not Linux ones. If the user or the client can determine that the game is a Linux executable and is confident that it can run reliably in the SLR, they can skip the overhead of wine. In the Steam client, users can enable this mechanism by forcing the Steam Linux Runtime (3.0) compatibility tool in their game's properties. As a result, the game will run inside sniper directly.

This feature is useful for games such as Katawa Shoujo which uses RenPy as its engine, hence do not need to be run through wine.

To run native Linux executables in the SLR, set `UMU_NO_PROTON=1`.