### PR TITLE
fix: use stderr for shim messages

### DIFF
--- a/umu/umu_runtime.py
+++ b/umu/umu_runtime.py
@@ -65,7 +65,7 @@ def create_shim(file_path: Path | None = None):
 
     # Capture the exit status
     status=$?
-    echo "Command exited with status: $status"
+    echo "Command exited with status: $status" >&2
     exit $status
     """
 


### PR DESCRIPTION
Heroic relies on stdout output from some commands, shim only interferes with that, see https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/4087 