### PR TITLE
fix: check baselayer sequence before rearranging

### DIFF
--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -462,7 +462,7 @@ def rearrange_gamescope_baselayer_order(
     rearranged: list[int]
 
     # Gamescope identifies Steam's window by the App ID 769 or by the atom
-    # STEAM_BIGPICTURE. This identifier must be last element in the sequence
+    # STEAM_BIGPICTURE. This id must be the last element in the sequence
     if sequence and sequence[-1] == 769:
         return None
 

--- a/umu/umu_test.py
+++ b/umu/umu_test.py
@@ -187,6 +187,20 @@ class TestGameLauncher(unittest.TestCase):
         if self.test_usr.exists():
             rmtree(self.test_usr.as_posix())
 
+    def test_rearrange_gamescope_baselayer_none(self):
+        """Test rearrange_gamescope_baselayer_order when passed correct seq.
+
+        A rearranged sequence should only be returned when the last element
+        is 769. Otherwise, None should be returned
+        """
+        baselayer = [1, 2, 3, 769]
+        result = umu_run.rearrange_gamescope_baselayer_order(baselayer)
+
+        self.assertTrue(
+            result is None,
+            f"Expected None to be returned for sequence {baselayer}",
+        )
+
     def test_rearrange_gamescope_baselayer_order_err(self):
         """Test rearrange_gamescope_baselayer_order for unexpected seq."""
         baselayer = []
@@ -195,7 +209,7 @@ class TestGameLauncher(unittest.TestCase):
             umu_run.rearrange_gamescope_baselayer_order(baselayer)
 
     def test_rearrange_gamescope_baselayer_order(self):
-        """Test rearrange_gamescope_baselayer_order for expected sequences."""
+        """Test rearrange_gamescope_baselayer_order when passed a sequence."""
         baselayer = [1, 2, 3, 4]
         expected = (
             [baselayer[0], baselayer[-1], *baselayer[1:-1]],


### PR DESCRIPTION
This PR updates the window setup routine to only rearrange the value from the GAMESCOPECTRL_BASELAYER_APPID atom when it needs to be.

Closes https://github.com/Open-Wine-Components/umu-launcher/issues/192 and tested on SteamOS 3.6.15 using Steam Version 1726683985 against a non-Steam game for potential regressions.

TODO:

- [x] Sanity check on the Steam Deck
