### PR TITLE
NixOS: Add `multiArch = true;` to `umu-run.nix`

### DIFF
--- a/packaging/nix/umu-run.nix
+++ b/packaging/nix/umu-run.nix
@@ -5,6 +5,7 @@ buildFHSEnv{
   targetPkgs = pkgs: ([
     package
   ]);
+  multiArch = true;
   runScript = writeShellScript "umu-run-shell" ''
     ${package}/bin/umu "$@"
   '';


### PR DESCRIPTION
The FHS environment was completely missing 32-bit binaries before because this option wasn't there. This should fix any issues relating to "wrong ELF class" errors.

Closes #246.