### PR TITLE
fix: use $HOME/.local/share/umu and $XDG_CACHE_HOME for flatpak

### DIFF
--- a/umu/umu_consts.py
+++ b/umu/umu_consts.py
@@ -16,10 +16,25 @@ PROTON_VERBS = {
     "getnativepath",
 }
 
-# Installation path of the runtime files.
-# Flatpak will be detected as outlined by systemd
+XDG_DATA_HOME: Path = (
+    Path(os.environ["XDG_DATA_HOME"])
+    if os.environ.get("XDG_DATA_HOME")
+    else Path.home().joinpath(".local", "share")
+)
+
+# Installation path of the runtime files that respects the XDG Base Directory
+# Specification and Systemd container interface.
 # See https://systemd.io/CONTAINER_INTERFACE
-UMU_LOCAL: Path = Path.home().joinpath(".local", "share", "umu")
+# See https://specifications.freedesktop.org/basedir-spec/latest/index.html#basics
+# NOTE: For Flatpaks, the runtime will be installed in $HOST_XDG_DATA_HOME
+# then $XDG_DATA_HOME, and will be required to update their manifests by adding
+# the permission 'xdg-data/umu:create'.
+# See https://github.com/Open-Wine-Components/umu-launcher/pull/229#discussion_r1799289068
+UMU_LOCAL: Path = (
+    Path(os.environ.get("HOST_XDG_DATA_HOME", "XDG_DATA_HOME")).joinpath("umu")
+    if os.environ.get("container") == "flatpak"  # noqa: SIM112
+    else XDG_DATA_HOME.joinpath("umu")
+)
 
 # Temporary directory for downloaded resources moved from tmpfs
 UMU_CACHE: Path = (

--- a/umu/umu_consts.py
+++ b/umu/umu_consts.py
@@ -28,6 +28,10 @@ XDG_CACHE_HOME: Path = (
     else Path.home().joinpath(".cache")
 )
 
+_HOST_XDG_DATA_HOME: str = os.environ.get(
+    "HOST_XDG_DATA_HOME", os.environ["XDG_DATA_HOME"]
+)
+
 # Installation path of the runtime files that respects the XDG Base Directory
 # Specification and Systemd container interface.
 # See https://systemd.io/CONTAINER_INTERFACE
@@ -37,7 +41,7 @@ XDG_CACHE_HOME: Path = (
 # the permission 'xdg-data/umu:create'.
 # See https://github.com/Open-Wine-Components/umu-launcher/pull/229#discussion_r1799289068
 UMU_LOCAL: Path = (
-    Path(os.environ.get("HOST_XDG_DATA_HOME", "XDG_DATA_HOME")).joinpath("umu")
+    Path(_HOST_XDG_DATA_HOME).joinpath("umu")
     if os.environ.get("container") == "flatpak"  # noqa: SIM112
     else XDG_DATA_HOME.joinpath("umu")
 )

--- a/umu/umu_consts.py
+++ b/umu/umu_consts.py
@@ -16,26 +16,14 @@ PROTON_VERBS = {
     "getnativepath",
 }
 
-# Installation path of the runtime files
+# Installation path of the runtime files.
 # Flatpak will be detected as outlined by systemd
 # See https://systemd.io/CONTAINER_INTERFACE
-UMU_LOCAL: Path = (
-    Path.home().joinpath(
-        ".var", "app", "org.openwinecomponents.umu.umu-launcher", "data", "umu"
-    )
-    if os.environ.get("container") == "flatpak"  # noqa: SIM112
-    else Path.home().joinpath(".local", "share", "umu")
-)
+UMU_LOCAL: Path = Path.home().joinpath(".local", "share", "umu")
 
 # Temporary directory for downloaded resources moved from tmpfs
 UMU_CACHE: Path = (
-    Path.home().joinpath(
-        ".var",
-        "app",
-        "org.openwinecomponents.umu.umu-launcher",
-        "cache",
-        "umu",
-    )
+    Path(os.environ["XDG_CACHE_HOME"], "umu")
     if os.environ.get("container") == "flatpak"  # noqa: SIM112
     else Path.home().joinpath(".cache", "umu")
 )

--- a/umu/umu_consts.py
+++ b/umu/umu_consts.py
@@ -37,8 +37,8 @@ XDG_CACHE_HOME: Path = (
 # See https://systemd.io/CONTAINER_INTERFACE
 # See https://specifications.freedesktop.org/basedir-spec/latest/index.html#basics
 # NOTE: For Flatpaks, the runtime will be installed in $HOST_XDG_DATA_HOME
-# then $XDG_DATA_HOME, and will be required to update their manifests by adding
-# the permission 'xdg-data/umu:create'.
+# then $XDG_DATA_HOME as fallback, and will be required to update their
+# manifests by adding the permission 'xdg-data/umu:create'.
 # See https://github.com/Open-Wine-Components/umu-launcher/pull/229#discussion_r1799289068
 UMU_LOCAL: Path = XDG_DATA_HOME.joinpath("umu")
 

--- a/umu/umu_consts.py
+++ b/umu/umu_consts.py
@@ -17,19 +17,19 @@ PROTON_VERBS = {
 }
 
 XDG_DATA_HOME: Path = (
-    Path(os.environ["XDG_DATA_HOME"])
-    if os.environ.get("XDG_DATA_HOME")
-    else Path.home().joinpath(".local", "share")
+    Path(os.environ["HOST_XDG_DATA_HOME"])
+    if os.environ.get("HOST_XDG_DATA_HOME")
+    else (
+        Path(os.environ["XDG_DATA_HOME"])
+        if os.environ.get("XDG_DATA_HOME")
+        else Path.home().joinpath(".local", "share")
+    )
 )
 
 XDG_CACHE_HOME: Path = (
     Path(os.environ["XDG_CACHE_HOME"])
     if os.environ.get("XDG_CACHE_HOME")
     else Path.home().joinpath(".cache")
-)
-
-_HOST_XDG_DATA_HOME: str = os.environ.get(
-    "HOST_XDG_DATA_HOME", os.environ["XDG_DATA_HOME"]
 )
 
 # Installation path of the runtime files that respects the XDG Base Directory
@@ -40,18 +40,10 @@ _HOST_XDG_DATA_HOME: str = os.environ.get(
 # then $XDG_DATA_HOME, and will be required to update their manifests by adding
 # the permission 'xdg-data/umu:create'.
 # See https://github.com/Open-Wine-Components/umu-launcher/pull/229#discussion_r1799289068
-UMU_LOCAL: Path = (
-    Path(_HOST_XDG_DATA_HOME).joinpath("umu")
-    if os.environ.get("container") == "flatpak"  # noqa: SIM112
-    else XDG_DATA_HOME.joinpath("umu")
-)
+UMU_LOCAL: Path = XDG_DATA_HOME.joinpath("umu")
 
 # Temporary directory for downloaded resources moved from tmpfs
-UMU_CACHE: Path = (
-    Path(os.environ["XDG_CACHE_HOME"], "umu")
-    if os.environ.get("container") == "flatpak"  # noqa: SIM112
-    else XDG_CACHE_HOME.joinpath("umu")
-)
+UMU_CACHE: Path = XDG_CACHE_HOME.joinpath("umu")
 
 # Constant defined in prctl.h
 # See prctl(2) for more details

--- a/umu/umu_consts.py
+++ b/umu/umu_consts.py
@@ -22,6 +22,12 @@ XDG_DATA_HOME: Path = (
     else Path.home().joinpath(".local", "share")
 )
 
+XDG_CACHE_HOME: Path = (
+    Path(os.environ["XDG_CACHE_HOME"])
+    if os.environ.get("XDG_CACHE_HOME")
+    else Path.home().joinpath(".cache")
+)
+
 # Installation path of the runtime files that respects the XDG Base Directory
 # Specification and Systemd container interface.
 # See https://systemd.io/CONTAINER_INTERFACE
@@ -40,7 +46,7 @@ UMU_LOCAL: Path = (
 UMU_CACHE: Path = (
     Path(os.environ["XDG_CACHE_HOME"], "umu")
     if os.environ.get("container") == "flatpak"  # noqa: SIM112
-    else Path.home().joinpath(".cache", "umu")
+    else XDG_CACHE_HOME.joinpath("umu")
 )
 
 # Constant defined in prctl.h


### PR DESCRIPTION
Centralizes the installation path of umu for both Flatpak and native applications in $HOME/.local/share/umu. This change will prevent cases like https://github.com/flathub/net.lutris.Lutris/issues/440 where the meaning of ~/.var/app/org.openwinecomponents.umu.umu-launcher/data/umu changes when the host's home directory is exposed.

Flatpaks will be required to change their manifest to allow read-write access to the host ~/.local/share/umu.

Closes https://github.com/Open-Wine-Components/umu-launcher/issues/230