### PR TITLE
packaging/flatpak: add flathub remote, fix placement of --env parameter in example calls

### DIFF
--- a/packaging/flatpak/README.md
+++ b/packaging/flatpak/README.md
@@ -9,6 +9,7 @@ sudo apt install flatpak-builder
 
 # Build + install (for testing):
 ```
+flatpak remote-add --user --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
 flatpak-builder --force-clean --user --install-deps-from=flathub --repo=umu-repo --install umu-launcher org.openwinecomponents.umu.umu-launcher.yml
 ```
 
@@ -31,10 +32,10 @@ flatpak run --env=GAMEID=umu-starcitizen --env=WINEPREFIX=/home/tcrider/Games/um
 
 # running a game using the latest GE-Proton:
 ```
-flatpak run --env=GAMEID=umu-starcitizen --env=WINEPREFIX=/home/tcrider/Games/umu/umu-starcitizen org.openwinecomponents.umu.umu-launcher --env=PROTONPATH=GE-Proton /path/to/some/game.exe
+flatpak run --env=GAMEID=umu-starcitizen --env=WINEPREFIX=/home/tcrider/Games/umu/umu-starcitizen --env=PROTONPATH=GE-Proton org.openwinecomponents.umu.umu-launcher /path/to/some/game.exe
 ```
 
 # running a game using a specific proton version:
 ```
-flatpak run --env=GAMEID=umu-starcitizen --env=WINEPREFIX=/home/tcrider/Games/umu/umu-starcitizen org.openwinecomponents.umu.umu-launcher --env=PROTONPATH=GE-Proton9-1 /path/to/some/game.exe
+flatpak run --env=GAMEID=umu-starcitizen --env=WINEPREFIX=/home/tcrider/Games/umu/umu-starcitizen --env=PROTONPATH=GE-Proton9-1 org.openwinecomponents.umu.umu-launcher /path/to/some/game.exe
 ```


### PR DESCRIPTION
motivation of `--env` parameter placement:
flatpak will interpret `--env=PROTONPATH=GE-Proton` **after** the app identifier as the executeable path, leading to errors for the example calls

motivation of the flathub remote-add:
quite a lot of users will not have flathub specified as a user repo, leading to a failure when trying the example build call (which uses `--user --install-deps-from=flathub`), add it with `--if-no-exists` so it doesn't hurt users that already have it