### PR TITLE
fix: add workaround to handle 32-bit driver paths on ubuntu

### DIFF
--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -269,7 +269,7 @@ def set_env(
 
     os_release: dict[str, str] = freedesktop_os_release()
 
-    if os_release.get("id") == "ubuntu":
+    if os_release.get("ID") == "ubuntu":
         # Ubuntu seems to require special handling as pressure-vessel is unable locate Mesa DRI drivers
         # and expose them in the container
         # See https://github.com/Open-Wine-Components/umu-launcher/issues/211

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -270,7 +270,7 @@ def set_env(
     os_release: dict[str, str] = freedesktop_os_release()
 
     if os_release.get("id") == "ubuntu":
-        # Ubuntu seems to require special handling as pressure-vessel is unable locate Mesa DRI driver
+        # Ubuntu seems to require special handling as pressure-vessel is unable locate Mesa DRI drivers
         # and expose them in the container
         # See https://github.com/Open-Wine-Components/umu-launcher/issues/211
         env["LIBGL_DRIVERS_PATH"] = (

--- a/umu/umu_util.py
+++ b/umu/umu_util.py
@@ -1,10 +1,10 @@
 import os
-from platform import freedesktop_os_release
 from contextlib import contextmanager
 from ctypes.util import find_library
 from functools import lru_cache
 from http.client import HTTPSConnection
 from pathlib import Path
+from platform import freedesktop_os_release
 from re import Pattern
 from re import compile as re_compile
 from shutil import rmtree, which

--- a/umu/umu_util.py
+++ b/umu/umu_util.py
@@ -65,7 +65,7 @@ def get_library_paths() -> set[str]:
     # Workaround for Ubuntu not finding 32-bit paths.
     # Values align and are taken from our snap manifest
     # See https://github.com/Open-Wine-Components/umu-launcher/issues/211
-    if os_release.get("id") == "ubuntu":
+    if os_release.get("ID") == "ubuntu":
         library_paths |= {
             "/usr/lib/i386-linux-gnu/pulseaudio",
             "/usr/lib/i386-linux-gnu",

--- a/umu/umu_util.py
+++ b/umu/umu_util.py
@@ -62,7 +62,8 @@ def get_library_paths() -> set[str]:
 
     os_release: dict[str, str] = freedesktop_os_release()
 
-    # Workaround for Ubuntu not find 32-bit paths
+    # Workaround for Ubuntu not finding 32-bit paths.
+    # Values align and are taken from our snap manifest
     # See https://github.com/Open-Wine-Components/umu-launcher/issues/211
     if os_release.get("id") == "ubuntu":
         library_paths |= {

--- a/umu/umu_util.py
+++ b/umu/umu_util.py
@@ -1,4 +1,5 @@
 import os
+from platform import freedesktop_os_release
 from contextlib import contextmanager
 from ctypes.util import find_library
 from functools import lru_cache
@@ -58,6 +59,16 @@ def get_library_paths() -> set[str]:
             }
     except OSError as e:
         log.exception(e)
+
+    os_release: dict[str, str] = freedesktop_os_release()
+
+    # Workaround for Ubuntu not find 32-bit paths
+    # See https://github.com/Open-Wine-Components/umu-launcher/issues/211
+    if os_release.get("id") == "ubuntu":
+        library_paths |= {
+            "/usr/lib/i386-linux-gnu/pulseaudio",
+            "/usr/lib/i386-linux-gnu",
+        }
 
     return library_paths
 


### PR DESCRIPTION
Related to https://github.com/Open-Wine-Components/umu-launcher/issues/211