### PR TITLE
refactor: don't raise runtime error on failure getting gh assets

### DIFF
--- a/umu/umu_proton.py
+++ b/umu/umu_proton.py
@@ -120,8 +120,9 @@ def _fetch_releases() -> tuple[tuple[str, str], tuple[str, str]] | tuple[()]:
             break
 
     if asset_count != 2:  # noqa: PLR2004
-        err: str = "Failed to acquire all assets from api.github.com"
-        raise RuntimeError(err)
+        log.warning("Failed to acquire release assets from '%s'", url)
+        log.debug("'%' returned: %s", url, releases)
+        return ()
 
     return digest_asset, proton_asset
 


### PR DESCRIPTION
Currently, we were raising a runtime error when we failed to get releases. This wasn't a problem as we pin to a specific Github API version, thus guaranteeing stability of the JSON interface. However, if we ever changed file names to something different (e.g., UMU-Proton9-10.tar.zst), the launcher would crash. In those cases, instead of raising a runtime error, continue to search for Proton in the user's system.
