### PR TITLE
refactor: restore runtime depending on directory integrity

### DIFF
--- a/docs/umu.1.scd
+++ b/docs/umu.1.scd
@@ -168,6 +168,13 @@ _UMU_RUNTIME_UPDATE_
 
 	Set _0_ to disable updates.
 
+_UMU_RUNTIME_INTEGRITY_
+	Optional. Enables automatic integrity checking of runtime files in
+	_$HOME/.local/share/umu_.
+
+	Set _1_ to verify integrity of runtime contents on launch and to auto restore
+	them on corruption.
+
 # SEE ALSO
 
 _umu_(5), _winetricks_(1), _zenity_(1)

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -291,6 +291,9 @@ def set_env(
     # Runtime
     env["UMU_NO_RUNTIME"] = os.environ.get("UMU_NO_RUNTIME") or ""
     env["UMU_RUNTIME_UPDATE"] = os.environ.get("UMU_RUNTIME_UPDATE") or ""
+    env["UMU_RUNTIME_INTEGRITY"] = (
+        os.environ.get("UMU_RUNTIME_INTEGRITY") or ""
+    )
 
     return env
 
@@ -723,6 +726,7 @@ def main() -> int:  # noqa: D103
         "UMU_ZENITY": "",
         "UMU_NO_RUNTIME": "",
         "UMU_RUNTIME_UPDATE": "",
+        "UMU_RUNTIME_INTEGRITY": "",
     }
     opts: list[str] = []
     prereq: bool = False

--- a/umu/umu_runtime.py
+++ b/umu/umu_runtime.py
@@ -547,6 +547,26 @@ def get_runtime_digest(path: Path, thread_pool: ThreadPoolExecutor) -> str:
     return hashsum.hexdigest()
 
 
+def _compute_digest(stat: os.stat_result):  # noqa: ANN202
+    hashsum = sha256()
+    fmt: str = "fiiiif"
+
+    hashsum.update(
+        pack(
+            fmt,
+            stat.st_mtime,  # Modification time
+            stat.st_mode,  # Permissions
+            stat.st_size,  # Size
+            stat.st_uid,  # User
+            stat.st_gid,  # Group
+            stat.st_ctime,  # Creation time
+        )
+        + bytes(2048)  # Pad enough bytes to release the GIL
+    )
+
+    return hashsum
+
+
 def _restore_umu(
     json: dict[str, Any],
     thread_pool: ThreadPoolExecutor,

--- a/umu/umu_runtime.py
+++ b/umu/umu_runtime.py
@@ -189,7 +189,20 @@ def _install_umu(
     UMU_LOCAL.joinpath("_v2-entry-point").rename(UMU_LOCAL.joinpath("umu"))
 
     # Validate the runtime after moving the files
-    check_runtime(UMU_LOCAL, json)
+    ret = check_runtime(UMU_LOCAL, json)
+
+    # Compute a digest of the metadata for future attestation
+    if ret != 1:
+        # At this point, the runtime is authenticated. For subsequent launches,
+        # we'll check against our digest to ensure we're intact
+        thread_pool.submit(
+            UMU_LOCAL.joinpath("umu.hashsum").write_text,
+            get_runtime_digest(UMU_LOCAL, thread_pool),
+            "utf-8",
+        )
+        return
+
+    log.warning("steamrt validation failed, skipping metadata checksum")
 
 
 def setup_umu(


### PR DESCRIPTION
Creates a checksum file `umu.hashsum` in `$HOME/.local/share/umu` or `$HOME/.var/app/org.openwinecomponents.umu.umu-launcher/data/umu` that stores the sha256 checksum of all the runtime files metadata. The file will be used each launch to automatically restore the runtime if the runtime directory is either tampered, corrupted, or if the checksum file itself is missing.

**Note**: Once this is merged, this will delete all users `$HOME/.local/share/umu` or `$HOME/.var/app/org.openwinecomponents.umu.umu-launcher/data/umu` directory and restore the runtime back to a clean state with the checksum file.

Expecting this to fix both current Lutris and Heroic users who are experiencing problems with missing files after installing or updating the runtime.

Tested on Lutris 0.5.17 with its runtime update. Additionally, a branch is made at https://github.com/Open-Wine-Components/umu-launcher/tree/integrity-check for testing.