### PR TITLE
refactor: change logging formats and move argument parsing functionality

### DIFF
--- a/docs/umu.1.scd
+++ b/docs/umu.1.scd
@@ -153,7 +153,7 @@ _UMU_LOG_
 	Optional. Enables debug logs for the launcher.
 	
 
-	Set _1_ to log environment variables, _warning_ for warning messages, or _debug_ to enable all logs.
+	Set _1_ to enable all logs.
 
 _STORE_
 	Optional. Can be an arbitrary value or a valid store id in the umu-database.

--- a/umu/__main__.py
+++ b/umu/__main__.py
@@ -78,7 +78,25 @@ def parse_args() -> Namespace | tuple[str, list[str]]:  # noqa: D103
 def main() -> int:  # noqa: D103
     args: Namespace | tuple[str, list[str]]
 
+    # Adjust logger for debugging when configured
+    if os.environ.get("UMU_LOG") in ("1", "debug"):
+        log.setLevel(level="DEBUG")
+        log.set_formatter(os.environ["UMU_LOG"])
+        for key, val in os.environ.items():
+            log.debug("%s=%s", key, val)
+
     args = parse_args()
+
+    if os.geteuid() == 0:
+        err: str = "This script should never be run as the root user"
+        log.error(err)
+        sys.exit(1)
+
+    if "musl" in os.environ.get("LD_LIBRARY_PATH", ""):
+        err: str = "This script is not designed to run on musl-based systems"
+        log.error(err)
+        sys.exit(1)
+
     return umu_run(args)
 
 

--- a/umu/__main__.py
+++ b/umu/__main__.py
@@ -108,7 +108,3 @@ if __name__ == "__main__":
             sys.exit(e.code)
     except BaseException as e:
         log.exception(e)
-    finally:
-        UMU_LOCAL.joinpath(".ref").unlink(
-            missing_ok=True
-        )  # Cleanup .ref file on every exit

--- a/umu/__main__.py
+++ b/umu/__main__.py
@@ -76,7 +76,7 @@ def parse_args() -> Namespace | tuple[str, list[str]]:  # noqa: D103
 
 
 def main() -> int:  # noqa: D103
-    args: Namespace | tuple[str, list[str]]
+    args: Namespace | tuple[str, list[str]] = parse_args()
 
     # Adjust logger for debugging when configured
     if os.environ.get("UMU_LOG") in {"1", "debug"}:
@@ -84,8 +84,6 @@ def main() -> int:  # noqa: D103
         log.set_formatter(os.environ["UMU_LOG"])
         for key, val in os.environ.items():
             log.debug("%s=%s", key, val)
-
-    args = parse_args()
 
     if os.geteuid() == 0:
         err: str = "This script should never be run as the root user"

--- a/umu/__main__.py
+++ b/umu/__main__.py
@@ -1,12 +1,85 @@
+import os
 import sys
+from argparse import ArgumentParser, Namespace, RawTextHelpFormatter
 
-from umu.umu_consts import UMU_LOCAL
+from umu import __version__
+from umu.umu_consts import PROTON_VERBS
 from umu.umu_log import log
-from umu.umu_run import main as umu_run
+from umu.umu_run import umu_run
+from umu.umu_util import is_winetricks_verb
+
+
+def parse_args() -> Namespace | tuple[str, list[str]]:  # noqa: D103
+    opt_args: set[str] = {"--help", "-h", "--config"}
+    parser: ArgumentParser = ArgumentParser(
+        description="Unified Linux Wine Game Launcher",
+        epilog=(
+            "See umu(1) for more info and examples, or visit\n"
+            "https://github.com/Open-Wine-Components/umu-launcher"
+        ),
+        formatter_class=RawTextHelpFormatter,
+    )
+    parser.add_argument(
+        "-v",
+        "--version",
+        action="store_true",
+        help="show this version and exit",
+    )
+    parser.add_argument(
+        "--config", help=("path to TOML file (requires Python 3.11+)")
+    )
+    parser.add_argument(
+        "winetricks",
+        help=("run winetricks verbs (requires UMU-Proton or GE-Proton)"),
+        nargs="?",
+        default=None,
+    )
+
+    if not sys.argv[1:]:
+        parser.print_help(sys.stderr)
+        sys.exit(1)
+
+    # Show version
+    # Need to avoid clashes with later options (for example: wineboot -u)
+    #   but parse_args scans the whole command line.
+    # So look at the first argument and see if we have -v or --version
+    #   in sort of the same way parse_args would.
+    if sys.argv[1].lower().endswith(("--version", "-v")):
+        print(
+            f"umu-launcher version {__version__} ({sys.version})",
+            file=sys.stderr,
+        )
+        sys.exit(0)
+
+    # Winetricks
+    # Exit if no winetricks verbs were passed
+    if sys.argv[1].endswith("winetricks") and not sys.argv[2:]:
+        err: str = "No winetricks verb specified"
+        log.error(err)
+        sys.exit(1)
+
+    # Exit if argument is not a verb
+    if sys.argv[1].endswith("winetricks") and not is_winetricks_verb(
+        sys.argv[2:]
+    ):
+        sys.exit(1)
+
+    if sys.argv[1:][0] in opt_args:
+        return parser.parse_args(sys.argv[1:])
+
+    if sys.argv[1] in PROTON_VERBS:
+        if "PROTON_VERB" not in os.environ:
+            os.environ["PROTON_VERB"] = sys.argv[1]
+        sys.argv.pop(1)
+
+    return sys.argv[1], sys.argv[2:]
 
 
 def main() -> int:  # noqa: D103
-    return umu_run()
+    args: Namespace | tuple[str, list[str]]
+
+    args = parse_args()
+    return umu_run(args)
 
 
 if __name__ == "__main__":

--- a/umu/__main__.py
+++ b/umu/__main__.py
@@ -3,7 +3,7 @@ import sys
 from argparse import ArgumentParser, Namespace, RawTextHelpFormatter
 
 from umu import __version__
-from umu.umu_consts import PROTON_VERBS, UMU_LOCAL
+from umu.umu_consts import PROTON_VERBS
 from umu.umu_log import log
 from umu.umu_run import umu_run
 from umu.umu_util import is_winetricks_verb

--- a/umu/__main__.py
+++ b/umu/__main__.py
@@ -3,7 +3,7 @@ import sys
 from argparse import ArgumentParser, Namespace, RawTextHelpFormatter
 
 from umu import __version__
-from umu.umu_consts import PROTON_VERBS
+from umu.umu_consts import PROTON_VERBS, UMU_LOCAL
 from umu.umu_log import log
 from umu.umu_run import umu_run
 from umu.umu_util import is_winetricks_verb

--- a/umu/__main__.py
+++ b/umu/__main__.py
@@ -79,7 +79,7 @@ def main() -> int:  # noqa: D103
     args: Namespace | tuple[str, list[str]]
 
     # Adjust logger for debugging when configured
-    if os.environ.get("UMU_LOG") in ("1", "debug"):
+    if os.environ.get("UMU_LOG") in {"1", "debug"}:
         log.setLevel(level="DEBUG")
         log.set_formatter(os.environ["UMU_LOG"])
         for key, val in os.environ.items():

--- a/umu/umu_log.py
+++ b/umu/umu_log.py
@@ -1,5 +1,4 @@
 import sys
-from enum import StrEnum
 from logging import (
     Formatter,
     Logger,
@@ -8,7 +7,7 @@ from logging import (
 )
 
 
-class Color(StrEnum):  # noqa: D101
+class Color:  # noqa: D101
     ERROR = "\033[31m"  # Red
     DEBUG = "\u001b[35m"  # Purple
     INFO = "\u001b[34m"  # Blue
@@ -44,7 +43,7 @@ class CustomLogger(Logger):  # noqa: D101
 
 class CustomFormatter(Formatter):  # noqa: D101
     def format(self, record: LogRecord) -> str:  # noqa: D102
-        color: Color
+        color: str
         match record.levelname:
             case "INFO":
                 color = Color.INFO

--- a/umu/umu_log.py
+++ b/umu/umu_log.py
@@ -12,7 +12,6 @@ class Color:  # noqa: D101
     DEBUG = "\u001b[35m"  # Purple
     INFO = "\u001b[34m"  # Blue
     WARNING = "\033[33m"  # Yellow
-    FATAL = "\033[33m"
     CRITICAL = "\033[33m"
     BOLD = "\033[1m"
     GREY = "\033[90m"

--- a/umu/umu_log.py
+++ b/umu/umu_log.py
@@ -44,7 +44,27 @@ class CustomLogger(Logger):  # noqa: D101
 
 class CustomFormatter(Formatter):  # noqa: D101
     def format(self, record: LogRecord) -> str:  # noqa: D102
-        record.levelname = f"{LogColor.get(record.levelname)}{LogColor.get('BOLD')}{record.levelname}{LogColor.get('RESET')}"
+        color: Color
+        match record.levelname:
+            case "INFO":
+                color = Color.INFO
+            case "DEBUG":
+                color = Color.DEBUG
+            case "CRITICAL":
+                color = Color.CRITICAL
+            case "ERROR":
+                color = Color.ERROR
+            case "WARNING":
+                color = Color.WARNING
+            case "WARN":
+                color = Color.WARNING
+            case "FATAL":
+                color = Color.WARNING
+            case _:
+                color = Color.BOLD
+        record.levelname = (
+            f"{color}{Color.BOLD}{record.levelname}{Color.RESET}"
+        )
         return super().format(record)
 
 

--- a/umu/umu_log.py
+++ b/umu/umu_log.py
@@ -19,7 +19,7 @@ class Color:  # noqa: D101
     RESET = "\u001b[0m"
 
 
-SIMPLE_FORMAT = "[%(name)s] %(levelname)s: %(message)s"
+SIMPLE_FORMAT = "%(levelname)s: %(message)s"
 
 DEBUG_FORMAT = "[%(name)s.%(module)s:%(lineno)d] %(levelname)s: %(message)s"
 

--- a/umu/umu_log.py
+++ b/umu/umu_log.py
@@ -1,4 +1,5 @@
 import sys
+from enum import StrEnum
 from logging import (
     Formatter,
     Logger,
@@ -6,17 +7,17 @@ from logging import (
     StreamHandler,
 )
 
-LogColor = {
-    "RESET": "\u001b[0m",
-    "INFO": "\u001b[34m",  # Blue
-    "WARNING": "\033[33m",  # Yellow
-    "ERROR": "\033[31m",  # Red
-    "DEBUG": "\u001b[35m",  # Purple
-    "BOLD": "\033[1m",
-    "GREY": "\033[90m",
-}
 
-SIMPLE_FORMAT = f"[{__package__}] %(levelname)s: %(message)s"
+class Color(StrEnum):  # noqa: D101
+    ERROR = "\033[31m"  # Red
+    DEBUG = "\u001b[35m"  # Purple
+    INFO = "\u001b[34m"  # Blue
+    WARNING = "\033[33m"  # Yellow
+    FATAL = "\033[33m"
+    CRITICAL = "\033[33m"
+    BOLD = "\033[1m"
+    GREY = "\033[90m"
+    RESET = "\u001b[0m"
 
 DEBUG_FORMAT = (
     f"[{__package__}.%(module)s:%(lineno)d] %(levelname)s: %(message)s"

--- a/umu/umu_log.py
+++ b/umu/umu_log.py
@@ -19,9 +19,10 @@ class Color(StrEnum):  # noqa: D101
     GREY = "\033[90m"
     RESET = "\u001b[0m"
 
-DEBUG_FORMAT = (
-    f"[{__package__}.%(module)s:%(lineno)d] %(levelname)s: %(message)s"
-)
+
+SIMPLE_FORMAT = "[%(name)s] %(levelname)s: %(message)s"
+
+DEBUG_FORMAT = "[%(name)s.%(module)s:%(lineno)d] %(levelname)s: %(message)s"
 
 
 class CustomLogger(Logger):  # noqa: D101

--- a/umu/umu_log.py
+++ b/umu/umu_log.py
@@ -30,7 +30,7 @@ class CustomLogger(Logger):  # noqa: D101
 
     def set_formatter(self, level: str) -> None:  # noqa: D102
         console_handler: StreamHandler
-        if level in ("1", "debug"):  # Values for UMU_LOG
+        if level in {"1", "debug"}:  # Values for UMU_LOG
             self._custom_fmt = DEBUG_FORMAT
             self.setLevel("DEBUG")
         console_handler = StreamHandler(stream=sys.stderr)

--- a/umu/umu_proton.py
+++ b/umu/umu_proton.py
@@ -182,7 +182,7 @@ def _fetch_proton(
     if ret:
         tmp.joinpath(tarball).unlink(missing_ok=True)
         log.warning("zenity exited with the status code: %s", ret)
-        log.console("Retrying from Python...")
+        log.info("Retrying from Python...")
 
     if not os.environ.get("UMU_ZENITY") or ret:
         log.console(f"Downloading {tarball}...")
@@ -211,7 +211,7 @@ def _fetch_proton(
                 err: str = f"Digest mismatched: {tarball}"
                 raise ValueError(err)
 
-            log.console(f"{tarball}: SHA512 is OK")
+            log.info("%s: SHA512 is OK", tarball)
 
     return env
 
@@ -226,7 +226,7 @@ def _extract_dir(file: Path) -> None:
             log.warning("Python: %s", sys.version)
             log.warning("Using no data filter for archive")
             log.warning("Archive will be extracted insecurely")
-        log.console(f"Extracting {file.name}...")
+        log.info("Extracting %s...", file.name)
         log.debug("Source: %s", str(file).removesuffix(".tar.gz"))
         tar.extractall(path=file.parent)  # noqa: S202
 
@@ -258,8 +258,8 @@ def _get_from_steamcompat(
                 for text in resplit(r"(\d+)", proton.name)
             ],
         )
-        log.console(f"{latest.name} found in '{steam_compat}'")
-        log.console(f"Using {latest.name}")
+        log.info("%s found in '%s'", latest.name, steam_compat)
+        log.info("Using %s", latest.name)
         os.environ["PROTONPATH"] = str(latest)
         env["PROTONPATH"] = os.environ["PROTONPATH"]
     except ValueError:
@@ -306,7 +306,7 @@ def _get_latest(
 
     # Return if the latest Proton is already installed
     if steam_compat.joinpath(proton).is_dir():
-        log.console(f"{version} is up to date")
+        log.info("%s is up to date", version)
         steam_compat.joinpath("UMU-Latest").unlink(missing_ok=True)
         steam_compat.joinpath("UMU-Latest").symlink_to(proton)
         os.environ["PROTONPATH"] = str(steam_compat.joinpath(proton))
@@ -344,7 +344,7 @@ def _get_latest(
     os.environ["PROTONPATH"] = str(steam_compat.joinpath(proton))
     env["PROTONPATH"] = os.environ["PROTONPATH"]
     log.debug("Removing: %s", tarball)
-    log.console(f"Using {proton}")
+    log.info("Using %s", proton)
 
     return env
 
@@ -416,7 +416,7 @@ def _install_proton(
     _extract_dir(tmpdirs[1] / tarball)
 
     # Move decompressed archive to compatibilitytools.d
-    log.console(f"'{proton_path}' -> '{steam_compat}'")
+    log.info("'%s' -> '%s'", proton_path, steam_compat)
     move(proton_path, steam_compat)
 
     steam_compat.joinpath("UMU-Latest").unlink(missing_ok=True)

--- a/umu/umu_proton.py
+++ b/umu/umu_proton.py
@@ -150,7 +150,7 @@ def _fetch_proton(
     # Digest file
     # Since the URLs are not hardcoded links, Ruff will flag the urlopen call
     # See https://github.com/astral-sh/ruff/issues/7918
-    log.info(f"Downloading {proton_hash}...")
+    log.info("Downloading %s...", proton_hash)
     with (
         urlopen(proton_hash_url, context=ssl_default_context) as resp,  # noqa: S310
     ):

--- a/umu/umu_proton.py
+++ b/umu/umu_proton.py
@@ -150,7 +150,7 @@ def _fetch_proton(
     # Digest file
     # Since the URLs are not hardcoded links, Ruff will flag the urlopen call
     # See https://github.com/astral-sh/ruff/issues/7918
-    log.console(f"Downloading {proton_hash}...")
+    log.info(f"Downloading {proton_hash}...")
     with (
         urlopen(proton_hash_url, context=ssl_default_context) as resp,  # noqa: S310
     ):
@@ -185,7 +185,7 @@ def _fetch_proton(
         log.info("Retrying from Python...")
 
     if not os.environ.get("UMU_ZENITY") or ret:
-        log.console(f"Downloading {tarball}...")
+        log.info("Downloading %s...", tarball)
         with (
             urlopen(tar_url, context=ssl_default_context) as resp,  # noqa: S310
         ):

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -18,7 +18,6 @@ try:
 except ModuleNotFoundError:
     from importlib.abc import Traversable
 
-from logging import DEBUG, INFO, WARNING
 from pathlib import Path
 from pwd import getpwuid
 from re import match
@@ -41,7 +40,7 @@ from umu.umu_consts import (
     STEAM_WINDOW_ID,
     UMU_LOCAL,
 )
-from umu.umu_log import CustomFormatter, console_handler, log
+from umu.umu_log import log
 from umu.umu_plugins import set_env_toml
 from umu.umu_proton import get_umu_proton
 from umu.umu_runtime import setup_umu
@@ -845,7 +844,7 @@ def main() -> int:  # noqa: D103
         for key, val in os.environ.items():
             log.debug("%s=%s", key, val)
 
-    log.console(f"umu-launcher version {__version__} ({sys.version})")
+    log.info("umu-launcher version %s (%s)", __version__, sys.version)
 
     with ThreadPoolExecutor() as thread_pool:
         try:

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -762,28 +762,6 @@ def umu_run(args: Namespace | tuple[str, list[str]]) -> int:
             Path(__file__).resolve().parent.parent, Path(__file__).parent.name
         )
 
-    if os.geteuid() == 0:
-        err: str = "This script should never be run as the root user"
-        log.error(err)
-        sys.exit(1)
-
-    if "musl" in os.environ.get("LD_LIBRARY_PATH", ""):
-        err: str = "This script is not designed to run on musl-based systems"
-        log.error(err)
-        sys.exit(1)
-
-    # Adjust the log level for the logger
-    if os.environ.get("UMU_LOG") == "1":
-        log.setLevel(level=INFO)
-    elif os.environ.get("UMU_LOG") == "warn":
-        log.setLevel(level=WARNING)
-    elif os.environ.get("UMU_LOG") == "debug":
-        console_handler.setFormatter(CustomFormatter(DEBUG))
-        log.addHandler(console_handler)
-        log.setLevel(level=DEBUG)
-        for key, val in os.environ.items():
-            log.debug("%s=%s", key, val)
-
     log.info("umu-launcher version %s (%s)", __version__, sys.version)
 
     with ThreadPoolExecutor() as thread_pool:

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -825,7 +825,7 @@ def umu_run(args: Namespace | tuple[str, list[str]]) -> int:
         # Set all environment variables
         # NOTE: `env` after this block should be read only
         for key, val in env.items():
-            log.info("%s=%s", key, val)
+            log.debug("%s=%s", key, val)
             os.environ[key] = val
 
         try:

--- a/umu/umu_runtime.py
+++ b/umu/umu_runtime.py
@@ -118,7 +118,7 @@ def _install_umu(
     # Handle the exit code from zenity
     if ret:
         tmp.joinpath(archive).unlink(missing_ok=True)
-        log.console("Retrying from Python...")
+        log.info("Retrying from Python...")
 
     if not os.environ.get("UMU_ZENITY") or ret:
         digest: str = ""
@@ -145,7 +145,7 @@ def _install_umu(
                     break
 
         # Download the runtime
-        log.console(f"Downloading latest steamrt {codename}, please wait...")
+        log.info("Downloading latest steamrt %s, please wait...", codename)
         client_session.request("GET", f"{endpoint}/{archive}{token}")
 
         with (
@@ -170,7 +170,7 @@ def _install_umu(
                 err: str = f"Digest mismatched: {archive}"
                 raise ValueError(err)
 
-        log.console(f"{archive}: SHA256 is OK")
+        log.info("%s: SHA256 is OK", archive)
 
     # Open the tar file and move the files
     log.debug("Opening: %s", tmp.joinpath(archive))
@@ -251,9 +251,7 @@ def setup_umu(
     # New install or umu dir is empty
     if not local.exists() or not any(local.iterdir()):
         log.debug("New install detected")
-        log.console(
-            "Setting up Unified Launcher for Windows Games on Linux..."
-        )
+        log.info("Setting up Unified Launcher for Windows Games on Linux...")
         local.mkdir(parents=True, exist_ok=True)
         with https_connection(host) as client_session:
             _restore_umu(
@@ -305,7 +303,7 @@ def _update_umu(
     except ValueError:
         log.debug("*_platform_* directory missing in '%s'", local)
         log.warning("Runtime Platform not found")
-        log.console("Restoring Runtime Platform...")
+        log.info("Restoring Runtime Platform...")
         _restore_umu(
             json,
             thread_pool,
@@ -323,7 +321,7 @@ def _update_umu(
     if not local.joinpath("pressure-vessel").is_dir():
         log.debug("pressure-vessel directory missing in '%s'", local)
         log.warning("Runtime Platform not found")
-        log.console("Restoring Runtime Platform...")
+        log.info("Restoring Runtime Platform...")
         _restore_umu(
             json,
             thread_pool,
@@ -347,7 +345,7 @@ def _update_umu(
         if not release.is_file():
             log.debug("os-release file missing in '%s'", local)
             log.warning("Runtime Platform corrupt")
-            log.console("Restoring Runtime Platform...")
+            log.info("Restoring Runtime Platform...")
             _restore_umu(
                 json,
                 thread_pool,
@@ -424,7 +422,7 @@ def _update_umu(
 
         if steamrt_latest_digest != steamrt_local_digest:
             lock: FileLock = FileLock(f"{local}/umu.lock")
-            log.console("Updating steamrt to latest...")
+            log.info("Updating steamrt to latest...")
             log.debug("Acquiring file lock '%s'...", lock.lock_file)
 
             with lock:
@@ -446,7 +444,7 @@ def _update_umu(
     if not local.joinpath("umu-shim").exists():
         create_shim()
 
-    log.console("steamrt is up to date")
+    log.info("steamrt is up to date")
 
 
 def _get_json(path: Traversable, config: str) -> dict[str, Any]:
@@ -539,7 +537,7 @@ def check_runtime(src: Path, json: dict[str, Any]) -> int:
         log.warning("File does not exist: '%s'", pv_verify)
         return ret
 
-    log.console(f"Verifying integrity of {runtime.name}...")
+    log.info("Verifying integrity of %s...", runtime.name)
     ret = run(
         [
             pv_verify,
@@ -554,7 +552,7 @@ def check_runtime(src: Path, json: dict[str, Any]) -> int:
         log.warning("steamrt validation failed")
         log.debug("%s exited with the status code: %s", pv_verify.name, ret)
         return ret
-    log.console(f"{runtime.name}: mtree is OK")
+    log.info("%s: mtree is OK", runtime.name)
 
     return ret
 
@@ -569,7 +567,7 @@ def _restore_umu(
         log.debug("Acquired file lock '%s'...", lock.lock_file)
         if callback_fn():
             log.debug("Released file lock '%s'", lock.lock_file)
-            log.console("steamrt was restored")
+            log.info("steamrt was restored")
             return
         _install_umu(json, thread_pool, client_session)
         log.debug("Released file lock '%s'", lock.lock_file)

--- a/umu/umu_test.py
+++ b/umu/umu_test.py
@@ -16,7 +16,7 @@ from unittest.mock import MagicMock, patch
 
 sys.path.append(str(Path(__file__).parent.parent))
 
-from umu import umu_proton, umu_run, umu_runtime, umu_util
+from umu import __main__, umu_proton, umu_run, umu_runtime, umu_util
 
 
 class TestGameLauncher(unittest.TestCase):
@@ -1086,7 +1086,7 @@ class TestGameLauncher(unittest.TestCase):
             os.environ["GAMEID"] = self.test_file
             os.environ["STORE"] = self.test_file
             # Args
-            args = umu_run.parse_args()
+            args = __main__.parse_args()
             # Config
             umu_run.check_env(self.env, thread_pool)
             # Prefix
@@ -1153,7 +1153,7 @@ class TestGameLauncher(unittest.TestCase):
             os.environ["GAMEID"] = self.test_file
             os.environ["STORE"] = self.test_file
             # Args
-            args = umu_run.parse_args()
+            args = __main__.parse_args()
             # Config
             umu_run.check_env(self.env, thread_pool)
             # Prefix
@@ -1253,7 +1253,7 @@ class TestGameLauncher(unittest.TestCase):
             os.environ["GAMEID"] = self.test_file
             os.environ["STORE"] = self.test_file
             # Args
-            args = umu_run.parse_args()
+            args = __main__.parse_args()
             # Config
             umu_run.check_env(self.env, thread_pool)
             # Prefix
@@ -1332,7 +1332,7 @@ class TestGameLauncher(unittest.TestCase):
             os.environ["STORE"] = self.test_file
             os.environ["UMU_NO_PROTON"] = "1"
             # Args
-            result_args = umu_run.parse_args()
+            result_args = __main__.parse_args()
             # Config
             umu_run.check_env(self.env, thread_pool)
             # Prefix
@@ -1418,7 +1418,7 @@ class TestGameLauncher(unittest.TestCase):
             os.environ["STORE"] = self.test_file
             os.environ["UMU_NO_RUNTIME"] = "1"
             # Args
-            result_args = umu_run.parse_args()
+            result_args = __main__.parse_args()
             # Config
             umu_run.check_env(self.env, thread_pool)
             # Prefix
@@ -1497,7 +1497,7 @@ class TestGameLauncher(unittest.TestCase):
             os.environ["STORE"] = self.test_file
             os.environ["UMU_NO_RUNTIME"] = "pressure-vessel"
             # Args
-            result_args = umu_run.parse_args()
+            result_args = __main__.parse_args()
             # Config
             umu_run.check_env(self.env, thread_pool)
             # Prefix
@@ -1544,7 +1544,7 @@ class TestGameLauncher(unittest.TestCase):
             os.environ["GAMEID"] = self.test_file
             os.environ["STORE"] = self.test_file
             # Args
-            result_args = umu_run.parse_args()
+            result_args = __main__.parse_args()
             # Config
             umu_run.check_env(self.env, thread_pool)
             # Prefix
@@ -1641,7 +1641,7 @@ class TestGameLauncher(unittest.TestCase):
             os.environ["STORE"] = test_str
             os.environ["PROTON_VERB"] = self.test_verb
             # Args
-            result = umu_run.parse_args()
+            result = __main__.parse_args()
             # Check
             umu_run.check_env(self.env, thread_pool)
             # Prefix
@@ -1725,7 +1725,7 @@ class TestGameLauncher(unittest.TestCase):
             os.environ["STORE"] = test_str
             os.environ["PROTON_VERB"] = self.test_verb
             # Args
-            result = umu_run.parse_args()
+            result = __main__.parse_args()
             # Check
             umu_run.check_env(self.env, thread_pool)
             # Prefix
@@ -1834,7 +1834,7 @@ class TestGameLauncher(unittest.TestCase):
             os.environ["STORE"] = test_str
             os.environ["PROTON_VERB"] = self.test_verb
             # Args
-            result = umu_run.parse_args()
+            result = __main__.parse_args()
             # Check
             umu_run.check_env(self.env, thread_pool)
             # Prefix
@@ -1951,7 +1951,7 @@ class TestGameLauncher(unittest.TestCase):
             os.environ["PROTON_VERB"] = self.test_verb
             os.environ["UMU_RUNTIME_UPDATE"] = "0"
             # Args
-            result = umu_run.parse_args()
+            result = __main__.parse_args()
             # Check
             umu_run.check_env(self.env, thread_pool)
             # Prefix
@@ -2082,7 +2082,7 @@ class TestGameLauncher(unittest.TestCase):
             os.environ["GAMEID"] = test_str
             os.environ["PROTON_VERB"] = proton_verb
             # Args
-            result = umu_run.parse_args()
+            result = __main__.parse_args()
             # Check
             umu_run.check_env(self.env, thread_pool)
             # Prefix
@@ -2487,7 +2487,7 @@ class TestGameLauncher(unittest.TestCase):
             patch("sys.argv", ["", "winetricks"]),
             self.assertRaises(SystemExit),
         ):
-            umu_run.parse_args()
+            __main__.parse_args()
 
     def test_parse_args_noopts(self):
         """Test parse_args with no options.
@@ -2495,7 +2495,7 @@ class TestGameLauncher(unittest.TestCase):
         A SystemExit should be raised in this usage: ./umu_run.py
         """
         with self.assertRaises(SystemExit):
-            umu_run.parse_args()
+            __main__.parse_args()
 
     def test_parse_args(self):
         """Test parse_args."""
@@ -2508,7 +2508,7 @@ class TestGameLauncher(unittest.TestCase):
             os.environ["STORE"] = self.test_file
 
             # Args
-            result = umu_run.parse_args()
+            result = __main__.parse_args()
             self.assertIsInstance(result, tuple, "Expected a tuple")
             self.assertIsInstance(result[0], str, "Expected a string")
             self.assertIsInstance(
@@ -2523,11 +2523,11 @@ class TestGameLauncher(unittest.TestCase):
     def test_parse_args_config(self):
         """Test parse_args --config."""
         with patch.object(
-            umu_run,
+            __main__,
             "parse_args",
             return_value=argparse.Namespace(config=self.test_file),
         ):
-            result = umu_run.parse_args()
+            result = __main__.parse_args()
             self.assertIsInstance(
                 result, Namespace, "Expected a Namespace from parse_arg"
             )

--- a/umu/umu_test_plugins.py
+++ b/umu/umu_test_plugins.py
@@ -14,7 +14,7 @@ from tomllib import TOMLDecodeError
 
 sys.path.append(str(Path(__file__).parent.parent))
 
-from umu import umu_plugins, umu_run, umu_runtime
+from umu import __main__, umu_plugins, umu_run, umu_runtime
 
 
 class TestGameLauncherPlugins(unittest.TestCase):
@@ -202,12 +202,12 @@ class TestGameLauncherPlugins(unittest.TestCase):
             file.write(toml_str)
 
         with patch.object(
-            umu_run,
+            __main__,
             "parse_args",
             return_value=argparse.Namespace(config=toml_path),
         ):
             # Args
-            result = umu_run.parse_args()
+            result = __main__.parse_args()
             # Config
             umu_plugins.set_env_toml(self.env, result)
             # Prefix
@@ -278,12 +278,12 @@ class TestGameLauncherPlugins(unittest.TestCase):
             file.write(toml_str)
 
         with patch.object(
-            umu_run,
+            __main__,
             "parse_args",
             return_value=argparse.Namespace(config=toml_path),
         ):
             # Args
-            result = umu_run.parse_args()
+            result = __main__.parse_args()
             # Config
             umu_plugins.set_env_toml(self.env, result)
             # Prefix
@@ -360,12 +360,12 @@ class TestGameLauncherPlugins(unittest.TestCase):
             file.write(toml_str)
 
         with patch.object(
-            umu_run,
+            __main__,
             "parse_args",
             return_value=argparse.Namespace(config=toml_path),
         ):
             # Args
-            result = umu_run.parse_args()
+            result = __main__.parse_args()
             # Config
             umu_plugins.set_env_toml(self.env, result)
             # Prefix
@@ -459,12 +459,12 @@ class TestGameLauncherPlugins(unittest.TestCase):
             file.write(toml_str)
 
         with patch.object(
-            umu_run,
+            __main__,
             "parse_args",
             return_value=argparse.Namespace(config=toml_path),
         ):
             # Args
-            result = umu_run.parse_args()
+            result = __main__.parse_args()
             self.assertIsInstance(
                 result, Namespace, "Expected a Namespace from parse_arg"
             )
@@ -497,12 +497,12 @@ class TestGameLauncherPlugins(unittest.TestCase):
             file.write(toml_str)
 
         with patch.object(
-            umu_run,
+            __main__,
             "parse_args",
             return_value=argparse.Namespace(config=toml_path),
         ):
             # Args
-            result = umu_run.parse_args()
+            result = __main__.parse_args()
             self.assertIsInstance(
                 result, Namespace, "Expected a Namespace from parse_arg"
             )
@@ -533,12 +533,12 @@ class TestGameLauncherPlugins(unittest.TestCase):
             file.write(toml_str)
 
         with patch.object(
-            umu_run,
+            __main__,
             "parse_args",
             return_value=argparse.Namespace(config=toml_path),
         ):
             # Args
-            result = umu_run.parse_args()
+            result = __main__.parse_args()
             self.assertIsInstance(
                 result, Namespace, "Expected a Namespace from parse_arg"
             )
@@ -571,12 +571,12 @@ class TestGameLauncherPlugins(unittest.TestCase):
             file.write(toml_str)
 
         with patch.object(
-            umu_run,
+            __main__,
             "parse_args",
             return_value=argparse.Namespace(config=toml_path),
         ):
             # Args
-            result = umu_run.parse_args()
+            result = __main__.parse_args()
             self.assertIsInstance(
                 result, Namespace, "Expected a Namespace from parse_arg"
             )
@@ -637,12 +637,12 @@ class TestGameLauncherPlugins(unittest.TestCase):
             file.write(toml_str)
 
         with patch.object(
-            umu_run,
+            __main__,
             "parse_args",
             return_value=argparse.Namespace(config=toml_path),
         ):
             # Args
-            result = umu_run.parse_args()
+            result = __main__.parse_args()
             self.assertIsInstance(
                 result, Namespace, "Expected a Namespace from parse_arg"
             )
@@ -703,12 +703,12 @@ class TestGameLauncherPlugins(unittest.TestCase):
             file.write(toml_str)
 
         with patch.object(
-            umu_run,
+            __main__,
             "parse_args",
             return_value=argparse.Namespace(config=toml_path),
         ):
             # Args
-            result = umu_run.parse_args()
+            result = __main__.parse_args()
             self.assertIsInstance(
                 result, Namespace, "Expected a Namespace from parse_arg"
             )
@@ -783,12 +783,12 @@ class TestGameLauncherPlugins(unittest.TestCase):
             file.write(toml_str)
 
         with patch.object(
-            umu_run,
+            __main__,
             "parse_args",
             return_value=argparse.Namespace(config=toml_path),
         ):
             # Args
-            result = umu_run.parse_args()
+            result = __main__.parse_args()
             self.assertIsInstance(
                 result, Namespace, "Expected a Namespace from parse_arg"
             )


### PR DESCRIPTION
Key changes:
- Moves `umu.umu_run.parse_args` to `__main__.py`.
- Renames `umu.umu_run.main` to `umu.umu_run.umu_run`. There will be only be one `main` function, which is in `__main__.py`.
- Removes the ANSI color code for bolded text from log messages. Color will still be applied, but only to the _level_ section of the logger like Gamescope.
- Removes _warning_ as a supported value in `UMU_LOG` and soft deprecates _debug_ in favor of simply _1_. `UMU_LOG=1` will be the new way to enable logging. Setting `UMU_LOG=debug` will still be valid and kept for compatibility until the next major version.
- Adds the line number when debugging is configured.


As a result, log files should be less tedious to read through for user uploaded files or when reading through a pager utility like `less`. The module's functionality is a bit more organized as well. Additionally, due to moving the argument parsing functionality, running this CLI will no longer be possible within the source directory through `umu_run.py`. Therefore, for usage, either execute `__main__.py`, build the zipapp, Flatpak, distribution package, or create a systemd-sysext image. See https://www.freedesktop.org/software/systemd/man/latest/systemd-sysext.html.
