### PR TITLE
Revise workflows to automatically upload artifacts on new releases

### DIFF
--- a/.github/workflows/build-umu-debian-12.yml
+++ b/.github/workflows/build-umu-debian-12.yml
@@ -1,11 +1,11 @@
 name: UMU Deb Build - Debian 12
 on:
-  push:
-    branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
-  release:
-    types: [published]
+  workflow_call:
+    inputs:
+      version:
+        required: true
+        type: string
+
 
 jobs:
   build:
@@ -35,7 +35,9 @@ jobs:
       run: cp -rvf ./packaging/deb/debian ./debian
 
     - name: Setup dh_make quilt files
-      run: LOGNAME=root dh_make --createorig -y -l -p umu-launcher_1.1.4 || true
+      run: |
+        sed -re 's|(umu-launcher \()[1-9.]+(-1\).*$)|\1${{ inputs.version }}\2|' -i ./debian/changelog
+        LOGNAME=root dh_make --createorig -y -l -p umu-launcher_${{ inputs.version }} || true
 
     - name: Install apt build dependencies
       run: apt build-dep -y ./ 
@@ -43,11 +45,22 @@ jobs:
     - name: Build
       run: dpkg-buildpackage --no-sign 
 
-    - name: Move DEB files to upload artifact path
-      run: mkdir -p results && cp -rvf ../*.deb results/
+    - name: Move and rename DEB files to upload artifact path
+      run: |
+        mkdir -p results
+        mv ../python3-umu-launcher_${{ inputs.version }}-1_amd64.deb \
+           results/python3-umu-launcher_${{ inputs.version }}-1_amd64_debian-12.deb
+        mv ../umu-launcher_${{ inputs.version }}-1_all.deb \
+           results/umu-launcher_${{ inputs.version }}-1_all_debian-12.deb
 
     - name: Upload artifact
-      uses: actions/upload-artifact@v4.6.0
+      uses: actions/upload-artifact@v4
       with:
-        name: Debian-12
-        path: results/
+        name: python3-umu-launcher_${{ inputs.version }}-1_amd64_debian-12.deb
+        path: results/python3-umu-launcher_${{ inputs.version }}-1_amd64_debian-12.deb
+
+    - name: Upload artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: umu-launcher_${{ inputs.version }}-1_all_debian-12.deb
+        path: results/umu-launcher_${{ inputs.version }}-1_all_debian-12.deb

--- a/.github/workflows/build-umu-fedora-40.yml
+++ b/.github/workflows/build-umu-fedora-40.yml
@@ -1,12 +1,15 @@
-name: UMU RPM Build - Fedora/Nobara
+name: UMU RPM Build - Fedora/Nobara 40
 
 on:
-  push:
-    branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
-  release:
-    types: [published]
+  workflow_call:
+    inputs:
+      version:
+        required: true
+        type: string
+      shasum:
+        required: true
+        type: string
+
 
 jobs:
   build:
@@ -34,10 +37,15 @@ jobs:
         make
         mkdir -p ~/rpmbuild/SOURCES
         cp -r . ~/rpmbuild/SOURCES/umu-launcher
+        sed -re 's|(Version:\s+)[1-9.]+|\1${{ inputs.version }}|g' -i packaging/rpm/umu-launcher.spec
+        sed -re 's|(%define tag\s+)[1-9.]+|\1${{ inputs.version }}|g' -i packaging/rpm/umu-launcher.spec
+        sed -re 's|(%define manual_commit\s+)\w+|\1${{ inputs.shasum }}|g' -i packaging/rpm/umu-launcher.spec
         rpmbuild -ba packaging/rpm/umu-launcher.spec
+        mv ~/rpmbuild/RPMS/noarch/umu-launcher-${{ inputs.version }}*.rpm \
+           ~/rpmbuild/RPMS/noarch/umu-launcher-${{ inputs.version }}.fc40.noarch.rpm
 
     - name: Fedora-40
-      uses: actions/upload-artifact@v4.6.0
+      uses: actions/upload-artifact@v4
       with:
-        name: umu-launcher-rpm-40
-        path: ~/rpmbuild/RPMS/x86_64/*.rpm
+        name: umu-launcher-${{ inputs.version }}.fc40.noarch.rpm
+        path: ~/rpmbuild/RPMS/noarch/umu-launcher-${{ inputs.version }}.fc40.noarch.rpm

--- a/.github/workflows/build-umu-fedora-40.yml
+++ b/.github/workflows/build-umu-fedora-40.yml
@@ -41,11 +41,11 @@ jobs:
         sed -re 's|(%define tag\s+)[1-9.]+|\1${{ inputs.version }}|g' -i packaging/rpm/umu-launcher.spec
         sed -re 's|(%define manual_commit\s+)\w+|\1${{ inputs.shasum }}|g' -i packaging/rpm/umu-launcher.spec
         rpmbuild -ba packaging/rpm/umu-launcher.spec
-        mv ~/rpmbuild/RPMS/noarch/umu-launcher-${{ inputs.version }}*.rpm \
-           ~/rpmbuild/RPMS/noarch/umu-launcher-${{ inputs.version }}.fc40.noarch.rpm
+        mv ~/rpmbuild/RPMS/x86_64/umu-launcher-${{ inputs.version }}*.rpm \
+           ~/rpmbuild/RPMS/x86_64/umu-launcher-${{ inputs.version }}.fc40.noarch.rpm
 
     - name: Fedora-40
       uses: actions/upload-artifact@v4
       with:
         name: umu-launcher-${{ inputs.version }}.fc40.noarch.rpm
-        path: ~/rpmbuild/RPMS/noarch/umu-launcher-${{ inputs.version }}.fc40.noarch.rpm
+        path: ~/rpmbuild/RPMS/x86_64/umu-launcher-${{ inputs.version }}.fc40.noarch.rpm

--- a/.github/workflows/build-umu-fedora-41.yml
+++ b/.github/workflows/build-umu-fedora-41.yml
@@ -41,11 +41,11 @@ jobs:
         sed -re 's|(%define tag\s+)[1-9.]+|\1${{ inputs.version }}|g' -i packaging/rpm/umu-launcher.spec
         sed -re 's|(%define manual_commit\s+)\w+|\1${{ inputs.shasum }}|g' -i packaging/rpm/umu-launcher.spec
         rpmbuild -ba packaging/rpm/umu-launcher.spec
-        mv ~/rpmbuild/RPMS/noarch/umu-launcher-${{ inputs.version }}*.rpm \
-           ~/rpmbuild/RPMS/noarch/umu-launcher-${{ inputs.version }}.fc41.noarch.rpm
+        mv ~/rpmbuild/RPMS/x86_64/umu-launcher-${{ inputs.version }}*.rpm \
+           ~/rpmbuild/RPMS/x86_64/umu-launcher-${{ inputs.version }}.fc41.noarch.rpm
 
     - name: Fedora-41
       uses: actions/upload-artifact@v4
       with:
         name: umu-launcher-${{ inputs.version }}.fc41.noarch.rpm
-        path: ~/rpmbuild/RPMS/noarch/umu-launcher-${{ inputs.version }}.fc41.noarch.rpm
+        path: ~/rpmbuild/RPMS/x86_64/umu-launcher-${{ inputs.version }}.fc41.noarch.rpm

--- a/.github/workflows/build-umu-fedora-41.yml
+++ b/.github/workflows/build-umu-fedora-41.yml
@@ -1,12 +1,15 @@
-name: UMU RPM Build - Fedora/Nobara
+name: UMU RPM Build - Fedora/Nobara 41
 
 on:
-  push:
-    branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
-  release:
-    types: [published]
+  workflow_call:
+    inputs:
+      version:
+        required: true
+        type: string
+      shasum:
+        required: true
+        type: string
+
 
 jobs:
   build:
@@ -23,7 +26,7 @@ jobs:
 
     - name: Configure Git safe directory
       run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
-      
+
     - name: Install build dependencies
       run: dnf install -y rpm-build meson ninja-build cmake g++ gcc-c++ scdoc git python3-devel python3-build python3-installer python3-hatchling python python3 cargo python3-hatch-vcs python3-wheel libzstd-devel
 
@@ -34,10 +37,15 @@ jobs:
         make
         mkdir -p ~/rpmbuild/SOURCES
         cp -r . ~/rpmbuild/SOURCES/umu-launcher
+        sed -re 's|(Version:\s+)[1-9.]+|\1${{ inputs.version }}|g' -i packaging/rpm/umu-launcher.spec
+        sed -re 's|(%define tag\s+)[1-9.]+|\1${{ inputs.version }}|g' -i packaging/rpm/umu-launcher.spec
+        sed -re 's|(%define manual_commit\s+)\w+|\1${{ inputs.shasum }}|g' -i packaging/rpm/umu-launcher.spec
         rpmbuild -ba packaging/rpm/umu-launcher.spec
+        mv ~/rpmbuild/RPMS/noarch/umu-launcher-${{ inputs.version }}*.rpm \
+           ~/rpmbuild/RPMS/noarch/umu-launcher-${{ inputs.version }}.fc41.noarch.rpm
 
     - name: Fedora-41
-      uses: actions/upload-artifact@v4.6.0
+      uses: actions/upload-artifact@v4
       with:
-        name: umu-launcher-rpm-41
-        path: ~/rpmbuild/RPMS/x86_64/*.rpm
+        name: umu-launcher-${{ inputs.version }}.fc41.noarch.rpm
+        path: ~/rpmbuild/RPMS/noarch/umu-launcher-${{ inputs.version }}.fc41.noarch.rpm

--- a/.github/workflows/build-umu-publish-release.yml
+++ b/.github/workflows/build-umu-publish-release.yml
@@ -1,0 +1,48 @@
+name: UMU Publish Release
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        required: true
+        type: string
+      file1:
+        required: true
+        type: string
+      name1:
+        required: true
+        type: string
+      name2:
+        type: string
+        default: ""
+      file2:
+        type: string
+        default: ""
+
+
+jobs:
+  release:
+    name: Publish
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - name: ${{ inputs.name1 }}
+            file: ${{ inputs.file1 }}
+          - name: ${{ inputs.name2 }}
+            file: ${{ inputs.file2 }}
+    steps:
+    - name: Download ${{ matrix.name }} from artifact
+      uses: actions/download-artifact@v4
+      if: ${{ matrix.name != '' }}
+      with:
+        name: ${{ matrix.name }}
+    - name: Upload ${{ matrix.name }} to release
+      uses: svenstaro/upload-release-action@v2
+      if: ${{ matrix.name != '' }}
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        file: ${{ matrix.file }}
+        asset_name: ${{ matrix.name }}
+        tag: ${{ inputs.version }}
+        overwrite: true

--- a/.github/workflows/build-umu-ubuntu-noble.yml
+++ b/.github/workflows/build-umu-ubuntu-noble.yml
@@ -1,11 +1,11 @@
 name: UMU Deb Build - Noble (Ubuntu 24.04 LTS)
 on:
-  push:
-    branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
-  release:
-    types: [published]
+  workflow_call:
+    inputs:
+      version:
+        required: true
+        type: string
+
 
 jobs:
   build:
@@ -35,7 +35,9 @@ jobs:
       run: cp -rvf ./packaging/deb/ubuntu ./debian
 
     - name: Setup dh_make quilt files
-      run: LOGNAME=root dh_make --createorig -y -l -p umu-launcher_1.1.4 || true
+      run: |
+        sed -re 's|(umu-launcher \()[1-9.]+(-1\).*$)|\1${{ inputs.version }}\2|' -i ./debian/changelog
+        LOGNAME=root dh_make --createorig -y -l -p umu-launcher_${{ inputs.version }} || true
 
     - name: Install apt build dependencies
       run: apt build-dep -y ./ 
@@ -43,11 +45,22 @@ jobs:
     - name: Build
       run: dpkg-buildpackage --no-sign 
 
-    - name: Move DEB files to upload artifact path
-      run: mkdir -p results && cp -rvf ../*.deb results/
+    - name: Move and rename DEB files to upload artifact path
+      run: |
+        mkdir -p results
+        mv ../python3-umu-launcher_${{ inputs.version }}-1_amd64.deb \
+           results/python3-umu-launcher_${{ inputs.version }}-1_amd64_ubuntu-noble.deb
+        mv ../umu-launcher_${{ inputs.version }}-1_all.deb \
+           results/umu-launcher_${{ inputs.version }}-1_all_ubuntu-noble.deb
 
     - name: Upload artifact
-      uses: actions/upload-artifact@v4.6.0
+      uses: actions/upload-artifact@v4
       with:
-        name: Ubuntu-24
-        path: results/
+        name: python3-umu-launcher_${{ inputs.version }}-1_amd64_ubuntu-noble.deb
+        path: results/python3-umu-launcher_${{ inputs.version }}-1_amd64_ubuntu-noble.deb
+
+    - name: Upload artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: umu-launcher_${{ inputs.version }}-1_all_ubuntu-noble.deb
+        path: results/umu-launcher_${{ inputs.version }}-1_all_ubuntu-noble.deb

--- a/.github/workflows/build-umu-version.yml
+++ b/.github/workflows/build-umu-version.yml
@@ -1,0 +1,35 @@
+name: job_version
+
+on:
+  workflow_call:
+    outputs:
+      version:
+        value: "${{ jobs.version.outputs.tag_abbrev }}.${{ jobs.version.outputs.tag_offset }}"
+      branch:
+        value: "${{ jobs.version.outputs.branch }}"
+
+
+jobs:
+  version:
+    name: Version
+    runs-on: ubuntu-latest
+    outputs:
+      tag_abbrev: ${{ steps.describe.outputs.tag_abbrev }}
+      tag_offset: ${{ steps.describe.outputs.tag_offset }}
+      sha_short: ${{ steps.describe.outputs.sha_short }}
+      full_desc: ${{ steps.describe.outputs.full_desc }}
+      branch: ${{ steps.describe.outputs.branch }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Describe
+        id: describe
+        shell: bash
+        run: |
+          tag_abbrev=$(git tag --sort=v:refname | grep -oE "(^[0-9]+\.[0-9]+(.[0-9]+)?)$" | tail -1)
+          echo "tag_abbrev=$tag_abbrev" >> $GITHUB_OUTPUT
+          echo "tag_offset=$(git rev-list $tag_abbrev..HEAD --count)" >> $GITHUB_OUTPUT
+          echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+          echo "full_desc=$(git describe --long --tags)" >> $GITHUB_OUTPUT
+          echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT

--- a/.github/workflows/build-umu-version.yml
+++ b/.github/workflows/build-umu-version.yml
@@ -1,4 +1,4 @@
-name: job_version
+name: UMU Describe Version
 
 on:
   workflow_call:

--- a/.github/workflows/build-umu-zipapp.yml
+++ b/.github/workflows/build-umu-zipapp.yml
@@ -1,11 +1,10 @@
 name: UMU Zipapp Build
 on:
-  push:
-    branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
-  release:
-    types: [published]
+  workflow_call:
+    inputs:
+      version:
+        required: true
+        type: string
 
 jobs:
   build:
@@ -37,10 +36,10 @@ jobs:
     - name: Create symlink for launchers
       # To preserve file mode bits and link file, use a tar archive.
       # See https://github.com/actions/upload-artifact?tab=readme-ov-file#permission-loss
-      run: cd results && ln -s umu-run umu_run.py && tar cvf Zipapp.tar umu-run umu_run.py
+      run: cd results && ln -s umu-run umu_run.py && tar cvf umu-launcher-${{ inputs.version }}-zipapp.tar.gz umu-run umu_run.py
 
     - name: Upload artifact
-      uses: actions/upload-artifact@v4.6.0
+      uses: actions/upload-artifact@v4
       with:
-        name: Zipapp
-        path: results/Zipapp.tar
+        name: umu-launcher-${{ inputs.version }}-zipapp.tar.gz
+        path: results/umu-launcher-${{ inputs.version }}-zipapp.tar.gz

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,50 @@
+name: Build and upload development artifacts
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  version:
+    name: Describe
+    uses: ./.github/workflows/build-umu-version.yml
+
+  fedora40-build:
+    name: Fedora 40 Build
+    uses: ./.github/workflows/build-umu-fedora-40.yml
+    needs: version
+    with:
+      version: ${{ needs.version.outputs.version }}
+      shasum: ${{ github.sha }}
+
+  fedora41-build:
+    name: Fedora 41 Build
+    uses: ./.github/workflows/build-umu-fedora-41.yml
+    needs: version
+    with:
+      version: ${{ needs.version.outputs.version }}
+      shasum: ${{ github.sha }}
+
+  debian12-build:
+    name: Debian 12 Build
+    uses: ./.github/workflows/build-umu-debian-12.yml
+    needs: version
+    with:
+      version: ${{ needs.version.outputs.version }}
+
+  ubuntu-noble-build:
+    name: Ubuntu 24.04 Build
+    uses: ./.github/workflows/build-umu-ubuntu-noble.yml
+    needs: version
+    with:
+      version: ${{ needs.version.outputs.version }}
+
+  zipapp-build:
+    name: Zipapp Build
+    uses: ./.github/workflows/build-umu-zipapp.yml
+    needs: version
+    with:
+      version: ${{ needs.version.outputs.version }}
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,83 @@
+name: Build and upload artifacts to Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  fedora40-build:
+    name: Fedora 40 Build
+    uses: ./.github/workflows/build-umu-fedora-40.yml
+    with:
+      version: ${{ github.ref_name }}
+      shasum: ${{ github.sha }}
+  fedora40-release:
+    name: Fedora 40 Release ${{ github.ref_name }}
+    needs: fedora40-build
+    uses: ./.github/workflows/build-umu-publish-release.yml
+    with:
+      version: ${{ github.ref_name }}
+      file1: umu-launcher-${{ github.ref_name }}.fc40.noarch.rpm
+      name1: umu-launcher-${{ github.ref_name }}.fc40.noarch.rpm
+
+  fedora41-build:
+    name: Fedora 41 Build
+    uses: ./.github/workflows/build-umu-fedora-41.yml
+    with:
+      version: ${{ github.ref_name }}
+      shasum: ${{ github.sha }}
+  fedora41-release:
+    name: Fedora 41 Release ${{ github.ref_name }}
+    needs: fedora41-build
+    uses: ./.github/workflows/build-umu-publish-release.yml
+    with:
+      version: ${{ github.ref_name }}
+      file1: umu-launcher-${{ github.ref_name }}.fc41.noarch.rpm
+      name1: umu-launcher-${{ github.ref_name }}.fc41.noarch.rpm
+
+  debian12-build:
+    name: Debian 12 Build
+    uses: ./.github/workflows/build-umu-debian-12.yml
+    with:
+      version: ${{ github.ref_name }}
+  debian12-release:
+    name: Debian 12 Release ${{ github.ref_name }}
+    needs: debian12-build
+    uses: ./.github/workflows/build-umu-publish-release.yml
+    with:
+      version: ${{ github.ref_name }}
+      file1: python3-umu-launcher_${{ github.ref_name }}-1_amd64_debian-12.deb
+      name1: python3-umu-launcher_${{ github.ref_name }}-1_amd64_debian-12.deb
+      file2: umu-launcher_${{ github.ref_name }}-1_all_debian-12.deb
+      name2: umu-launcher_${{ github.ref_name }}-1_all_debian-12.deb
+
+  ubuntu-noble-build:
+    name: Ubuntu 24.04 Build
+    uses: ./.github/workflows/build-umu-ubuntu-noble.yml
+    with:
+      version: ${{ github.ref_name }}
+  ubuntu-noble-release:
+    name: Ubuntu 24.04 Release ${{ github.ref_name }}
+    needs: ubuntu-noble-build
+    uses: ./.github/workflows/build-umu-publish-release.yml
+    with:
+      version: ${{ github.ref_name }}
+      file1: python3-umu-launcher_${{ github.ref_name }}-1_amd64_ubuntu-noble.deb
+      name1: python3-umu-launcher_${{ github.ref_name }}-1_amd64_ubuntu-noble.deb
+      file2: umu-launcher_${{ github.ref_name }}-1_all_ubuntu-noble.deb
+      name2: umu-launcher_${{ github.ref_name }}-1_all_ubuntu-noble.deb
+
+  zipapp-build:
+    name: Zipapp Build
+    uses: ./.github/workflows/build-umu-zipapp.yml
+    with:
+      version: ${{ github.ref_name }}
+  zipapp-release:
+    name: Zippapp Release ${{ github.ref_name }}
+    needs: zipapp-build
+    uses: ./.github/workflows/build-umu-publish-release.yml
+    with:
+      version: ${{ github.ref_name }}
+      file1: umu-launcher-${{ github.ref_name }}-zipapp.tar.gz
+      name1: umu-launcher-${{ github.ref_name }}-zipapp.tar.gz
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Build and upload artifacts to Release
+name: Build and upload release
 
 on:
   release:

--- a/packaging/rpm/umu-launcher.spec
+++ b/packaging/rpm/umu-launcher.spec
@@ -52,7 +52,7 @@ Recommends:	libzstd
 %{name} A tool for launching non-steam games with proton
 
 %prep
-git clone --single-branch --branch main https://github.com/Open-Wine-Components/umu-launcher.git
+git clone https://github.com/Open-Wine-Components/umu-launcher.git
 cd umu-launcher
 git submodule update --init --recursive
 


### PR DESCRIPTION
This PR revises the GH workflows to upload build artifacts to releases automatically. It should fix #271 among other things. Once a release is created and published the `release` workflow should build the artifacts and upload them automatically.

Changes:
* Canonicalize artifact names for different distributions
   - On RPM packages, the version information in the package name was truncated to remove the date and short SHA information. This change would be a better fit for the spec file but I didn't want to touch it yet.
   - On DEB packages, the `_ubuntu-noble` or `_debian-12` suffixes are used to differentiate between them. @CosmicFusion is this accepted by Debian packaging tools?
   - The zipapp name was changed to contain version information and compressed with `gzip`, i.e `umu-launcher-1.1.4-zipapp.tar.gz`. Third-party scripts will need to be adjusted.
* The build workflows for RPM and DEB packages have been adjusted to also build development snapshots. This requires copious amounts of `sed` and I would be more than happy to revert these changes and only build tagged releases. The RPM spec was also adjusted for the same reason to checkout the `manual_commit` if the `tag` doesn't exist.
* Added a separate development workflow to build packages and upload them only to the action's artifacts, The individual packaging workflows are not executed on push or PRs any more, but through this development `build` workflow.

The workflow for RPM packages fails currently because cloning the repo inside the specfile doesn't find the PR merge commit. If we want to handle that for PRs it will take some finessing, but I want to be sure it is needed before diving into it.

![image](https://github.com/user-attachments/assets/c17c9d52-37cb-48e8-bf62-3896b1e720ce)
