### PR TITLE
fix: don't remove cache while installing new runtime

### DIFF
--- a/umu/umu_runtime.py
+++ b/umu/umu_runtime.py
@@ -170,9 +170,6 @@ def _install_umu(
                 ]
             )
 
-            # Remove the archive
-            futures.append(thread_pool.submit(rmtree, str(tmpcache)))
-
             for future in futures:
                 future.result()
 


### PR DESCRIPTION
Fixes a regression in the runtime code when updating the sniper runtime from 0.20240916.101795 -> 0.20241008.104210.