### PR TITLE
fix: fallback to $XDG_DATA_HOME instead of $HOME/.local/share for Flatpak

### DIFF
--- a/packaging/flatpak/org.openwinecomponents.umu.umu-launcher.yml
+++ b/packaging/flatpak/org.openwinecomponents.umu.umu-launcher.yml
@@ -64,6 +64,9 @@ finish-args:
   # Pressure Vessel
   # See https://github.com/flathub/com.valvesoftware.Steam/commit/0538256facdb0837c33232bc65a9195a8a5bc750
   - --env=XDG_DATA_DIRS=/app/share:/usr/lib/extensions/vulkan/share:/usr/share:/usr/share/runtime/share:/run/host/user-share:/run/host/share:/usr/lib/pressure-vessel/overrides/share
+  # umu
+  # Use host's $XDG_DATA_HOME, otherwise Flatpak's
+  - --filesystem=xdg-data/umu:create
 
 add-extensions:
   org.freedesktop.Platform.Compat.i386:

--- a/umu/umu_consts.py
+++ b/umu/umu_consts.py
@@ -45,7 +45,7 @@ if os.environ.get("container") == "flatpak":  # noqa: SIM112
     XDG_DATA_HOME: Path = (
         Path(os.environ["HOST_XDG_DATA_HOME"])
         if os.environ.get("HOST_XDG_DATA_HOME")
-        else Path.home().joinpath(".local", "share")
+        else Path(os.environ["XDG_DATA_HOME"])
     )
 elif os.environ.get("SNAP"):
     XDG_DATA_HOME: Path = Path(os.environ["SNAP_REAL_HOME"])


### PR DESCRIPTION
In DEs that do not set `$XDG_DATA_HOME`, the umu-launcher Flatpak would create` .local/share/umu` within its private home directory and install its runtime files there.