### PR TITLE
refactor: get runtime metadata from package init file

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -34,21 +34,6 @@ all: umu-dist umu-docs umu-launcher
 install: umu-install umu-launcher-install
 endif
 
-# Special case, do this inside the source directory for release distribution
-umu/umu_version.json: umu/umu_version.json.in
-	$(info :: Updating $(@) )
-	cp $(<) $(<).tmp
-	sed 's|##UMU_VERSION##|$(shell git describe --always --long --tags)|g' -i $(<).tmp
-	mv $(<).tmp $(@)
-
-.PHONY: version
-version: umu/umu_version.json
-
-version-install: version
-	$(info :: Installing umu_version.json )
-	install -d $(DESTDIR)$(PYTHONDIR)/$(INSTALLDIR)
-	install -Dm 644 umu/umu_version.json -t $(DESTDIR)$(PYTHONDIR)/$(INSTALLDIR)
-
 
 $(OBJDIR)/.build-umu-docs: | $(OBJDIR)
 	$(info :: Building umu man pages )
@@ -67,7 +52,7 @@ umu-docs-install: umu-docs
 	install -m644 $(OBJDIR)/umu.5 $(DESTDIR)$(MANDIR)/man5/umu.5
 
 
-$(OBJDIR)/.build-umu-dist: | $(OBJDIR) version
+$(OBJDIR)/.build-umu-dist: | $(OBJDIR)
 	$(info :: Building umu )
 	$(PYTHON_INTERPRETER) -m build --wheel --skip-dependency-check --no-isolation --outdir=$(OBJDIR)
 	touch $(@)
@@ -81,9 +66,9 @@ umu-dist-install: umu-dist
 	$(PYTHON_INTERPRETER)  -m installer --destdir=$(DESTDIR) $(OBJDIR)/*.whl
 
 ifeq ($(FLATPAK), xtrue)
-umu-install: version-install umu-dist-install
+umu-install: umu-dist-install
 else
-umu-install: version-install umu-dist-install umu-docs-install
+umu-install: umu-dist-install umu-docs-install
 endif
 
 ifeq ($(FLATPAK), xtrue)
@@ -136,7 +121,7 @@ $(OBJDIR):
 .PHONY: clean
 clean:
 	$(info :: Cleaning source directory )
-	@rm -rf -v $(OBJDIR) umu/umu_version.json ./$(RELEASEDIR) $(RELEASEDIR).tar.gz
+	@rm -rf -v ./$(RELEASEDIR) $(RELEASEDIR).tar.gz
 
 
 RELEASEDIR := $(PROJECT)-$(shell git describe --abbrev=0)
@@ -144,7 +129,7 @@ $(RELEASEDIR):
 	mkdir -p $(@)
 
 .PHONY: release
-release: $(RELEASEDIR) | version zipapp
+release: $(RELEASEDIR) | zipapp
 	$(info :: Creating source distribution for release )
 	mkdir -p $(<)
 	rm -rf umu/__pycache__
@@ -165,11 +150,10 @@ ZIPAPP := $(OBJDIR)/umu-run
 ZIPAPP_STAGING := $(OBJDIR)/zipapp_staging
 ZIPAPP_VENV := $(OBJDIR)/zipapp_venv
 
-$(OBJDIR)/.build-zipapp: | $(OBJDIR) version
+$(OBJDIR)/.build-zipapp: | $(OBJDIR)
 	$(info :: Building umu-launcher as zipapp )
 	$(PYTHON_INTERPRETER) -m venv $(ZIPAPP_VENV)
 	. $(ZIPAPP_VENV)/bin/activate && python3 -m pip install -t "$(ZIPAPP_STAGING)" -U --no-compile .
-	install -Dm644 umu/umu_version.json "$(ZIPAPP_STAGING)"/umu/umu_version.json
 	cp umu/__main__.py "$(ZIPAPP_STAGING)"
 	find "$(ZIPAPP_STAGING)" -exec touch -h -d "$(SOURCE_DATE_EPOCH)" {} +
 	. $(ZIPAPP_VENV)/bin/activate && python3 -m zipapp $(ZIPAPP_STAGING) -o $(ZIPAPP) -p "$(PYTHON_INTERPRETER)" -c

--- a/umu/__init__.py
+++ b/umu/__init__.py
@@ -1,1 +1,3 @@
 __version__ = "1.1.4"  # noqa: D104
+__runtime_versions__ = (("sniper", "steamrt3"), ("soldier", "steamrt2"))
+__runtime_version__ = __runtime_versions__[0]

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -31,7 +31,7 @@ from Xlib.protocol.request import GetProperty
 from Xlib.protocol.rq import Event
 from Xlib.xobject.drawable import Window
 
-from umu import __version__
+from umu import __runtime_version__, __version__
 from umu.umu_consts import (
     PR_SET_CHILD_SUBREAPER,
     PROTON_VERBS,
@@ -803,7 +803,7 @@ def umu_run(args: Namespace | tuple[str, list[str]]) -> int:
 
         # Setup the launcher and runtime files
         future: Future = thread_pool.submit(
-            setup_umu, root, UMU_LOCAL, thread_pool
+            setup_umu, root, UMU_LOCAL, __runtime_version__, thread_pool
         )
 
         if isinstance(args, Namespace):

--- a/umu/umu_runtime.py
+++ b/umu/umu_runtime.py
@@ -11,14 +11,12 @@ except ModuleNotFoundError:
     from importlib.abc import Traversable
 
 from http import HTTPStatus
-from json import load
 from pathlib import Path
 from secrets import token_urlsafe
 from shutil import move, rmtree
 from subprocess import run
 from tarfile import open as taropen
 from tempfile import TemporaryDirectory, mkdtemp
-from typing import Any
 
 from filelock import FileLock
 
@@ -443,50 +441,6 @@ def _update_umu(
         create_shim()
 
     log.info("steamrt is up to date")
-
-
-def _get_json(path: Traversable, config: str) -> dict[str, Any]:
-    """Validate the state of the configuration file umu_version.json in a path.
-
-    The configuration file will be used to update the runtime and it reflects
-    the tools currently used by launcher. The key/value pairs umu and versions
-    must exist.
-    """
-    json: dict[str, Any]
-    # Steam Runtime platform values
-    # See https://gitlab.steamos.cloud/steamrt/steamrt/-/wikis/home
-    steamrts: set[str] = {
-        "soldier",
-        "sniper",
-        "medic",
-        "steamrt5",
-    }
-
-    # umu_version.json in the system path should always exist
-    if not path.joinpath(config).is_file():
-        err: str = (
-            f"File not found: {config}\n"
-            "Please reinstall the package to recover configuration file"
-        )
-        raise FileNotFoundError(err)
-
-    with path.joinpath(config).open(mode="r", encoding="utf-8") as file:
-        json = load(file)
-
-    # Raise an error if "umu" and "versions" doesn't exist
-    if not json or "umu" not in json or "versions" not in json["umu"]:
-        err: str = (
-            f"Failed to load {config} or 'umu' or 'versions' not in: {config}"
-        )
-        raise ValueError(err)
-
-    # The launcher will use the value runtime_platform to glob files. Attempt
-    # to guard against directory removal attacks for non-system wide installs
-    if json["umu"]["versions"]["runtime_platform"] not in steamrts:
-        err: str = "Value for 'runtime_platform' is not a steamrt"
-        raise ValueError(err)
-
-    return json
 
 
 def _move(file: Path, src: Path, dst: Path) -> None:

--- a/umu/umu_test_plugins.py
+++ b/umu/umu_test_plugins.py
@@ -1,5 +1,4 @@
 import argparse
-import json
 import os
 import re
 import sys
@@ -66,33 +65,13 @@ class TestGameLauncherPlugins(unittest.TestCase):
         self.test_user_share = Path("./tmp.jl3W4MtO57")
         # ~/.local/share/Steam/compatibilitytools.d
         self.test_local_share = Path("./tmp.WUaQAk7hQJ")
-
-        # Dictionary that represents the umu_versionS.json
-        self.root_config = {
-            "umu": {
-                "versions": {
-                    "launcher": "0.1-RC3",
-                    "runner": "0.1-RC3",
-                    "runtime_platform": "sniper",
-                }
-            }
-        }
-        # umu_version.json
-        self.test_config = json.dumps(self.root_config, indent=4)
+        self.test_runtime_version = ("sniper", "steamrt3")
 
         self.test_user_share.mkdir(exist_ok=True)
         self.test_local_share.mkdir(exist_ok=True)
         self.test_cache.mkdir(exist_ok=True)
         self.test_compat.mkdir(exist_ok=True)
         self.test_proton_dir.mkdir(exist_ok=True)
-
-        # Mock a valid configuration file at /usr/share/umu:
-        # tmp.BXk2NnvW2m/umu_version.json
-        Path(self.test_user_share, "umu_version.json").touch()
-        with Path(self.test_user_share, "umu_version.json").open(
-            mode="w", encoding="utf-8"
-        ) as file:
-            file.write(self.test_config)
 
         # Mock the launcher files
         Path(self.test_user_share, "umu_consts.py").touch()
@@ -222,8 +201,12 @@ class TestGameLauncherPlugins(unittest.TestCase):
         with (
             patch.object(umu_runtime, "_install_umu", return_value=None),
         ):
+            # TODO
             umu_runtime.setup_umu(
-                self.test_user_share, self.test_local_share, None
+                self.test_user_share,
+                self.test_local_share,
+                self.test_runtime_version,
+                None,
             )
             copytree(
                 Path(self.test_user_share, "sniper_platform_0.20240125.75305"),
@@ -298,7 +281,10 @@ class TestGameLauncherPlugins(unittest.TestCase):
             patch.object(umu_runtime, "_install_umu", return_value=None),
         ):
             umu_runtime.setup_umu(
-                self.test_user_share, self.test_local_share, None
+                self.test_user_share,
+                self.test_local_share,
+                self.test_runtime_version,
+                None,
             )
             copytree(
                 Path(self.test_user_share, "sniper_platform_0.20240125.75305"),
@@ -380,7 +366,10 @@ class TestGameLauncherPlugins(unittest.TestCase):
             patch.object(umu_runtime, "_install_umu", return_value=None),
         ):
             umu_runtime.setup_umu(
-                self.test_user_share, self.test_local_share, None
+                self.test_user_share,
+                self.test_local_share,
+                self.test_runtime_version,
+                None,
             )
             copytree(
                 Path(self.test_user_share, "sniper_platform_0.20240125.75305"),

--- a/umu/umu_version.json.in
+++ b/umu/umu_version.json.in
@@ -1,9 +1,0 @@
-{
-  "umu": {
-    "versions": {
-      "launcher": "##UMU_VERSION##",
-      "runner": "##UMU_VERSION##",
-      "runtime_platform": "sniper"
-    }
-  }
-}


### PR DESCRIPTION
Cherry picked from https://github.com/Open-Wine-Components/umu-launcher/pull/201 and supersedes https://github.com/Open-Wine-Components/umu-launcher/pull/154.

umu-launcher will no longer parse `umu_version.json` for runtime metadata. Instead, it'll retrieve them from hard coded variables declared in the package's `__init__.py` file. In the future, additional metadata can be added to this file (e.g., git commit) if desired. More importantly, updates to the next major SLR version will require updating the appropriate variable in `__init__.py`. Currently, this is the first value in `__runtime_versions__`.
