### PR TITLE
ci: fix permission loss in zipapp workflow

### DIFF
--- a/.github/workflows/build-umu-zipapp.yml
+++ b/.github/workflows/build-umu-zipapp.yml
@@ -35,10 +35,12 @@ jobs:
       run: mkdir -p results && cp -rvf builddir/umu-run results/
 
     - name: Create symlink for launchers
-      run: cd results && ln -s umu-run umu_run.py && cd ..
+      # To preserve file mode bits and link file, use a tar archive.
+      # See https://github.com/actions/upload-artifact?tab=readme-ov-file#permission-loss
+      run: cd results && ln -s umu-run umu_run.py && tar cvf Zipapp.tar umu-run umu_run.py
 
     - name: Upload artifact
       uses: actions/upload-artifact@v4.0.0
       with:
         name: Zipapp
-        path: results/
+        path: results/Zipapp.tar


### PR DESCRIPTION
Closes https://github.com/Open-Wine-Components/umu-launcher/issues/253, https://github.com/lutris/lutris/issues/5674, and https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/4072.

Creates a `Zipapp.tar` file to preserve file permissions and any symbolic links. Requires Lutris to first unpack the Github artifact then the tar archive for the `umu-run `and `umu_run.py` files.