### PR TITLE
fix: remove runtime variable directory each update

### DIFF
--- a/tests/test_update.sh
+++ b/tests/test_update.sh
@@ -7,4 +7,8 @@ tar xaf SteamLinuxRuntime_sniper.tar.xz
 mv SteamLinuxRuntime_sniper/* "$HOME/.local/share/umu"
 mv "$HOME/.local/share/umu/_v2-entry-point" "$HOME/.local/share/umu/umu"
 
+# Perform a preflight step, where we ensure everything is in order and create '$HOME/.local/share/umu/var'
+UMU_LOG=debug GAMEID=umu-0 UMU_RUNTIME_UPDATE=0 "$HOME/.local/bin/umu-run" wineboot -u
+
+# Run a 2nd time to perform the runtime update and ensure '$HOME/.local/share/umu/var' is removed
 UMU_LOG=debug GAMEID=umu-0 "$HOME/.local/bin/umu-run" wineboot -u

--- a/tests/test_update.sh
+++ b/tests/test_update.sh
@@ -8,7 +8,5 @@ mv SteamLinuxRuntime_sniper/* "$HOME/.local/share/umu"
 mv "$HOME/.local/share/umu/_v2-entry-point" "$HOME/.local/share/umu/umu"
 
 # Perform a preflight step, where we ensure everything is in order and create '$HOME/.local/share/umu/var'
-UMU_LOG=debug GAMEID=umu-0 UMU_RUNTIME_UPDATE=0 "$HOME/.local/bin/umu-run" wineboot -u
-
-# Run a 2nd time to perform the runtime update and ensure '$HOME/.local/share/umu/var' is removed
-UMU_LOG=debug GAMEID=umu-0 "$HOME/.local/bin/umu-run" wineboot -u
+# Afterwards, run a 2nd time to perform the runtime update and ensure '$HOME/.local/share/umu/var' is removed
+UMU_LOG=debug GAMEID=umu-0 UMU_RUNTIME_UPDATE=0 "$HOME/.local/bin/umu-run" wineboot -u && UMU_LOG=debug GAMEID=umu-0 "$HOME/.local/bin/umu-run" wineboot -u

--- a/umu/umu_runtime.py
+++ b/umu/umu_runtime.py
@@ -173,6 +173,10 @@ def _install_umu(
 
             if var.is_dir():
                 log.debug("Removing: %s", var)
+                # Remove the variable directory to avoid Steam Linux Runtime
+                # related errors when creating it. Supposedly, it only happens
+                # when going from umu-launcher 0.1-RC4 -> 1.1.1
+                # See https://github.com/Open-Wine-Components/umu-launcher/issues/213#issue-2576708738
                 thread_pool.submit(rmtree, str(var))
 
             for future in futures:

--- a/umu/umu_runtime.py
+++ b/umu/umu_runtime.py
@@ -159,6 +159,7 @@ def _install_umu(
 
             # Move the files to the correct location
             source_dir: Path = Path(tmpcache, f"SteamLinuxRuntime_{codename}")
+            var: Path = UMU_LOCAL.joinpath("var")
             log.debug("Source: %s", source_dir)
             log.debug("Destination: %s", UMU_LOCAL)
 
@@ -169,6 +170,10 @@ def _install_umu(
                     for file in source_dir.glob("*")
                 ]
             )
+
+            if var.is_dir():
+                log.debug("Removing: %s", var)
+                thread_pool.submit(rmtree, str(var))
 
             for future in futures:
                 future.result()


### PR DESCRIPTION
Related to https://github.com/Open-Wine-Components/umu-launcher/issues/213

Aims to fix reported issues such as:
```
pressure-vessel-wrap[73104]: W: /home/wyktor/.local/share/umu/var/tmp-LHAPV2/bin does not exist, this probably won't work
pressure-vessel-wrap[73104]: W: /home/wyktor/.local/share/umu/var/tmp-LHAPV2/etc does not exist, this probably won't work
pressure-vessel-wrap[73104]: W: /home/wyktor/.local/share/umu/var/tmp-LHAPV2/lib does not exist, this probably won't work
pressure-vessel-wrap[73104]: W: /home/wyktor/.local/share/umu/var/tmp-LHAPV2/sbin does not exist, this probably won't work
```

-whenever the Steam Runtime updates.
