### PR TITLE
fix: disable failing tests on nix

### DIFF
--- a/packaging/nix/umu-launcher.nix
+++ b/packaging/nix/umu-launcher.nix
@@ -10,7 +10,14 @@ python3Packages.buildPythonPackage {
     pkgs.scdoc
     pkgs.git
     pkgs.python3Packages.installer
-    pkgs.hatch
+    (pkgs.hatch.overrideAttrs (prev: {
+      disabledTests = prev.disabledTests ++ [
+        "test_field_readme"
+        "test_field_string"
+        "test_field_complex"
+        "test_plugin_dependencies_unmet"
+      ];
+    }))
     pkgs.python3Packages.build
   ];
   propagatedBuildInputs = [


### PR DESCRIPTION
Building hatch currently fails on Nixos 24.05 and unstable because of 4 failing tests, preventing the installation of umu.

This PR disables the tests `test_field_readme`, `test_field_string`, `test_field_complex` and `test_plugin_dependencies_unmet`; until they are fixed upstream