### PR TITLE
refactor: simplify version printing when parsing arguments

### DIFF
--- a/umu/__main__.py
+++ b/umu/__main__.py
@@ -10,7 +10,7 @@ from umu.umu_util import is_winetricks_verb
 
 
 def parse_args() -> Namespace | tuple[str, list[str]]:  # noqa: D103
-    opt_args: set[str] = {"--help", "-h", "--config"}
+    opt_args: set[str] = {"--help", "-h", "--config", "--version", "-v"}
     parser: ArgumentParser = ArgumentParser(
         description="Unified Linux Wine Game Launcher",
         epilog=(
@@ -22,7 +22,8 @@ def parse_args() -> Namespace | tuple[str, list[str]]:  # noqa: D103
     parser.add_argument(
         "-v",
         "--version",
-        action="store_true",
+        action="version",
+        version=f"umu-launcher version {__version__} ({sys.version})",
         help="show this version and exit",
     )
     parser.add_argument(
@@ -38,18 +39,6 @@ def parse_args() -> Namespace | tuple[str, list[str]]:  # noqa: D103
     if not sys.argv[1:]:
         parser.print_help(sys.stderr)
         sys.exit(1)
-
-    # Show version
-    # Need to avoid clashes with later options (for example: wineboot -u)
-    #   but parse_args scans the whole command line.
-    # So look at the first argument and see if we have -v or --version
-    #   in sort of the same way parse_args would.
-    if sys.argv[1].lower().endswith(("--version", "-v")):
-        print(
-            f"umu-launcher version {__version__} ({sys.version})",
-            file=sys.stderr,
-        )
-        sys.exit(0)
 
     # Winetricks
     # Exit if no winetricks verbs were passed

--- a/umu/umu_test.py
+++ b/umu/umu_test.py
@@ -2520,6 +2520,29 @@ class TestGameLauncher(unittest.TestCase):
                 "Expected the test string when passed as an option",
             )
 
+    def test_parse_args_version(self):
+        """Test parse_args --version."""
+        mock_val = "foo"
+        opt = "version"
+        with patch.object(
+            __main__,
+            "parse_args",
+            return_value=argparse.Namespace(version=mock_val),
+        ):
+            result = __main__.parse_args()
+            self.assertIsInstance(
+                result, Namespace, "Expected a Namespace from parse_arg"
+            )
+            self.assertTrue(
+                hasattr(result, opt),
+                f"Expected {result} to have attr {opt}",
+            )
+            self.assertEqual(
+                getattr(result, opt),
+                mock_val,
+                f"Expected {mock_val}, received {getattr(result, opt)}",
+            )
+
     def test_parse_args_config(self):
         """Test parse_args --config."""
         with patch.object(


### PR DESCRIPTION
Delegates version printing to the argparse module by using the version action and adds the option to our optional argument whitelist.
