### PR TITLE
refactor: remove custom cleanup routine on proton install error

### DIFF
--- a/umu/umu_proton.py
+++ b/umu/umu_proton.py
@@ -364,11 +364,11 @@ def _update_proton(
     will be removed, so users should not be storing important files there.
     """
     futures: list[Future] = []
-
-    log.debug("Previous builds: %s", protons)
-    log.debug("Linking UMU-Latest -> %s", proton)
     steam_compat.joinpath("UMU-Latest").unlink(missing_ok=True)
     steam_compat.joinpath("UMU-Latest").symlink_to(proton)
+    log.debug("Updating UMU-Proton")
+    log.debug("Previous builds: %s", protons)
+    log.debug("Linking UMU-Latest -> %s", proton)
 
     if not protons:
         return
@@ -379,8 +379,8 @@ def _update_proton(
             log.debug("Removing: %s", stable)
             futures.append(thread_pool.submit(rmtree, str(stable)))
 
-    for _ in futures:
-        _.result()
+    for future in futures:
+        future.result()
 
 
 def _install_proton(

--- a/umu/umu_proton.py
+++ b/umu/umu_proton.py
@@ -386,6 +386,14 @@ def _install_proton(
     steam_compat: Path,
     thread_pool: ThreadPoolExecutor,
 ) -> None:
+    """Install a Proton directory to Steam's compatibilitytools.d.
+
+    An installation is primarily composed of two steps: extract and move. A
+    UMU-Proton or GE-Proton build will first be extracted to a secure temporary
+    directory then moved to compatibilitytools.d, which is expected to be in
+    $HOME. In the case of UMU-Proton, an installation will include a remove
+    step, where old builds will be removed in parallel.
+    """
     future: Future | None = None
     version: str = (
         "GE-Proton"
@@ -394,7 +402,8 @@ def _install_proton(
     )
     proton: str = tarball.removesuffix(".tar.gz")
 
-    # Remove all previous builds when the version is UMU-Proton
+    # TODO: Refactor when differential updates are implemented.
+    # Remove all previous builds when the build is UMU-Proton
     if version == "UMU-Proton":
         protons: list[Path] = [
             file
@@ -405,7 +414,7 @@ def _install_proton(
             _update_proton, proton, steam_compat, protons, thread_pool
         )
 
-    # Extract the new build in a temporary directory then move it
+    # Extract the new build in its temporary directory then move it
     _extract_dir(tmp.joinpath(tarball))
     log.console(f"'{tmp.joinpath(proton)}' -> '{steam_compat}'")
     move(tmp.joinpath(proton), steam_compat)

--- a/umu/umu_proton.py
+++ b/umu/umu_proton.py
@@ -230,20 +230,6 @@ def _extract_dir(file: Path, steam_compat: Path) -> None:
         tar.extractall(path=steam_compat)  # noqa: S202
 
 
-def _cleanup(tarball: str, proton: str, tmp: Path, steam_compat: Path) -> None:
-    """Remove files that may have been left in an incomplete state.
-
-    We want to do this when a download for a new release is interrupted to
-    avoid corruption.
-    """
-    log.console("Keyboard Interrupt.\nCleaning...")
-
-    if tmp.joinpath(tarball).is_file():
-        log.console(f"Purging '{tarball}' in '{tmp}'...")
-        tmp.joinpath(tarball).unlink()
-    if steam_compat.joinpath(proton).is_dir():
-        log.console(f"Purging '{proton}' in '{steam_compat}'...")
-        rmtree(str(steam_compat.joinpath(proton)))
 
 
 def _get_from_steamcompat(

--- a/umu/umu_proton.py
+++ b/umu/umu_proton.py
@@ -408,7 +408,7 @@ def _install_proton(
     # Extract the new build in a temporary directory then move it
     _extract_dir(tmp.joinpath(tarball))
     log.console(f"'{tmp.joinpath(proton)}' -> '{steam_compat}'")
-    thread_pool.submit(move, tmp.joinpath(proton), steam_compat)
+    move(tmp.joinpath(proton), steam_compat)
 
     if future:
         future.result()

--- a/umu/umu_proton.py
+++ b/umu/umu_proton.py
@@ -213,7 +213,7 @@ def _fetch_proton(
     return env
 
 
-def _extract_dir(file: Path, steam_compat: Path) -> None:
+def _extract_dir(file: Path) -> None:
     """Extract from a path to another location."""
     with tar_open(file, "r:gz") as tar:
         if has_data_filter:
@@ -223,13 +223,9 @@ def _extract_dir(file: Path, steam_compat: Path) -> None:
             log.warning("Python: %s", sys.version)
             log.warning("Using no data filter for archive")
             log.warning("Archive will be extracted insecurely")
-
-        log.console(f"Extracting '{file}' -> '{steam_compat}'...")
-        # TODO: Rather than extracting all of the contents, we should prefer
-        # the difference (e.g., rsync)
-        tar.extractall(path=steam_compat)  # noqa: S202
-
-
+        log.console(f"Extracting {file.name}...")
+        log.debug("Source: %s", str(file).removesuffix(".tar.gz"))
+        tar.extractall(path=file.parent)  # noqa: S202
 
 
 def _get_from_steamcompat(

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -182,6 +182,7 @@ def check_env(
     if os.environ.get("PROTONPATH") == "GE-Proton":
         get_umu_proton(env, thread_pool)
 
+    # UMU-Proton
     if "PROTONPATH" not in os.environ:
         os.environ["PROTONPATH"] = ""
         get_umu_proton(env, thread_pool)
@@ -191,9 +192,8 @@ def check_env(
     # If download fails/doesn't exist in the system, raise an error
     if not os.environ["PROTONPATH"]:
         err: str = (
-            "Download failed\n"
-            "UMU-Proton could not be found in compatibilitytools.d\n"
-            "Please set $PROTONPATH or visit https://github.com/Open-Wine-Components/umu-proton/releases"
+            "$PROTONPATH not set or could not download Proton\n"
+            "Visit https://github.com/Open-Wine-Components/umu-proton/releases"
         )
         raise FileNotFoundError(err)
 

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -182,7 +182,6 @@ def check_env(
     if os.environ.get("PROTONPATH") == "GE-Proton":
         get_umu_proton(env, thread_pool)
 
-    # UMU-Proton
     if "PROTONPATH" not in os.environ:
         os.environ["PROTONPATH"] = ""
         get_umu_proton(env, thread_pool)
@@ -192,8 +191,9 @@ def check_env(
     # If download fails/doesn't exist in the system, raise an error
     if not os.environ["PROTONPATH"]:
         err: str = (
-            "$PROTONPATH not set or could not download Proton\n"
-            "Visit https://github.com/Open-Wine-Components/umu-proton/releases"
+            "Download failed\n"
+            "UMU-Proton could not be found in compatibilitytools.d\n"
+            "Please set $PROTONPATH or visit https://github.com/Open-Wine-Components/umu-proton/releases"
         )
         raise FileNotFoundError(err)
 

--- a/umu/umu_test.py
+++ b/umu/umu_test.py
@@ -639,21 +639,7 @@ class TestGameLauncher(unittest.TestCase):
             self.assertFalse(
                 self.env["PROTONPATH"], "Expected PROTONPATH to be empty"
             )
-            self.assertFalse(result, "Expected None when a ValueError occurs")
-
-            # Verify the state of the compat dir/cache
-            self.assertFalse(
-                self.test_compat.joinpath(
-                    self.test_archive.name[
-                        : self.test_archive.name.find(".tar.gz")
-                    ]
-                ).exists(),
-                "Expected Proton dir in compat to be cleaned",
-            )
-            self.assertFalse(
-                self.test_cache.joinpath(self.test_archive.name).exists(),
-                "Expected Proton dir in compat to be cleaned",
-            )
+            self.assertFalse(result, "Expected None on KeyboardInterrupt")
 
     def test_latest_val_err(self):
         """Test _get_latest when something goes wrong when downloading Proton.
@@ -688,12 +674,6 @@ class TestGameLauncher(unittest.TestCase):
                 self.env["PROTONPATH"], "Expected PROTONPATH to be empty"
             )
             self.assertFalse(result, "Expected None when a ValueError occurs")
-
-            # Ensure we clean up suspected files
-            self.assertFalse(
-                self.test_archive.is_file(),
-                "Expected test file in cache to be deleted",
-            )
 
     def test_latest_offline(self):
         """Test _get_latest when the user doesn't have internet."""

--- a/umu/umu_test.py
+++ b/umu/umu_test.py
@@ -9,7 +9,7 @@ from argparse import Namespace
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from pwd import getpwuid
-from shutil import copy, copytree, rmtree
+from shutil import copy, copytree, move, rmtree
 from subprocess import CompletedProcess
 from unittest.mock import MagicMock, patch
 
@@ -449,7 +449,7 @@ class TestGameLauncher(unittest.TestCase):
         wasn't found in local system.
         """
         test_archive = self.test_archive.rename("GE-Proton9-2.tar.gz")
-        umu_proton._extract_dir(test_archive, self.test_compat)
+        umu_proton._extract_dir(test_archive)
 
         with (
             self.assertRaises(FileNotFoundError),
@@ -882,7 +882,8 @@ class TestGameLauncher(unittest.TestCase):
         """
         result = None
 
-        umu_proton._extract_dir(self.test_archive, self.test_compat)
+        umu_proton._extract_dir(self.test_archive)
+        move(str(self.test_archive).removesuffix(".tar.gz"), self.test_compat)
 
         result = umu_proton._get_from_steamcompat(self.env, self.test_compat)
 
@@ -895,111 +896,6 @@ class TestGameLauncher(unittest.TestCase):
                 ]
             ).as_posix(),
             "Expected PROTONPATH to be proton dir in compat",
-        )
-
-    def test_cleanup_no_exists(self):
-        """Test _cleanup when passed files that do not exist.
-
-        In the event of an interrupt during the download/extract process, we
-        only want to clean the files that exist
-
-        NOTE: This is **extremely** important, as we do **not** want to delete
-        anything else but the files we downloaded/extracted -- the incomplete
-        tarball/extracted dir
-        """
-        result = None
-
-        umu_proton._extract_dir(self.test_archive, self.test_compat)
-
-        # Create a file in the cache and compat
-        self.test_cache.joinpath("foo").touch()
-        self.test_compat.joinpath("foo").touch()
-
-        # Before cleaning
-        # On setUp, an archive is created and a dir should exist in compat
-        # after extraction
-        self.assertTrue(
-            self.test_compat.joinpath("foo").exists(),
-            "Expected test file to exist in compat before cleaning",
-        )
-        self.assertTrue(
-            self.test_cache.joinpath("foo").exists(),
-            "Expected test file to exist in cache before cleaning",
-        )
-        self.assertTrue(
-            self.test_archive.exists(),
-            "Expected archive to exist in cache before cleaning",
-        )
-        self.assertTrue(
-            self.test_compat.joinpath(self.test_proton_dir)
-            .joinpath("proton")
-            .exists(),
-            "Expected 'proton' to exist before cleaning",
-        )
-
-        # Pass files that do not exist
-        result = umu_proton._cleanup(
-            "foo.tar.gz",
-            "foo",
-            self.test_cache,
-            self.test_compat,
-        )
-
-        # Verify state of cache and compat after cleaning
-        self.assertFalse(result, "Expected None after cleaning")
-        self.assertTrue(
-            self.test_compat.joinpath("foo").exists(),
-            "Expected test file to exist in compat after cleaning",
-        )
-        self.assertTrue(
-            self.test_cache.joinpath("foo").exists(),
-            "Expected test file to exist in cache after cleaning",
-        )
-        self.assertTrue(
-            self.test_compat.joinpath(self.test_proton_dir).exists(),
-            "Expected proton dir to still exist after cleaning",
-        )
-        self.assertTrue(
-            self.test_archive.exists(),
-            "Expected archive to still exist after cleaning",
-        )
-        self.assertTrue(
-            self.test_compat.joinpath(self.test_proton_dir)
-            .joinpath("proton")
-            .exists(),
-            "Expected 'proton' to still exist after cleaning",
-        )
-
-    def test_cleanup(self):
-        """Test _cleanup.
-
-        In the event of an interrupt during the download/extract process, we
-        want to clean the cache or the extracted dir in Steam compat to avoid
-        incomplete files
-        """
-        result = None
-
-        umu_proton._extract_dir(self.test_archive, self.test_compat)
-        result = umu_proton._cleanup(
-            self.test_proton_dir.as_posix() + ".tar.gz",
-            self.test_proton_dir.as_posix(),
-            self.test_cache,
-            self.test_compat,
-        )
-        self.assertFalse(result, "Expected None after cleaning")
-        self.assertFalse(
-            self.test_compat.joinpath(self.test_proton_dir).exists(),
-            "Expected proton dir to be cleaned in compat",
-        )
-        self.assertFalse(
-            self.test_archive.exists(),
-            "Expected archive to be cleaned in cache",
-        )
-        self.assertFalse(
-            self.test_compat.joinpath(self.test_proton_dir)
-            .joinpath("proton")
-            .exists(),
-            "Expected 'proton' to not exist after cleaned",
         )
 
     def test_extract_err(self):
@@ -1016,7 +912,7 @@ class TestGameLauncher(unittest.TestCase):
             )
 
         with self.assertRaisesRegex(tarfile.ReadError, "gzip"):
-            umu_proton._extract_dir(test_archive, self.test_compat)
+            umu_proton._extract_dir(test_archive)
 
         if test_archive.exists():
             test_archive.unlink()
@@ -1025,11 +921,12 @@ class TestGameLauncher(unittest.TestCase):
         """Test _extract_dir.
 
         An error should not be raised when the Proton release is extracted to
-        the Steam compat dir
+        a temporary directory
         """
         result = None
 
-        result = umu_proton._extract_dir(self.test_archive, self.test_compat)
+        result = umu_proton._extract_dir(self.test_archive)
+        move(str(self.test_archive).removesuffix(".tar.gz"), self.test_compat)
         self.assertFalse(result, "Expected None after extracting")
         self.assertTrue(
             self.test_compat.joinpath(self.test_proton_dir).exists(),


### PR DESCRIPTION
Currently, we were extracting the Proton archive directly to `$HOME/.local/share/Steam/compatibilitytools.d` then would clean that directory if the extraction was interrupted. While this process was direct, it required writing a custom cleanup routine to remove the partially extracted files in case an exception occurred. Instead, the launcher will extract to its secure temporary directory created at runtime then move the files to `$HOME` like we do with the SLR. Like the previous behavior, when an exception occurs in either the download or installation, the (temporary) directory will be cleaned but by the context manager's cleanup routine. While this would be less direct as it would involve an extra step, it would result in the launcher having to remove less files from the user's home directory and make the Proton installation _partially_ atomic.

Additionally, some minor refactoring (e..g, collapsing code blocks) are done for readability.
