### PR TITLE
feat: check for mismatching compatibility tools

### DIFF
--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -683,12 +683,18 @@ def has_mismatching_compat(
 ) -> tuple[str, str] | tuple[()]:
     """Check if the current Proton is not using its required compat tool.
 
-    Arguments:
-      path_proton: Path to a Proton build containing toolmanifest.vdf in top
-          Path is expected to end with toolmanifest.vdf as the last segment.
+    Args:
+      path_proton: Path to a Proton build containing toolmanifest.vdf in the
+          top level. Path is expected to end with toolmanifest.vdf as the last
+          segment.
       path_runtime: Path to the SLR, the required compatibility tool for
-          Proton. Path is expected to end with the `steampipe` subdirectory
-          where all its *.vdf files will be read.
+          Proton. Path is expected to end with the `steampipe` or similar
+          subdirectory where all its *.vdf files will be read.
+
+    Returns:
+        Tuple of mismatching compatibility tools where [0] is the Proton
+        compatibility tool's name and [1] is the App ID of its required SLR.
+        An empty tuple will be returned if the compatibility tools match.
 
     """
     # App ID of Proton's required compatibility tool -- Steam Linux Runtime

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -689,7 +689,7 @@ def has_mismatching_compat(
           segment.
       path_runtime: Path to the SLR, the required compatibility tool for
           Proton. Path is expected to end with the `steampipe` or similar
-          subdirectory where all its *.vdf files will be read.
+          as the last segment where all its *.vdf files will be read.
 
     Returns:
         Tuple of mismatching compatibility tools where [0] is the Proton

--- a/umu/umu_test.py
+++ b/umu/umu_test.py
@@ -249,6 +249,7 @@ class TestGameLauncher(unittest.TestCase):
             proton_dir.joinpath("toolmanifest.vdf"),
             self.test_local_share.joinpath("steampipe/"),
         )
+        self.assertIsInstance(result, tuple, "Expected a tuple")
         self.assertTrue(
             result,
             "Expected True to be returned for mismatching Proton and SLR",
@@ -265,6 +266,7 @@ class TestGameLauncher(unittest.TestCase):
             self.test_proton_dir.joinpath("toolmanifest.vdf"),
             self.test_local_share.joinpath("steampipe/"),
         )
+        self.assertIsInstance(result, tuple, "Expected a tuple")
         self.assertFalse(
             result,
             "Expected False to be returned for matching Proton and SLR",

--- a/umu/umu_test.py
+++ b/umu/umu_test.py
@@ -269,6 +269,69 @@ class TestGameLauncher(unittest.TestCase):
             result,
             "Expected False to be returned for matching Proton and SLR",
         )
+
+    def test_get_vdf_na(self):
+        """Test get_vdf_value when the toolmanifest.vdf isn't found.
+
+        Expects an empty string to be returned
+        """
+        key = "qux"
+
+        self.test_proton_dir.joinpath("toolmanifest.vdf").unlink()
+        result = umu_util.get_vdf_value(
+            self.test_proton_dir.joinpath("toolmanifest.vdf"), key
+        )
+        self.assertFalse(
+            result, "Expected an empty string when file was not found"
+        )
+
+    def test_get_vdf_binary(self):
+        """Test get_vdf_value when reading binary data.
+
+        Expects an empty string to be returned when reading binary data
+        """
+        key = "baz"
+        data = random.randbytes(16)  # noqa: S311
+        self.test_proton_dir.joinpath("toolmanifest.vdf").write_bytes(data)
+
+        result = umu_util.get_vdf_value(
+            self.test_proton_dir.joinpath("toolmanifest.vdf"), key
+        )
+        self.assertFalse(
+            result, "Expected an empty string when reading binary"
+        )
+
+    def test_get_vdf_value_foo(self):
+        """Test get_vdf_value when a key does not exist.
+
+        Expects an empty string to be returned.
+        """
+        key = "foo"
+        result = umu_util.get_vdf_value(
+            self.test_proton_dir.joinpath("toolmanifest.vdf"), key
+        )
+        expected = ""
+
+        self.assertEqual(
+            result, expected, f"Expected '{expected}', received '{result}'"
+        )
+
+    def test_get_vdf_value(self):
+        """Test get_vdf_value.
+
+        Expects a value to be returned when passed a valid key from reading a
+        non-binary VDF file
+        """
+        key = "require_tool_appid"
+        result = umu_util.get_vdf_value(
+            self.test_proton_dir.joinpath("toolmanifest.vdf"), key
+        )
+        expected = "1628350"
+
+        self.assertEqual(
+            result, expected, f"Expected '{expected}', received '{result}'"
+        )
+
     def test_rearrange_gamescope_baselayer_order_err(self):
         """Test rearrange_gamescope_baselayer_order for unexpected seq."""
         baselayer = []

--- a/umu/umu_util.py
+++ b/umu/umu_util.py
@@ -182,7 +182,7 @@ def get_vdf_value(path: Path, key: str) -> str:
         log.debug("File does not contain .vdf suffix: %s", path.name)
         return value
 
-    log.debug("Reading: %s", path)
+    log.debug("Parsing '%s'...", path)
 
     try:
         # Assumes the input is a VDF file and conforms to the

--- a/umu/umu_util.py
+++ b/umu/umu_util.py
@@ -178,33 +178,34 @@ def get_vdf_value(path: Path, key: str) -> str:
     """Get a value from a specific key in a VDF file."""
     value: str = ""
 
-    try:
-        with path.open(mode="r", encoding="utf-8") as file:
-            pass
-    except (UnicodeDecodeError, FileNotFoundError) as e:
-        log.exception(e)
+    if not path.name.endswith(".vdf"):
+        log.debug("File does not contain .vdf suffix: %s", path.name)
         return value
 
     log.debug("Reading: %s", path)
 
-    # Assumes the input is a VDF file and conforms to the
-    # KeyValues Text File Format
-    # See https://developer.valvesoftware.com/wiki/VDF
-    # See https://developer.valvesoftware.com/wiki/KeyValues
-    with path.open(mode="r", encoding="utf-8") as file:
-        for line in (line for line in file if line.isascii()):
-            tokens: list[str] = line.split()
-            if len(tokens) != 2:
-                continue
+    try:
+        # Assumes the input is a VDF file and conforms to the
+        # KeyValues Text File Format
+        # See https://developer.valvesoftware.com/wiki/VDF
+        # See https://developer.valvesoftware.com/wiki/KeyValues
+        with path.open(mode="r", encoding="utf-8") as file:
+            for line in (line for line in file if line.isascii()):
+                tokens: list[str] = line.split()
+                if len(tokens) != 2:
+                    continue
 
-            # In each token, a double quote is used as a control character and
-            # a double quote must not be used within its name or value
-            # See https://developer.valvesoftware.com/wiki/KeyValues#About_KeyValues_Text_File_Format
-            vdf_key, vdf_val = (token.strip('"') for token in tokens)
-            log.debug("%s=%s", vdf_key, vdf_val)
-            if key == vdf_key:
-                value = vdf_val
-                break
+                # In each token, a double quote is used as a control character
+                # and a double quote must not be used within its name or value
+                # See https://developer.valvesoftware.com/wiki/KeyValues#About_KeyValues_Text_File_Format
+                vdf_key, vdf_val = (token.strip('"') for token in tokens)
+                log.debug("%s=%s", vdf_key, vdf_val)
+                if key == vdf_key:
+                    value = vdf_val
+                    break
+    except (UnicodeDecodeError, FileNotFoundError) as e:
+        log.exception(e)
+        return value
 
     return value
 


### PR DESCRIPTION
Currently, it is possible for a user to set a Proton built against steamrt2 (soldier) to run their games. However, umu-launcher does not download SLRs like soldier for older Protons, and currently has no plans (yet) to. For cases like those or when the current SLR falls out of sync with the SLR associated with the latest Proton, have umu-launcher check if the two compatibility tools match and log warnings when they do not.
