### PR TITLE
feat: force reinstall of runtime

### DIFF
--- a/docs/umu.1.scd
+++ b/docs/umu.1.scd
@@ -166,7 +166,8 @@ _UMU_ZENITY_
 _UMU_RUNTIME_UPDATE_
 	Optional. Disables automatic updates to the *Steam Linux Runtime*[6].
 
-	Set _0_ to disable updates.
+	Set _0_ to disable updates. Set _1_ to force updates and restore
+	_$HOME/.local/share/umu_ to clean state.
 
 # SEE ALSO
 

--- a/umu/umu_runtime.py
+++ b/umu/umu_runtime.py
@@ -212,6 +212,21 @@ def setup_umu(
 
     find_obsolete()
 
+    # Force a runtime update
+    if os.environ.get("UMU_RUNTIME_UPDATE") == "1":
+        log.debug("Forcing update to Runtime Platform")
+        log.debug("Removing: %s", local)
+        rmtree(str(local))
+        local.mkdir(parents=True, exist_ok=True)
+        with https_connection(host) as client_session:
+            _restore_umu(
+                json,
+                thread_pool,
+                lambda: local.joinpath("umu").is_file(),
+                client_session,
+            )
+        return
+
     with https_connection(host) as client_session:
         _update_umu(local, json, thread_pool, client_session)
 

--- a/umu/umu_runtime.py
+++ b/umu/umu_runtime.py
@@ -23,7 +23,7 @@ from filelock import FileLock
 
 from umu.umu_consts import CONFIG, UMU_CACHE, UMU_LOCAL
 from umu.umu_log import log
-from umu.umu_util import find_obsolete, https_connection, run_zenity
+from umu.umu_util import https_connection, run_zenity
 
 try:
     from tarfile import tar_filter
@@ -209,8 +209,6 @@ def setup_umu(
     if os.environ.get("UMU_RUNTIME_UPDATE") == "0":
         log.debug("Runtime Platform updates disabled")
         return
-
-    find_obsolete()
 
     # Force a runtime update
     if os.environ.get("UMU_RUNTIME_UPDATE") == "1":

--- a/umu/umu_util.py
+++ b/umu/umu_util.py
@@ -6,13 +6,12 @@ from http.client import HTTPSConnection
 from pathlib import Path
 from re import Pattern
 from re import compile as re_compile
-from shutil import rmtree, which
+from shutil import which
 from ssl import SSLContext, create_default_context
 from subprocess import PIPE, STDOUT, Popen, TimeoutExpired
 
 from Xlib import display
 
-from umu.umu_consts import STEAM_COMPAT, UMU_LOCAL
 from umu.umu_log import log
 
 ssl_context: SSLContext | None = None
@@ -171,45 +170,6 @@ def is_winetricks_verb(
             return False
 
     return True
-
-
-def find_obsolete() -> None:
-    """Find obsoleted launcher files and log them."""
-    home: Path = Path.home()
-    obsoleted: set[str] = {
-        "reaper",
-        "sniper_platform_0.20240125.75305",
-        "BUILD_ID.txt",
-        "umu_version.json",
-        "sniper_platform_0.20231211.70175",
-    }
-    obsolete: Path
-
-    # Obsoleted files in $HOME/.local/share/umu from RC4 and below
-    for file in UMU_LOCAL.glob("*"):
-        is_umu_file: bool = file.name.endswith(".py") and (
-            file.name.startswith(("umu", "ulwgl"))
-        )
-        if is_umu_file or file.name in obsoleted:
-            if file.is_file():
-                file.unlink()
-            if file.is_dir():
-                rmtree(str(file))
-
-    # $HOME/.local/share/Steam/compatibilitytool.d
-    obsolete = STEAM_COMPAT.joinpath("ULWGL-Launcher")
-    if obsolete.is_dir():
-        rmtree(str(obsolete))
-
-    # $HOME/.cache
-    obsolete = home.joinpath(".cache", "ULWGL")
-    if obsolete.is_dir():
-        rmtree(str(obsolete))
-
-    # $HOME/.local/share
-    obsolete = home.joinpath(".local", "share", "ULWGL")
-    if obsolete.is_dir():
-        rmtree(str(obsolete))
 
 
 @contextmanager

--- a/umu/umu_util.py
+++ b/umu/umu_util.py
@@ -6,7 +6,7 @@ from http.client import HTTPSConnection
 from pathlib import Path
 from re import Pattern
 from re import compile as re_compile
-from shutil import which
+from shutil import rmtree, which
 from ssl import SSLContext, create_default_context
 from subprocess import PIPE, STDOUT, Popen, TimeoutExpired
 
@@ -183,6 +183,7 @@ def find_obsolete() -> None:
         "umu_version.json",
         "sniper_platform_0.20231211.70175",
     }
+    obsolete: Path
 
     # Obsoleted files in $HOME/.local/share/umu from RC4 and below
     for file in UMU_LOCAL.glob("*"):
@@ -190,19 +191,25 @@ def find_obsolete() -> None:
             file.name.startswith(("umu", "ulwgl"))
         )
         if is_umu_file or file.name in obsoleted:
-            log.warning("'%s' is obsolete", file)
+            if file.is_file():
+                file.unlink()
+            if file.is_dir():
+                rmtree(str(file))
 
     # $HOME/.local/share/Steam/compatibilitytool.d
-    if (launcher := STEAM_COMPAT.joinpath("ULWGL-Launcher")).is_dir():
-        log.warning("'%s' is obsolete", launcher)
+    obsolete = STEAM_COMPAT.joinpath("ULWGL-Launcher")
+    if obsolete.is_dir():
+        rmtree(str(obsolete))
 
     # $HOME/.cache
-    if (cache := home.joinpath(".cache", "ULWGL")).is_dir():
-        log.warning("'%s' is obsolete", cache)
+    obsolete = home.joinpath(".cache", "ULWGL")
+    if obsolete.is_dir():
+        rmtree(str(obsolete))
 
     # $HOME/.local/share
-    if (ulwgl := home.joinpath(".local", "share", "ULWGL")).is_dir():
-        log.warning("'%s' is obsolete", ulwgl)
+    obsolete = home.joinpath(".local", "share", "ULWGL")
+    if obsolete.is_dir():
+        rmtree(str(obsolete))
 
 
 @contextmanager


### PR DESCRIPTION
Allows clients to force reinstall latest runtime via `UMU_RUNTIME_UPDATE=1`. 

**Note**: Setting `UMU_RUNTIME_UPDATE=1` will delete everything in `$HOME/.local/share/umu`