### PR TITLE
ci: add test for runtime updates

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,32 @@
+name: e2e
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: Install dependencies
+      run: |
+        sudo apt-get install meson scdoc python3-hatchling python3-build python3-installer python3-filelock
+    - name: Initialize submodules
+      run: |
+        git submodule update --init --recursive
+    - name: Make system package
+      run: |
+        ./configure.sh --prefix=/usr
+        make DESTDIR=dist install
+    - name: Run tests
+      run: |
+        bash tests/test_update.sh

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Make system package
       run: |
         ./configure.sh --prefix=/usr
-        make DESTDIR=dist install
+        sudo make install
     - name: Run tests
       run: |
         bash tests/test_update.sh

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -25,9 +25,8 @@ jobs:
         git submodule update --init --recursive
     - name: Make system package
       run: |
-        ./configure.sh --prefix=/usr
-        sudo make install
+        ./configure.sh --user-install
+        make install
     - name: Run tests
       run: |
-        which umu-run
         bash tests/test_update.sh

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Initialize submodules
       run: |
         git submodule update --init --recursive
-    - name: Make system package
+    - name: Make user install
       run: |
         ./configure.sh --user-install
         make install

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -29,4 +29,5 @@ jobs:
         sudo make install
     - name: Run tests
       run: |
+        which umu-run
         bash tests/test_update.sh

--- a/tests/test_update.sh
+++ b/tests/test_update.sh
@@ -7,4 +7,4 @@ tar xaf SteamLinuxRuntime_sniper.tar.xz
 mv SteamLinuxRuntime_sniper/* $HOME/.local/share/umu
 mv $HOME/.local/share/umu/_v2-entry-point $HOME/.local/share/umu/umu
 
-UMU_LOG=debug GAMEID=umu-0 /usr/bin/umu-run wineboot -u
+UMU_LOG=debug GAMEID=umu-0 umu-run wineboot -u

--- a/tests/test_update.sh
+++ b/tests/test_update.sh
@@ -7,4 +7,4 @@ tar xaf SteamLinuxRuntime_sniper.tar.xz
 mv SteamLinuxRuntime_sniper/* $HOME/.local/share/umu
 mv $HOME/.local/share/umu/_v2-entry-point $HOME/.local/share/umu/umu
 
-UMU_LOG=debug GAMEID=umu-0 umu-run wineboot -u
+UMU_LOG=debug GAMEID=umu-0 $HOME/.local/bin/umu-run wineboot -u

--- a/tests/test_update.sh
+++ b/tests/test_update.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env sh
+
+mkdir -p $HOME/.local/share/umu
+
+curl -LJO "https://repo.steampowered.com/steamrt3/images/0.20240916.101795/SteamLinuxRuntime_sniper.tar.xz"
+tar xaf SteamLinuxRuntime_sniper.tar.xz .
+mv SteamLinuxRuntime_sniper/* $HOME/.local/share/umu
+mv $HOME/.local/share/umu/_v2-entry-point $HOME/.local/share/umu/umu
+
+UMU_LOG=debug GAMEID=umu-0 umu-run wineboot -u

--- a/tests/test_update.sh
+++ b/tests/test_update.sh
@@ -3,7 +3,7 @@
 mkdir -p $HOME/.local/share/umu
 
 curl -LJO "https://repo.steampowered.com/steamrt3/images/0.20240916.101795/SteamLinuxRuntime_sniper.tar.xz"
-tar xaf SteamLinuxRuntime_sniper.tar.xz .
+tar xaf SteamLinuxRuntime_sniper.tar.xz
 mv SteamLinuxRuntime_sniper/* $HOME/.local/share/umu
 mv $HOME/.local/share/umu/_v2-entry-point $HOME/.local/share/umu/umu
 

--- a/tests/test_update.sh
+++ b/tests/test_update.sh
@@ -7,4 +7,4 @@ tar xaf SteamLinuxRuntime_sniper.tar.xz
 mv SteamLinuxRuntime_sniper/* $HOME/.local/share/umu
 mv $HOME/.local/share/umu/_v2-entry-point $HOME/.local/share/umu/umu
 
-UMU_LOG=debug GAMEID=umu-0 umu-run wineboot -u
+UMU_LOG=debug GAMEID=umu-0 /usr/bin/umu-run wineboot -u


### PR DESCRIPTION
Ensures bugs like https://github.com/Open-Wine-Components/umu-launcher/commit/976ccfae0685fc4bd781e19d0cbf935d8016da17 will not occur again in cases when the steam runtime updates to its next minor version or regressions in the runtime code introduced in rebases/merge conflicts.