### PR TITLE
ci: add more e2e tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -20,6 +20,8 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get install meson scdoc python3-hatchling python3-build python3-installer python3-filelock shellcheck
+        python3 -m pip install --upgrade pip
+        pip install uv
     - name: Initialize submodules
       run: |
         git submodule update --init --recursive
@@ -34,8 +36,12 @@ jobs:
       run: |
         bash tests/test_update.sh
         rm -rf "$HOME/.local/share/umu" "$HOME/Games/umu" "$HOME/.local/share/Steam/compatibilitytools.d"
-        bash tests/test_config.sh
+
+        uv python install 3.11
+        uv run --python pypy@3.11 -- bash tests/test_config.sh
         rm -rf "$HOME/.local/share/umu" "$HOME/Games/umu" "$HOME/.local/share/Steam/compatibilitytools.d"
+
         bash tests/test_install.sh
         rm -rf "$HOME/.local/share/umu" "$HOME/Games/umu" "$HOME/.local/share/Steam/compatibilitytools.d"
+
         bash tests/test_winetricks.sh

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -38,7 +38,7 @@ jobs:
         rm -rf "$HOME/.local/share/umu" "$HOME/Games/umu" "$HOME/.local/share/Steam/compatibilitytools.d"
 
         uv python install 3.11
-        uv run --python pypy@3.11 -- bash tests/test_config.sh
+        uv run --python 3.11 -- bash tests/test_config.sh
         rm -rf "$HOME/.local/share/umu" "$HOME/Games/umu" "$HOME/.local/share/Steam/compatibilitytools.d"
 
         bash tests/test_install.sh

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -19,7 +19,7 @@ jobs:
         fetch-depth: 0
     - name: Install dependencies
       run: |
-        sudo apt-get install meson scdoc python3-hatchling python3-build python3-installer python3-filelock
+        sudo apt-get install meson scdoc python3-hatchling python3-build python3-installer python3-filelock shellcheck
     - name: Initialize submodules
       run: |
         git submodule update --init --recursive
@@ -27,6 +27,9 @@ jobs:
       run: |
         ./configure.sh --user-install
         make install
+    - name: Run shellcheck
+      run: |
+        shellcheck tests/*.sh
     - name: Run tests
       run: |
         bash tests/test_update.sh

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -32,16 +32,19 @@ jobs:
     - name: Run shellcheck
       run: |
         shellcheck tests/*.sh
-    - name: Run tests
+    - name: Test steamrt install
+      run: |
+        bash tests/test_install.sh
+        rm -rf "$HOME/.local/share/umu" "$HOME/Games/umu" "$HOME/.local/share/Steam/compatibilitytools.d"
+    - name: Test steamrt update
       run: |
         bash tests/test_update.sh
         rm -rf "$HOME/.local/share/umu" "$HOME/Games/umu" "$HOME/.local/share/Steam/compatibilitytools.d"
-
+    - name: Test winetricks
+      run: |
+        bash tests/test_winetricks.sh
+        rm -rf "$HOME/.local/share/umu" "$HOME/Games/umu" "$HOME/.local/share/Steam/compatibilitytools.d"
+    - name: Test configuration file
+      run: |
         uv python install 3.11
         uv run --python 3.11 -- bash tests/test_config.sh
-        rm -rf "$HOME/.local/share/umu" "$HOME/Games/umu" "$HOME/.local/share/Steam/compatibilitytools.d"
-
-        bash tests/test_install.sh
-        rm -rf "$HOME/.local/share/umu" "$HOME/Games/umu" "$HOME/.local/share/Steam/compatibilitytools.d"
-
-        bash tests/test_winetricks.sh

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -43,7 +43,7 @@ jobs:
     - name: Test winetricks
       run: |
         bash tests/test_winetricks.sh
-        rm -rf "$HOME/.local/share/umu" "$HOME/Games/umu" "$HOME/.local/share/Steam/compatibilitytools.d"
+        rm -rf "$HOME/.local/share/umu" "$HOME/.local/share/Steam/compatibilitytools.d"
     - name: Test configuration file
       run: |
         uv python install 3.11

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -34,17 +34,17 @@ jobs:
         shellcheck tests/*.sh
     - name: Test steamrt install
       run: |
-        bash tests/test_install.sh
+        sh tests/test_install.sh
         rm -rf "$HOME/.local/share/umu" "$HOME/Games/umu" "$HOME/.local/share/Steam/compatibilitytools.d"
     - name: Test steamrt update
       run: |
-        bash tests/test_update.sh
+        sh tests/test_update.sh
         rm -rf "$HOME/.local/share/umu" "$HOME/Games/umu" "$HOME/.local/share/Steam/compatibilitytools.d"
     - name: Test winetricks
       run: |
-        bash tests/test_winetricks.sh
+        sh tests/test_winetricks.sh
         rm -rf "$HOME/.local/share/umu" "$HOME/.local/share/Steam/compatibilitytools.d"
     - name: Test configuration file
       run: |
         uv python install 3.11
-        uv run --python 3.11 -- bash tests/test_config.sh
+        uv run --python 3.11 -- sh tests/test_config.sh

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -30,3 +30,9 @@ jobs:
     - name: Run tests
       run: |
         bash tests/test_update.sh
+        rm -rf "$HOME/.local/share/umu" "$HOME/Games/umu" "$HOME/.local/share/Steam/compatibilitytools.d"
+        bash tests/test_config.sh
+        rm -rf "$HOME/.local/share/umu" "$HOME/Games/umu" "$HOME/.local/share/Steam/compatibilitytools.d"
+        bash tests/test_install.sh
+        rm -rf "$HOME/.local/share/umu" "$HOME/Games/umu" "$HOME/.local/share/Steam/compatibilitytools.d"
+        bash tests/test_winetricks.sh

--- a/tests/test_config.sh
+++ b/tests/test_config.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env sh
+
+tmp=$(mktemp)
+mkdir -p "$HOME/.local/share/Steam/compatibilitytools.d"
+mkdir -p "$HOME/Games/umu/umu-0"
+curl -LJO "https://github.com/GloriousEggroll/proton-ge-custom/releases/download/GE-Proton9-15/GE-Proton9-15.tar.gz"
+tar xafv GE-Proton9-15.tar.gz
+mv GE-Proton9-15 "$HOME/.local/share/Steam/compatibilitytools.d"
+
+echo "[umu]
+proton = '~/.local/share/Steam/compatibilitytools.d/GE-Proton9-15'
+game_id = 'umu-0'
+prefix = '~/Games/umu/umu-0'
+exe = '~/.wine/drive_c/windows/syswow64/wineboot.exe'
+launch_args = ['-u']
+" >> "$tmp"
+
+
+cd $HOME && UMU_LOG=debug GAMEID=umu-0 "$HOME/.local/bin/umu-run" --config "$tmp"

--- a/tests/test_config.sh
+++ b/tests/test_config.sh
@@ -4,7 +4,8 @@ python --version
 
 tmp=$(mktemp)
 mkdir -p "$HOME/.local/share/Steam/compatibilitytools.d"
-mkdir -p "$HOME/Games/umu/umu-0"
+mkdir -p "$HOME/Games/umu/umu-0/drive_c/windows/syswow64"
+touch "$HOME/Games/umu/umu-0/drive_c/windows/syswow64/wineboot.exe"
 curl -LJO "https://github.com/GloriousEggroll/proton-ge-custom/releases/download/GE-Proton9-15/GE-Proton9-15.tar.gz"
 tar xaf GE-Proton9-15.tar.gz
 mv GE-Proton9-15 "$HOME/.local/share/Steam/compatibilitytools.d"
@@ -13,7 +14,7 @@ echo "[umu]
 proton = '~/.local/share/Steam/compatibilitytools.d/GE-Proton9-15'
 game_id = 'umu-0'
 prefix = '~/Games/umu/umu-0'
-exe = '~/.wine/drive_c/windows/syswow64/wineboot.exe'
+exe = '~/Games/umu/umu-0/drive_c/windows/syswow64/wineboot.exe'
 launch_args = ['-u']
 " >> "$tmp"
 

--- a/tests/test_config.sh
+++ b/tests/test_config.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env sh
 
+python --version
+
 tmp=$(mktemp)
 mkdir -p "$HOME/.local/share/Steam/compatibilitytools.d"
 mkdir -p "$HOME/Games/umu/umu-0"

--- a/tests/test_config.sh
+++ b/tests/test_config.sh
@@ -5,12 +5,12 @@ python --version
 tmp=$(mktemp)
 mkdir -p "$HOME/.local/share/Steam/compatibilitytools.d"
 mkdir -p "$HOME/Games/umu/umu-0"
-curl -LJO "https://github.com/GloriousEggroll/proton-ge-custom/releases/download/GE-Proton9-15/GE-Proton9-15.tar.gz"
-tar xaf GE-Proton9-15.tar.gz
-mv GE-Proton9-15 "$HOME/.local/share/Steam/compatibilitytools.d"
+curl -LJO "https://github.com/Open-Wine-Components/umu-proton/releases/download/UMU-Proton-9.0-3/UMU-Proton-9.0-3.tar.gz"
+tar xaf UMU-Proton-9.0-3.tar.gz
+mv UMU-Proton-9.0-3 "$HOME/.local/share/Steam/compatibilitytools.d"
 
 echo "[umu]
-proton = '~/.local/share/Steam/compatibilitytools.d/GE-Proton9-15'
+proton = '~/.local/share/Steam/compatibilitytools.d/UMU-Proton-9.0-3'
 game_id = 'umu-0'
 prefix = '~/Games/umu/umu-0'
 exe = '~/Games/umu/umu-0/drive_c/windows/syswow64/wineboot.exe'

--- a/tests/test_config.sh
+++ b/tests/test_config.sh
@@ -4,7 +4,7 @@ tmp=$(mktemp)
 mkdir -p "$HOME/.local/share/Steam/compatibilitytools.d"
 mkdir -p "$HOME/Games/umu/umu-0"
 curl -LJO "https://github.com/GloriousEggroll/proton-ge-custom/releases/download/GE-Proton9-15/GE-Proton9-15.tar.gz"
-tar xafv GE-Proton9-15.tar.gz
+tar xaf GE-Proton9-15.tar.gz
 mv GE-Proton9-15 "$HOME/.local/share/Steam/compatibilitytools.d"
 
 echo "[umu]

--- a/tests/test_config.sh
+++ b/tests/test_config.sh
@@ -16,4 +16,4 @@ launch_args = ['-u']
 " >> "$tmp"
 
 
-cd $HOME && UMU_LOG=debug GAMEID=umu-0 "$HOME/.local/bin/umu-run" --config "$tmp"
+UMU_LOG=debug GAMEID=umu-0 "$HOME/.local/bin/umu-run" --config "$tmp"

--- a/tests/test_config.sh
+++ b/tests/test_config.sh
@@ -18,4 +18,4 @@ launch_args = ['-u']
 " >> "$tmp"
 
 
-UMU_LOG=debug GAMEID=umu-0 "$HOME/.local/bin/umu-run" --config "$tmp"
+UMU_LOG=debug GAMEID=umu-0 "$PWD/.venv/bin/python" "$HOME/.local/bin/umu-run" --config "$tmp"

--- a/tests/test_config.sh
+++ b/tests/test_config.sh
@@ -4,8 +4,7 @@ python --version
 
 tmp=$(mktemp)
 mkdir -p "$HOME/.local/share/Steam/compatibilitytools.d"
-mkdir -p "$HOME/Games/umu/umu-0/drive_c/windows/syswow64"
-touch "$HOME/Games/umu/umu-0/drive_c/windows/syswow64/wineboot.exe"
+mkdir -p "$HOME/Games/umu/umu-0"
 curl -LJO "https://github.com/GloriousEggroll/proton-ge-custom/releases/download/GE-Proton9-15/GE-Proton9-15.tar.gz"
 tar xaf GE-Proton9-15.tar.gz
 mv GE-Proton9-15 "$HOME/.local/share/Steam/compatibilitytools.d"

--- a/tests/test_install.sh
+++ b/tests/test_install.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env sh
 
-UMU_LOG=debug GAMEID=umu-0 $HOME/.local/bin/umu-run wineboot -u
+UMU_LOG=debug GAMEID=umu-0 "$HOME/.local/bin/umu-run" wineboot -u

--- a/tests/test_install.sh
+++ b/tests/test_install.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+
+UMU_LOG=debug GAMEID=umu-0 $HOME/.local/bin/umu-run wineboot -u

--- a/tests/test_update.sh
+++ b/tests/test_update.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env sh
 
-mkdir -p $HOME/.local/share/umu
+mkdir -p "$HOME/.local/share/umu"
 
 curl -LJO "https://repo.steampowered.com/steamrt3/images/0.20240916.101795/SteamLinuxRuntime_sniper.tar.xz"
 tar xaf SteamLinuxRuntime_sniper.tar.xz
-mv SteamLinuxRuntime_sniper/* $HOME/.local/share/umu
-mv $HOME/.local/share/umu/_v2-entry-point $HOME/.local/share/umu/umu
+mv SteamLinuxRuntime_sniper/* "$HOME/.local/share/umu"
+mv "$HOME/.local/share/umu/_v2-entry-point" "$HOME/.local/share/umu/umu"
 
-UMU_LOG=debug GAMEID=umu-0 $HOME/.local/bin/umu-run wineboot -u
+UMU_LOG=debug GAMEID=umu-0 "$HOME/.local/bin/umu-run" wineboot -u

--- a/tests/test_winetricks.sh
+++ b/tests/test_winetricks.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+
+UMU_LOG=debug GAMEID=umu-0 $HOME/.local/bin/umu-run winetricks good

--- a/tests/test_winetricks.sh
+++ b/tests/test_winetricks.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env sh
 
-UMU_LOG=debug GAMEID=umu-0 $HOME/.local/bin/umu-run winetricks good
+UMU_LOG=debug GAMEID=umu-0 "$HOME/.local/bin/umu-run winetricks" good

--- a/tests/test_winetricks.sh
+++ b/tests/test_winetricks.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env sh
 
-UMU_LOG=debug GAMEID=umu-0 "$HOME/.local/bin/umu-run winetricks" good
+UMU_LOG=debug GAMEID=umu-0 "$HOME/.local/bin/umu-run" winetricks good


### PR DESCRIPTION
Adds tests that represent the following:

- Setting up umu for the first time
- Installing winetricks verbs
- Running umu via the configuration file usage

Mitigates cases like https://github.com/Open-Wine-Components/umu-launcher/commit/976ccfae0685fc4bd781e19d0cbf935d8016da17 from happening in case of merge conflicts/implementation changes.