### PR TITLE
feat: add gamescope-dbus

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "subprojects/python-xlib"]
 	path = subprojects/python-xlib
 	url = https://github.com/python-xlib/python-xlib.git
+[submodule "subprojects/gamescope-dbus"]
+	path = subprojects/gamescope-dbus
+	url = https://github.com/ShadowBlip/gamescope-dbus.git

--- a/Makefile.in
+++ b/Makefile.in
@@ -148,7 +148,7 @@ $(OBJDIR):
 .PHONY: clean
 clean:
 	$(info :: Cleaning source directory )
-	@rm -rf -v $(OBJDIR) umu/umu_version.json ./$(RELEASEDIR) $(RELEASEDIR).tar.gz
+	@rm -rf -v $(OBJDIR) umu/umu_version.json ./$(RELEASEDIR) $(RELEASEDIR).tar.gz subprojects/gamescope-dbus/target
 
 
 RELEASEDIR := $(PROJECT)-$(shell git describe --abbrev=0)
@@ -196,5 +196,20 @@ zipapp-install: zipapp
 	install -d $(DESTDIR)$(PREFIX)/bin
 	install -Dm755 $(ZIPAPP) $(DESTDIR)$(BINDIR)
 	@echo "Standalone application 'umu-run' created at '$(DESTDIR)$(PREFIX)/bin'"
+
+
+$(OBJDIR)/.build-gamescope-dbus: | $(OBJDIR)
+	$(info :: Building gamescope-dbus )
+	cd subprojects/gamescope-dbus && \
+	cargo update && \
+	make build
+	touch $(@)
+
+.PHONY: gamescope-dbus
+gamescope-dbus: $(OBJDIR)/.build-gamescope-dbus
+
+gamescope-dbus-install: gamescope-dbus
+	$(info :: Installing gamescope-dbus )
+	PREFIX=$(DESTDIR) make -C subprojects/gamescope-dbus install
 
 # vim: ft=make

--- a/systemd/units/gamescope-dbus.service.in
+++ b/systemd/units/gamescope-dbus.service.in
@@ -1,0 +1,59 @@
+[Unit]
+Description=Daemon for interacting with Gamescope over DBus
+
+[Service]
+Type=simple
+ExecStart=gamescope-dbus
+Restart=always
+RestartSec=1
+
+# Filesystem lockdown
+ProtectHome=true
+ProtectSystem=strict
+ProtectKernelTunables=true
+ProtectControlGroups=true
+PrivateTmp=true
+ProtectProc=invisible
+ProcSubset=pid
+UMask=0077
+
+# Privilege escalation
+NoNewPrivileges=true
+RestrictSUIDSGID=true
+
+# Network
+PrivateNetwork=true
+IPAddressDeny=any
+
+# System call interfaces
+SystemCallFilter=@system-service
+SystemCallFilter=~@resources
+SystemCallErrorNumber=EPERM
+SystemCallArchitectures=native
+
+# Kernel
+ProtectKernelLogs=true
+ProtectKernelModules=true
+LockPersonality=true
+
+# Namespaces
+RestrictNamespaces=true
+
+# Service capabilities
+CapabilityBoundingSet=CAP_SYS_ADMIN CAP_CHOWN CAP_SYS_TTY_CONFIG CAP_DAC_OVERRIDE
+RestrictAddressFamilies=AF_UNIX
+RestrictRealtime=true
+MemoryDenyWriteExecute=true
+ProtectClock=true
+ProtectHostname=true
+
+# Devices
+DevicePolicy=strict
+DeviceAllow=char-/dev/console rw
+DeviceAllow=char-drm rw
+DeviceAllow=char-input rw
+DeviceAllow=char-tty rw
+DeviceAllow=/dev/null rw
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
**Note**: Intended to be merged post release.

Adds gamescope-dbus to allow clients to access and change various properties set by gamescope. In particular, this is for clients looking to create their own overlay and/or wanting to modify properties (e.g., FPS) at runtime without restarting the game.

See https://github.com/ShadowBlip/gamescope-dbus?tab=readme-ov-file#documentation to learn more.
