### PR TITLE
feat: automatically use the correct runtime

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -46,21 +46,6 @@ fix_shebangs:
 	find $(DESTDIR) -type f -name "*.sh" -exec sed -i '1s|^#!/usr/bin/env sh|#!$(SHELL_INTERPRETER)|' {} \;
 	find $(DESTDIR) -type f -name "umu-run" -exec sed -i '1s|^#!/usr/bin/env sh|#!$(SHELL_INTERPRETER)|' {} \;
 
-# Special case, do this inside the source directory for release distribution
-umu/umu_version.json: umu/umu_version.json.in
-	$(info :: Updating $(@) )
-	cp $(<) $(<).tmp
-	sed 's|##UMU_VERSION##|$(shell git describe --always --long --tags)|g' -i $(<).tmp
-	mv $(<).tmp $(@)
-
-.PHONY: version
-version: umu/umu_version.json
-
-version-install: version
-	$(info :: Installing umu_version.json )
-	install -d $(DESTDIR)$(PYTHONDIR)/$(INSTALLDIR)
-	install -Dm 644 umu/umu_version.json -t $(DESTDIR)$(PYTHONDIR)/$(INSTALLDIR)
-
 
 $(OBJDIR)/.build-umu-docs: | $(OBJDIR)
 	$(info :: Building umu man pages )
@@ -79,7 +64,7 @@ umu-docs-install: umu-docs
 	install -m644 $(OBJDIR)/umu.5 $(DESTDIR)$(MANDIR)/man5/umu.5
 
 
-$(OBJDIR)/.build-umu-dist: | $(OBJDIR) version
+$(OBJDIR)/.build-umu-dist: | $(OBJDIR)
 	$(info :: Building umu )
 	$(PYTHON_INTERPRETER) -m build --wheel --skip-dependency-check --no-isolation --outdir=$(OBJDIR)
 	touch $(@)
@@ -93,9 +78,9 @@ umu-dist-install: umu-dist
 	$(PYTHON_INTERPRETER)  -m installer --destdir=$(DESTDIR) $(OBJDIR)/*.whl
 
 ifeq ($(FLATPAK), xtrue)
-umu-install: version-install umu-dist-install
+umu-install: umu-dist-install
 else
-umu-install: version-install umu-dist-install umu-docs-install
+umu-install: umu-dist-install umu-docs-install
 endif
 
 ifeq ($(FLATPAK), xtrue)
@@ -148,7 +133,7 @@ $(OBJDIR):
 .PHONY: clean
 clean:
 	$(info :: Cleaning source directory )
-	@rm -rf -v $(OBJDIR) umu/umu_version.json ./$(RELEASEDIR) $(RELEASEDIR).tar.gz
+	@rm -rf -v $(OBJDIR) ./$(RELEASEDIR) $(RELEASEDIR).tar.gz
 
 
 RELEASEDIR := $(PROJECT)-$(shell git describe --abbrev=0)
@@ -156,7 +141,7 @@ $(RELEASEDIR):
 	mkdir -p $(@)
 
 .PHONY: release
-release: $(RELEASEDIR) | version zipapp
+release: $(RELEASEDIR) | zipapp
 	$(info :: Creating source distribution for release )
 	mkdir -p $(<)
 	rm -rf umu/__pycache__
@@ -177,11 +162,10 @@ ZIPAPP := $(OBJDIR)/umu-run
 ZIPAPP_STAGING := $(OBJDIR)/zipapp_staging
 ZIPAPP_VENV := $(OBJDIR)/zipapp_venv
 
-$(OBJDIR)/.build-zipapp: | $(OBJDIR) version
+$(OBJDIR)/.build-zipapp: | $(OBJDIR)
 	$(info :: Building umu-launcher as zipapp )
 	$(PYTHON_INTERPRETER) -m venv $(ZIPAPP_VENV)
 	. $(ZIPAPP_VENV)/bin/activate && python3 -m pip install -t "$(ZIPAPP_STAGING)" -U --no-compile .
-	install -Dm644 umu/umu_version.json "$(ZIPAPP_STAGING)"/umu/umu_version.json
 	cp umu/__main__.py "$(ZIPAPP_STAGING)"
 	find "$(ZIPAPP_STAGING)" -exec touch -h -d "$(SOURCE_DATE_EPOCH)" {} +
 	. $(ZIPAPP_VENV)/bin/activate && python3 -m zipapp $(ZIPAPP_STAGING) -o $(ZIPAPP) -p "$(PYTHON_INTERPRETER)" -c

--- a/umu/__init__.py
+++ b/umu/__init__.py
@@ -1,2 +1,6 @@
 __version__ = "1.1.1"  # noqa: D104
-__runtime_platform__ = "sniper"
+__pressure_vessel_runtime__ = ("steamrt3", "sniper", "1628350")
+__pressure_vessel_runtimes__ = (
+    ("steamrt3", "sniper", "1628350"),
+    ("steamrt2", "soldier", "1391110"),
+)

--- a/umu/__init__.py
+++ b/umu/__init__.py
@@ -1,1 +1,2 @@
 __version__ = "1.1.1"  # noqa: D104
+__runtime_platform__ = "sniper"

--- a/umu/umu_consts.py
+++ b/umu/umu_consts.py
@@ -1,8 +1,6 @@
 import os
 from pathlib import Path
 
-CONFIG = "umu_version.json"
-
 STEAM_COMPAT: Path = Path.home().joinpath(
     ".local", "share", "Steam", "compatibilitytools.d"
 )

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -909,7 +909,3 @@ if __name__ == "__main__":
             sys.exit(e.code)
     except BaseException as e:
         log.exception(e)
-    finally:
-        UMU_LOCAL.joinpath(".ref").unlink(
-            missing_ok=True
-        )  # Cleanup .ref file on every exit

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -884,7 +884,7 @@ def main() -> int:  # noqa: D103
             env["PROTONPATH"],
         )
         log.warning(
-            "Prefix '%s' was created with compatibility tool '%s'",
+            "Prefix '%s' was created with compatibility tool %s",
             env["WINEPREFIX"],
             Path(env["PROTONPATH"], "version").read_text(encoding="utf-8"),
         )

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -861,7 +861,7 @@ def main() -> int:  # noqa: D103
         if get_vdf_value(file, "appid") == toolappid_proton:
             runtime_platform: Path = file.parent.parent
             log.debug("App ID (Proton): %s", toolappid_proton)
-            log.debug("Steam Linux Runtime: %s", file.name)
+            log.debug("Steam Linux Runtime: %s", file.parent.parent.name)
             log.console(
                 f"Using {Path(env['PROTONPATH']).name} with "
                 f"{runtime_platform.name}"

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -869,6 +869,26 @@ def main() -> int:  # noqa: D103
             has_matching_compat_tools = True
             break
 
+    # Warn if compatibility tools mismatch (e.g., using proton 7 with sniper)
+    # Assuming our parser is correct, at this point, the user is probably
+    # trying to use a proton without its required runtime. This may happen if
+    # we did not bump the runtime in time because, at the time of this writing,
+    # we're currently assuming the usage of sniper. In this case, just warn
+    # them and opt not to set an appropriate proton for the user to avoid the
+    # risk of breaking users' pfxs
+    if not has_matching_compat_tools:
+        log.warning("Compatibility tools mismatch")
+        log.warning(
+            "'%s' is not a required compatibility tool for '%s'",
+            runtime_platform,
+            env["PROTONPATH"],
+        )
+        log.warning(
+            "Prefix '%s' was created with compatibility tool '%s'",
+            env["WINEPREFIX"],
+            Path(env["PROTONPATH"], "version").read_text(encoding="utf-8"),
+        )
+
     # Build the command
     command: tuple[Path | str, ...] = build_command(
         env, runtime_platform, opts

--- a/umu/umu_runtime.py
+++ b/umu/umu_runtime.py
@@ -20,7 +20,7 @@ from tempfile import TemporaryDirectory, mkdtemp
 from filelock import FileLock
 
 from umu import __pressure_vessel_runtimes__
-from umu.umu_consts import UMU_CACHE, UMU_LOCAL
+from umu.umu_consts import UMU_CACHE
 from umu.umu_log import log
 from umu.umu_util import (
     find_obsolete,
@@ -208,7 +208,7 @@ def _install_umu(
             # Move each file to the dest dir, overwriting if exists
             futures.extend(
                 [
-                    thread_pool.submit(_move, file, source_dir, UMU_LOCAL)
+                    thread_pool.submit(_move, file, source_dir, local)
                     for file in source_dir.glob("*")
                 ]
             )
@@ -221,7 +221,7 @@ def _install_umu(
 
     # Rename _v2-entry-point
     log.debug("Renaming: _v2-entry-point -> umu")
-    UMU_LOCAL.joinpath("_v2-entry-point").rename(UMU_LOCAL.joinpath("umu"))
+    local.joinpath("_v2-entry-point").rename(local.joinpath("umu"))
 
     # Validate the runtime after moving the files
     check_runtime(local, runtime_platform[1])

--- a/umu/umu_runtime.py
+++ b/umu/umu_runtime.py
@@ -66,21 +66,21 @@ def _install_umu(
             toolmanifest.parent.name,
         )
 
-        for runtime in __pressure_vessel_runtimes__:
-            if compat_tool in runtime:
         # Change runtime paths and runtime base platform
+        for pv_runtime in __pressure_vessel_runtimes__:
+            if compat_tool in pv_runtime:
                 log.debug(
                     "Changing SLR base platform: %s -> %s",
                     runtime_platform,
-                    runtime,
+                    pv_runtime,
                 )
                 log.debug(
                     "Changing base directory: %s -> %s",
                     local,
-                    local.parent / runtime[0],
+                    local.parent / pv_runtime[0],
                 )
-                runtime_platform = runtime
-                local = local.parent / runtime[0]
+                runtime_platform = pv_runtime
+                local = local.parent / pv_runtime[0]
                 break
 
     local.mkdir(parents=True, exist_ok=True)

--- a/umu/umu_runtime.py
+++ b/umu/umu_runtime.py
@@ -285,10 +285,7 @@ def _update_umu(
     """
     runtime: Path
     resp: HTTPResponse
-    endpoint: str = (
-        f"/steamrt-images-{runtime_platform[1]}"
-        "/snapshots/latest-container-runtime-public-beta"
-    )
+    endpoint: str
     token: str = f"?version={token_urlsafe(16)}"
 
     log.debug("Existing install detected")
@@ -319,6 +316,11 @@ def _update_umu(
                 runtime_platform = pv_runtime
                 local = local.parent / pv_runtime[0]
                 break
+
+    endpoint = (
+        f"/steamrt-images-{runtime_platform[1]}"
+        "/snapshots/latest-container-runtime-public-beta"
+    )
 
     # Find the runtime directory (e.g., sniper_platform_0.20240530.90143)
     # Assume the directory begins with the alias

--- a/umu/umu_runtime.py
+++ b/umu/umu_runtime.py
@@ -56,13 +56,14 @@ def _install_umu(
     # been downloaded for them yet.
     if _is_obsolete_umu(runtime_platform):
         toolmanifest: Path = Path(os.environ["PROTONPATH"], "toolmanifest.vdf")
-        compat_tool = get_vdf_value(
+        compat_tool: str = get_vdf_value(
             toolmanifest,
             "require_tool_appid",
         )
 
         log.warning(
-            "Obsolete compatibility tool detected: %s", toolmanifest.parent
+            "%s is obsolete, downloading obsolete steamrt",
+            toolmanifest.parent.name,
         )
 
         for runtime in __pressure_vessel_runtimes__:
@@ -291,7 +292,10 @@ def _update_umu(
 
     # Skip SLR updates when not using the latest variant
     if _is_obsolete_umu(runtime_platform):
-        log.warning("Obsolete compatibility tools detected, skipping updates")
+        log.warning(
+            "%s is obsolete, skipping steamrt update",
+            Path(os.environ["PROTONPATH"]).name,
+        )
         return
 
     log.debug("Existing install detected")

--- a/umu/umu_runtime.py
+++ b/umu/umu_runtime.py
@@ -75,7 +75,7 @@ def _install_umu(
                     pv_runtime,
                 )
                 log.debug(
-                    "Changing base directory: %s -> %s",
+                    "Changing base directory: '%s' -> '%s'",
                     local,
                     local.parent / pv_runtime[0],
                 )
@@ -309,7 +309,7 @@ def _update_umu(
                     pv_runtime,
                 )
                 log.debug(
-                    "Changing base directory: %s -> %s",
+                    "Changing base directory: '%s' -> '%s'",
                     local,
                     local.parent / pv_runtime[0],
                 )

--- a/umu/umu_runtime.py
+++ b/umu/umu_runtime.py
@@ -50,10 +50,10 @@ def _install_umu(
     ret: int = 0  # Exit code from zenity
     token: str = f"?versions={token_urlsafe(16)}"
 
-    # When using an existing proton build, download its intended runtime
-    # Handles cases where on a new install, the user or the client passes
-    # and existing obsolete proton build but its corresponding runtime has not
-    # been downloaded for them yet.
+    # When using an existing obsolete proton build, download its intended
+    # runtime. Handles cases where on a new install, the user or the client
+    # passes and existing obsolete proton build but its corresponding runtime
+    # has not been downloaded for them yet.
     if _is_obsolete_umu(runtime_platform):
         toolmanifest: Path = Path(os.environ["PROTONPATH"], "toolmanifest.vdf")
         compat_tool: str = get_vdf_value(
@@ -68,6 +68,7 @@ def _install_umu(
 
         for runtime in __pressure_vessel_runtimes__:
             if compat_tool in runtime:
+        # Change runtime paths and runtime base platform
                 log.debug(
                     "Changing SLR base platform: %s -> %s",
                     runtime_platform,

--- a/umu/umu_test.py
+++ b/umu/umu_test.py
@@ -1371,7 +1371,7 @@ class TestGameLauncher(unittest.TestCase):
 
         # Mock setting up the runtime
         with (
-            patch.object(umu_runtime, "_install_umu", return_value=None),
+            patch.object(umu_runtime, "setup_umu", return_value=None),
         ):
             umu_runtime.setup_umu(
                 self.test_user_share,

--- a/umu/umu_test.py
+++ b/umu/umu_test.py
@@ -366,23 +366,19 @@ class TestGameLauncher(unittest.TestCase):
         If the pv-verify binary does not exist, a warning should be logged and
         the function should return
         """
-        json_root = umu_runtime._get_json(
-            self.test_user_share, "umu_version.json"
-        )
+        codename = "sniper"
         self.test_user_share.joinpath(
             "pressure-vessel", "bin", "pv-verify"
         ).unlink()
-        result = umu_runtime.check_runtime(self.test_user_share, json_root)
+        result = umu_runtime.check_runtime(self.test_user_share, codename)
         self.assertEqual(result, 1, "Expected the exit code 1")
 
     def test_check_runtime_success(self):
         """Test check_runtime when runtime validation succeeds."""
-        json_root = umu_runtime._get_json(
-            self.test_user_share, "umu_version.json"
-        )
+        codename = "sniper"
         mock = CompletedProcess(["foo"], 0)
         with patch.object(umu_runtime, "run", return_value=mock):
-            result = umu_runtime.check_runtime(self.test_user_share, json_root)
+            result = umu_runtime.check_runtime(self.test_user_share, codename)
             self.assertEqual(result, 0, "Expected the exit code 0")
 
     def test_check_runtime_dir(self):
@@ -390,9 +386,7 @@ class TestGameLauncher(unittest.TestCase):
         runtime = Path(
             self.test_user_share, "sniper_platform_0.20240125.75305"
         )
-        json_root = umu_runtime._get_json(
-            self.test_user_share, "umu_version.json"
-        )
+        codename = "sniper"
 
         # Mock the removal of the runtime directory
         # In the real usage when updating the runtime, this should not happen
@@ -403,7 +397,7 @@ class TestGameLauncher(unittest.TestCase):
 
         mock = CompletedProcess(["foo"], 1)
         with patch.object(umu_runtime, "run", return_value=mock):
-            result = umu_runtime.check_runtime(self.test_user_share, json_root)
+            result = umu_runtime.check_runtime(self.test_user_share, codename)
             self.assertEqual(result, 1, "Expected the exit code 1")
 
     def test_move(self):
@@ -517,119 +511,6 @@ class TestGameLauncher(unittest.TestCase):
             self.assertFalse(
                 os.environ.get("PROTONPATH"), "Expected empty string"
             )
-
-    def test_get_json_err(self):
-        """Test _get_json when specifying a corrupted umu_version.json file.
-
-        A ValueError should be raised because we expect 'umu' and 'version'
-        keys to exist
-        """
-        test_config = """
-        {
-            "foo": {
-                "versions": {
-                    "launcher": "0.1-RC3",
-                    "runner": "0.1-RC3",
-                    "runtime_platform": "sniper"
-                }
-            }
-        }
-        """
-        test_config2 = """
-        {
-            "umu": {
-                "foo": {
-                    "launcher": "0.1-RC3",
-                    "runner": "0.1-RC3",
-                    "runtime_platform": "sniper"
-                }
-            }
-        }
-        """
-        # Remove the valid config created at setup
-        Path(self.test_user_share, "umu_version.json").unlink(missing_ok=True)
-
-        Path(self.test_user_share, "umu_version.json").touch()
-        with Path(self.test_user_share, "umu_version.json").open(
-            mode="w", encoding="utf-8"
-        ) as file:
-            file.write(test_config)
-
-        # Test when "umu" doesn't exist
-        with self.assertRaisesRegex(ValueError, "load"):
-            umu_runtime._get_json(self.test_user_share, "umu_version.json")
-
-        # Test when "versions" doesn't exist
-        Path(self.test_user_share, "umu_version.json").unlink(missing_ok=True)
-
-        Path(self.test_user_share, "umu_version.json").touch()
-        with Path(self.test_user_share, "umu_version.json").open(
-            mode="w", encoding="utf-8"
-        ) as file:
-            file.write(test_config2)
-
-        with self.assertRaisesRegex(ValueError, "load"):
-            umu_runtime._get_json(self.test_user_share, "umu_version.json")
-
-    def test_get_json_foo(self):
-        """Test _get_json when not specifying umu_version.json as 2nd arg.
-
-        A FileNotFoundError should be raised
-        """
-        with self.assertRaisesRegex(FileNotFoundError, "configuration"):
-            umu_runtime._get_json(self.test_user_share, "foo")
-
-    def test_get_json_steamrt(self):
-        """Test _get_json when passed a non-steamrt value.
-
-        This attempts to mitigate against directory removal attacks for user
-        installations in the home directory, since the launcher will remove the
-        old runtime on update. Currently expects runtime_platform value to be
-        'soldier', 'sniper', 'medic' and 'steamrt5'
-        """
-        config = {
-            "umu": {
-                "versions": {
-                    "launcher": "0.1-RC3",
-                    "runner": "0.1-RC3",
-                    "runtime_platform": "foo",
-                }
-            }
-        }
-        test_config = json.dumps(config, indent=4)
-
-        self.test_user_share.joinpath("umu_version.json").unlink(
-            missing_ok=True
-        )
-        self.test_user_share.joinpath("umu_version.json").write_text(
-            test_config, encoding="utf-8"
-        )
-
-        with self.assertRaises(ValueError):
-            umu_runtime._get_json(self.test_user_share, "umu_version.json")
-
-    def test_get_json(self):
-        """Test _get_json.
-
-        This function is used to verify the existence and integrity of
-        umu_version.json file during the setup process
-
-        umu_version.json is used to synchronize the state of 2 directories:
-        /usr/share/umu and ~/.local/share/umu
-
-        An error should not be raised when passed a JSON we expect
-        """
-        result = None
-
-        self.assertTrue(
-            self.test_user_share.joinpath("umu_version.json").exists(),
-            "Expected umu_version.json to exist",
-        )
-
-        result = umu_runtime._get_json(
-            self.test_user_share, "umu_version.json"
-        )
-        self.assertIsInstance(result, dict, "Expected a dict")
 
     def test_latest_interrupt(self):
         """Test _get_latest when the user interrupts the download/extraction.

--- a/umu/umu_test_plugins.py
+++ b/umu/umu_test_plugins.py
@@ -193,6 +193,7 @@ class TestGameLauncherPlugins(unittest.TestCase):
         toml_path = self.test_file + "/" + test_toml
         result = None
         test_command = []
+        test_runtime_platform = ("steamrt3", "sniper", "1628350")
         Path(toml_path).touch()
 
         # Mock the proton file
@@ -220,10 +221,13 @@ class TestGameLauncherPlugins(unittest.TestCase):
         # Mock setting up the runtime
         # Don't copy _v2-entry-point
         with (
-            patch.object(umu_runtime, "_install_umu", return_value=None),
+            patch.object(umu_runtime, "setup_umu", return_value=None),
         ):
             umu_runtime.setup_umu(
-                self.test_user_share, self.test_local_share, None
+                self.test_user_share,
+                self.test_local_share,
+                test_runtime_platform,
+                None,
             )
             copytree(
                 Path(self.test_user_share, "sniper_platform_0.20240125.75305"),
@@ -272,6 +276,7 @@ class TestGameLauncherPlugins(unittest.TestCase):
         toml_path = self.test_file + "/" + test_toml
         result = None
         test_command = []
+        test_runtime_platform = ("steamrt3", "sniper", "1628350")
         Path(toml_path).touch()
 
         with Path(toml_path).open(mode="w", encoding="utf-8") as file:
@@ -298,7 +303,10 @@ class TestGameLauncherPlugins(unittest.TestCase):
             patch.object(umu_runtime, "_install_umu", return_value=None),
         ):
             umu_runtime.setup_umu(
-                self.test_user_share, self.test_local_share, None
+                self.test_user_share,
+                self.test_local_share,
+                test_runtime_platform,
+                None,
             )
             copytree(
                 Path(self.test_user_share, "sniper_platform_0.20240125.75305"),
@@ -348,6 +356,7 @@ class TestGameLauncherPlugins(unittest.TestCase):
         toml_path = self.test_file + "/" + test_toml
         result = None
         test_command = []
+        test_runtime_platform = ("steamrt3", "sniper", "1628350")
 
         Path(self.test_file + "/proton").touch()
         Path(toml_path).touch()
@@ -373,10 +382,13 @@ class TestGameLauncherPlugins(unittest.TestCase):
 
         # Mock setting up the runtime
         with (
-            patch.object(umu_runtime, "_install_umu", return_value=None),
+            patch.object(umu_runtime, "setup_umu", return_value=None),
         ):
             umu_runtime.setup_umu(
-                self.test_user_share, self.test_local_share, None
+                self.test_user_share,
+                self.test_local_share,
+                test_runtime_platform,
+                None,
             )
             copytree(
                 Path(self.test_user_share, "sniper_platform_0.20240125.75305"),

--- a/umu/umu_version.json.in
+++ b/umu/umu_version.json.in
@@ -1,9 +1,0 @@
-{
-  "umu": {
-    "versions": {
-      "launcher": "##UMU_VERSION##",
-      "runner": "##UMU_VERSION##",
-      "runtime_platform": "sniper"
-    }
-  }
-}


### PR DESCRIPTION
Related to https://github.com/Open-Wine-Components/umu-launcher/pull/178 and https://github.com/Open-Wine-Components/umu-launcher/pull/154 

## Changes 
- Deletes umu_version.json in favor updating global variables in `__init__.py`.
- Updates the directory structure of $HOME/.local/share/umu to store SLRs in subdirectories.
- Adds downloading and automatically changing to the correct runtime for Proton each launch

## Description
This PR changes the launcher so it automatically changes to the correct runtime for the set Proton each launch to prepare for future updates, and to downloaded the appropriate runtime for new installations. 

Currently, umu-launcher only officially supports running in the sniper container and using Proton versions compiled for it. However, not everyone will be using the latest runtime/Proton, and some clients (e.g., Steam, Heroic Games Launcher) allow their users to use obsolete Proton builds to run their games. More importantly, since updating to the latest SLR is currently a manual procedure, users may not be able to run their games in case the latest downloaded Proton and the installed SLR are out of sync as we download them in parallel and don't attempt to sync them.

Now, when the user sets an obsolete Proton build or when the runtime gets updated to a major version, umu-launcher will change to its intended runtime _if it was already downloaded_. This will prepare for the event when a major SLR is released (e.g., steamrt4) and when users still has some games configured in their client application to run in sniper. In that event, users will be responsible for deleting the obsolete runtimes at `$HOME/.local/share/umu`.

TODO:
- Add more tests
- Skip or attempt to synchronize with Proton updates
