### PR TITLE
refactor: use context managers whenever to manage resources

### DIFF
--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -50,7 +50,6 @@ from umu.umu_runtime import setup_umu
 from umu.umu_util import (
     get_libc,
     get_library_paths,
-    get_osrelease_id,
     is_installed_verb,
     is_winetricks_verb,
     xdisplay,

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -577,7 +577,8 @@ def run_in_steammode(proc: Popen) -> int:
     # Currently, steamos creates two xwayland servers at :0 and :1
     # Despite the socket for display :0 being hidden at /tmp/.x11-unix in
     # in the Flatpak, it is still possible to connect to it.
-    # TODO: Find a way to get the displays
+    # TODO: Find a robust way to get gamescope displays both in a container
+    # and outside a container
     with (
         xdisplay(":0") as d_primary,
         xdisplay(":1") as d_secondary,
@@ -623,7 +624,6 @@ def run_in_steammode(proc: Popen) -> int:
             )
             baselayer_thread.daemon = True
             baselayer_thread.start()
-
         return proc.wait()
 
     return proc.wait()
@@ -637,6 +637,8 @@ def run_command(command: tuple[Path | str, ...]) -> int:
     ret: int = 0
     prctl_ret: int = 0
     libc: str = get_libc()
+    # Note: STEAM_MULTIPLE_XWAYLANDS is steam mode specific and is
+    # documented to be a legacy env var.
     is_steammode: bool = (
         os.environ.get("XDG_CURRENT_DESKTOP") == "gamescope"
         and os.environ.get("STEAM_MULTIPLE_XWAYLANDS") == "1"

--- a/umu/umu_runtime.py
+++ b/umu/umu_runtime.py
@@ -13,7 +13,6 @@ except ModuleNotFoundError:
 from json import load
 from pathlib import Path
 from shutil import move, rmtree
-from ssl import create_default_context
 from subprocess import run
 from tarfile import open as taropen
 from tempfile import mkdtemp
@@ -23,12 +22,7 @@ from filelock import FileLock
 
 from umu.umu_consts import CONFIG, UMU_LOCAL
 from umu.umu_log import log
-from umu.umu_util import find_obsolete, run_zenity
-
-client_session: HTTPSConnection = HTTPSConnection(
-    "repo.steampowered.com",
-    context=create_default_context(),
-)
+from umu.umu_util import find_obsolete, https_connection, run_zenity
 
 try:
     from tarfile import tar_filter
@@ -39,7 +33,9 @@ except ImportError:
 
 
 def _install_umu(
-    json: dict[str, Any], thread_pool: ThreadPoolExecutor
+    json: dict[str, Any],
+    thread_pool: ThreadPoolExecutor,
+    client_session: HTTPSConnection,
 ) -> None:
     resp: HTTPResponse
     tmp: Path = Path(mkdtemp())
@@ -91,15 +87,16 @@ def _install_umu(
             err: str = (
                 f"repo.steampowered.com returned the status: {resp.status}"
             )
-            client_session.close()
             raise HTTPException(err)
 
+        # Parse SHA256SUMS
         for line in resp.read().decode("utf-8").splitlines():
             if line.endswith(archive):
                 digest = line.split(" ")[0]
                 break
 
         # Download the runtime
+        log.console(f"Downloading latest steamrt {codename}, please wait...")
         client_session.request("GET", f"{endpoint}/{archive}")
         resp = client_session.getresponse()
 
@@ -107,10 +104,8 @@ def _install_umu(
             err: str = (
                 f"repo.steampowered.com returned the status: {resp.status}"
             )
-            client_session.close()
             raise HTTPException(err)
 
-        log.console(f"Downloading latest steamrt {codename}, please wait...")
         with tmp.joinpath(archive).open(mode="ab+", buffering=0) as file:
             chunk_size: int = 64 * 1024  # 64 KB
             buffer: bytearray = bytearray(chunk_size)
@@ -122,11 +117,9 @@ def _install_umu(
         # Verify the runtime digest
         if hashsum.hexdigest() != digest:
             err: str = f"Digest mismatched: {archive}"
-            client_session.close()
             raise ValueError(err)
 
         log.console(f"{archive}: SHA256 is OK")
-        client_session.close()
 
     # Open the tar file and move the files
     log.debug("Opening: %s", tmp.joinpath(archive))
@@ -166,8 +159,8 @@ def _install_umu(
         # Remove the archive
         futures.append(thread_pool.submit(tmp.joinpath(archive).unlink, True))
 
-        for _ in futures:
-            _.result()
+        for future in futures:
+            future.result()
 
         # Rename _v2-entry-point
         log.debug("Renaming: _v2-entry-point -> umu")
@@ -184,6 +177,7 @@ def setup_umu(
     log.debug("Root: %s", root)
     log.debug("Local: %s", local)
     json: dict[str, Any] = _get_json(root, CONFIG)
+    host: str = "repo.steampowered.com"
 
     # New install or umu dir is empty
     if not local.exists() or not any(local.iterdir()):
@@ -192,9 +186,13 @@ def setup_umu(
             "Setting up Unified Launcher for Windows Games on Linux..."
         )
         local.mkdir(parents=True, exist_ok=True)
-        _restore_umu(
-            json, thread_pool, lambda: local.joinpath("umu").is_file()
-        )
+        with https_connection(host) as client_session:
+            _restore_umu(
+                json,
+                thread_pool,
+                lambda: local.joinpath("umu").is_file(),
+                client_session,
+            )
         return
 
     if os.environ.get("UMU_RUNTIME_UPDATE") == "0":
@@ -203,11 +201,15 @@ def setup_umu(
 
     find_obsolete()
 
-    _update_umu(local, json, thread_pool)
+    with https_connection(host) as client_session:
+        _update_umu(local, json, thread_pool, client_session)
 
 
 def _update_umu(
-    local: Path, json: dict[str, Any], thread_pool: ThreadPoolExecutor
+    local: Path,
+    json: dict[str, Any],
+    thread_pool: ThreadPoolExecutor,
+    client_session: HTTPSConnection,
 ) -> None:
     """For existing installations, check for updates to the runtime.
 
@@ -240,6 +242,7 @@ def _update_umu(
                 [file for file in local.glob(f"{codename}*") if file.is_dir()]
             )
             > 0,
+            client_session,
         )
         return
 
@@ -254,6 +257,7 @@ def _update_umu(
             json,
             thread_pool,
             lambda: local.joinpath("pressure-vessel").is_dir(),
+            client_session,
         )
         return
 
@@ -277,6 +281,7 @@ def _update_umu(
                 json,
                 thread_pool,
                 lambda: local.joinpath("VERSIONS.txt").is_file(),
+                client_session,
             )
             return
 
@@ -326,7 +331,6 @@ def _update_umu(
         log.warning(
             "repo.steampowered.com returned the status: %s", resp.status
         )
-        client_session.close()
         return
 
     steamrt_latest_digest: bytes = sha256(resp.read()).digest()
@@ -350,7 +354,7 @@ def _update_umu(
             ):
                 raise FileExistsError
 
-            _install_umu(json, thread_pool)
+            _install_umu(json, thread_pool, client_session)
             log.debug("Removing: %s", runtime)
             rmtree(str(runtime))
         except FileExistsError:
@@ -360,12 +364,9 @@ def _update_umu(
         finally:
             log.debug("Released file lock '%s'", lock.lock_file)
             lock.release()
-            client_session.close()
         return
 
     log.console("steamrt is up to date")
-
-    client_session.close()
 
 
 def _get_json(path: Traversable, config: str) -> dict[str, Any]:
@@ -482,6 +483,7 @@ def _restore_umu(
     json: dict[str, Any],
     thread_pool: ThreadPoolExecutor,
     callback: Callable[[], bool],
+    client_session: HTTPSConnection,
 ) -> None:
     lock: FileLock = FileLock(f"{UMU_LOCAL}/umu.lock")
 
@@ -494,7 +496,7 @@ def _restore_umu(
             log.debug("Will not restore Runtime Platform")
             raise FileExistsError
 
-        _install_umu(json, thread_pool)
+        _install_umu(json, thread_pool, client_session)
     except FileExistsError:
         pass
     except BaseException:

--- a/umu/umu_test.py
+++ b/umu/umu_test.py
@@ -248,33 +248,6 @@ class TestGameLauncher(unittest.TestCase):
                 "Expected 0 status code when libc could not be found",
             )
 
-    def test_run_command_nolibc(self):
-        """Test run_command when libc.so could not be found in system.
-
-        In this case, we do not set the subprocess as the subreaper and a
-        warning message should be logged
-        """
-        mock_exe = "foo"
-        mock_command = (
-            "/home/foo/.local/share/umu/umu",
-            "--verb",
-            "waitforexitandrun",
-            "--",
-            "/home/foo/.local/share/Steam/compatibilitytools.d/GE-Proton9-7/proton",
-            mock_exe,
-        )
-        mock = MagicMock()
-
-        os.environ["EXE"] = mock_exe
-        with (
-            patch.object(umu_run, "Popen", return_value=mock) as proc,
-            patch.object(umu_run, "get_libc", return_value=""),
-            patch.object(
-                umu_run, "get_gamescope_baselayer_order", return_value=None
-            ),
-        ):
-            umu_run.run_command(mock_command)
-            proc.assert_called_once()
 
     def test_run_command_none(self):
         """Test run_command when passed an empty tuple or None."""

--- a/umu/umu_test.py
+++ b/umu/umu_test.py
@@ -232,11 +232,9 @@ class TestGameLauncher(unittest.TestCase):
                 umu_run,
                 "Popen",
             ) as mock_popen,
-            patch.object(
-                umu_run, "get_gamescope_baselayer_order", return_value=None
-            ),
         ):
             mock_proc = MagicMock()
+            mock_proc.__enter__.return_value = mock_proc
             mock_proc.wait.return_value = 0
             mock_proc.pid = 1234
             mock_popen.return_value = mock_proc
@@ -245,18 +243,12 @@ class TestGameLauncher(unittest.TestCase):
             self.assertEqual(
                 result,
                 0,
-                "Expected 0 status code when libc could not be found",
+                "Expected 0 status code",
             )
-
 
     def test_run_command_none(self):
         """Test run_command when passed an empty tuple or None."""
-        with (
-            self.assertRaises(ValueError),
-            patch.object(
-                umu_run, "get_gamescope_baselayer_order", return_value=None
-            ),
-        ):
+        with self.assertRaises(ValueError):
             umu_run.run_command(())
             umu_run.run_command(None)
 

--- a/umu/umu_util.py
+++ b/umu/umu_util.py
@@ -205,35 +205,12 @@ def find_obsolete() -> None:
         log.warning("'%s' is obsolete", ulwgl)
 
 
-def get_osrelease_id() -> str:
-    """Get the identity of the host OS."""
-    release: Path
-    osid: str = ""
-
-    # Flatpak follows the Container Interface outlined by systemd
-    # See https://systemd.io/CONTAINER_INTERFACE
-    if os.environ.get("container") == "flatpak":  # noqa: SIM112
-        release = Path("/run/host/os-release")
-    else:
-        release = Path("/etc/os-release")
-
-    if not release.is_file():
-        log.debug("File '%s' could not be found", release)
-        return osid
-
-    with release.open(mode="r", encoding="utf-8") as file:
-        for line in file:
-            if line.startswith("ID="):
-                osid = line.removeprefix("ID=").strip()
-                log.debug("OS: %s", osid)
-                break
 @contextmanager
 def https_connection(host: str):  # noqa: ANN201
     """Create an HTTPSConnection."""
     global ssl_context
     conn: HTTPSConnection
 
-    return osid
     if not ssl_context:
         ssl_context = create_default_context()
 

--- a/umu/umu_util.py
+++ b/umu/umu_util.py
@@ -1,4 +1,5 @@
 import os
+from contextlib import contextmanager
 from ctypes.util import find_library
 from functools import lru_cache
 from pathlib import Path
@@ -6,6 +7,8 @@ from re import Pattern
 from re import compile as re_compile
 from shutil import which
 from subprocess import PIPE, STDOUT, Popen, TimeoutExpired
+
+from Xlib import display
 
 from umu.umu_consts import STEAM_COMPAT, UMU_LOCAL
 from umu.umu_log import log
@@ -222,3 +225,12 @@ def get_osrelease_id() -> str:
                 break
 
     return osid
+@contextmanager
+def xdisplay(no: str):  # noqa: ANN201
+    """Create a Display."""
+    d: display.Display = display.Display(no)
+
+    try:
+        yield d
+    finally:
+        d.close()


### PR DESCRIPTION
Tested on SteamOS (3.16.13) and on the latest Steam beta client (1726256783) for regressions.

This PR refactors some code to use context managers whenever possible, so system resources are properly released when the launcher is forcefully killed any time in its lifecycle. In particular, when the launcher is interrupted before the thread pool is shutdown or before the file descriptors of python-xlib objects are closed during the gamescope window setup.

TODO:
- [x] Sanity check on the Steam Deck