### PR TITLE
feat: add urllib3 v2 as network backend

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -29,23 +29,25 @@ jobs:
         run: |
           ./configure.sh --user-install
           make install
-      - name: Setup venv
-        run: |
-          uv venv --python 3.11
-          source .venv/bin/activate
       - name: Run shellcheck
         run: |
           shellcheck tests/*.sh
       - name: Test steamrt install
         run: |
+          uv venv --python 3.11
+          source .venv/bin/activate
           sh tests/test_install.sh
           rm -rf "$HOME/.local/share/umu" "$HOME/Games/umu" "$HOME/.local/share/Steam/compatibilitytools.d"
       - name: Test steamrt update
         run: |
+          uv venv --python 3.11
+          source .venv/bin/activate
           sh tests/test_update.sh
           rm -rf "$HOME/.local/share/umu" "$HOME/Games/umu" "$HOME/.local/share/Steam/compatibilitytools.d"
       - name: Test winetricks
         run: |
+          uv venv --python 3.11
+          source .venv/bin/activate
           sh tests/test_winetricks.sh
           rm -rf "$HOME/.local/share/umu" "$HOME/.local/share/Steam/compatibilitytools.d"
       - name: Test configuration file

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -2,9 +2,9 @@ name: e2e
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
 
 permissions:
   contents: read
@@ -14,37 +14,41 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
-    - name: Install dependencies
-      run: |
-        sudo apt-get install meson scdoc python3-hatchling python3-build python3-installer python3-filelock shellcheck
-        python3 -m pip install --upgrade pip
-        pip install uv
-    - name: Initialize submodules
-      run: |
-        git submodule update --init --recursive
-    - name: Make user install
-      run: |
-        ./configure.sh --user-install
-        make install
-    - name: Run shellcheck
-      run: |
-        shellcheck tests/*.sh
-    - name: Test steamrt install
-      run: |
-        sh tests/test_install.sh
-        rm -rf "$HOME/.local/share/umu" "$HOME/Games/umu" "$HOME/.local/share/Steam/compatibilitytools.d"
-    - name: Test steamrt update
-      run: |
-        sh tests/test_update.sh
-        rm -rf "$HOME/.local/share/umu" "$HOME/Games/umu" "$HOME/.local/share/Steam/compatibilitytools.d"
-    - name: Test winetricks
-      run: |
-        sh tests/test_winetricks.sh
-        rm -rf "$HOME/.local/share/umu" "$HOME/.local/share/Steam/compatibilitytools.d"
-    - name: Test configuration file
-      run: |
-        uv python install 3.11
-        uv run --python 3.11 -- sh tests/test_config.sh
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install dependencies
+        run: |
+          sudo apt-get install meson scdoc python3-hatchling python3-build python3-installer python3-filelock shellcheck
+          python3 -m pip install --upgrade pip
+          pip install uv
+      - name: Initialize submodules
+        run: |
+          git submodule update --init --recursive
+      - name: Make user install
+        run: |
+          ./configure.sh --user-install
+          make install
+      - name: Setup venv
+        run: |
+          uv venv --python 3.11
+          source .venv/bin/activate
+      - name: Run shellcheck
+        run: |
+          shellcheck tests/*.sh
+      - name: Test steamrt install
+        run: |
+          sh tests/test_install.sh
+          rm -rf "$HOME/.local/share/umu" "$HOME/Games/umu" "$HOME/.local/share/Steam/compatibilitytools.d"
+      - name: Test steamrt update
+        run: |
+          sh tests/test_update.sh
+          rm -rf "$HOME/.local/share/umu" "$HOME/Games/umu" "$HOME/.local/share/Steam/compatibilitytools.d"
+      - name: Test winetricks
+        run: |
+          sh tests/test_winetricks.sh
+          rm -rf "$HOME/.local/share/umu" "$HOME/.local/share/Steam/compatibilitytools.d"
+      - name: Test configuration file
+        run: |
+          uv python install 3.11
+          uv run --python 3.11 -- sh tests/test_config.sh

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -32,25 +32,25 @@ jobs:
       - name: Run shellcheck
         run: |
           shellcheck tests/*.sh
-      - name: Test steamrt install
+      - name: Setup venv
         run: |
           uv venv --python 3.11
+      - name: Test steamrt install
+        run: |
           source .venv/bin/activate
           sh tests/test_install.sh
           rm -rf "$HOME/.local/share/umu" "$HOME/Games/umu" "$HOME/.local/share/Steam/compatibilitytools.d"
       - name: Test steamrt update
         run: |
-          uv venv --python 3.11
           source .venv/bin/activate
           sh tests/test_update.sh
           rm -rf "$HOME/.local/share/umu" "$HOME/Games/umu" "$HOME/.local/share/Steam/compatibilitytools.d"
       - name: Test winetricks
         run: |
-          uv venv --python 3.11
           source .venv/bin/activate
           sh tests/test_winetricks.sh
           rm -rf "$HOME/.local/share/umu" "$HOME/.local/share/Steam/compatibilitytools.d"
       - name: Test configuration file
         run: |
-          uv python install 3.11
-          uv run --python 3.11 -- sh tests/test_config.sh
+          source .venv/bin/activate
+          sh tests/test_config.sh

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -25,7 +25,7 @@ jobs:
           python-version: ${{ matrix.version }}
       - name: Install dependencies
         run: |
-          python3 -m pip install --upgrade pip uv
+          python3 -m pip install --upgrade pip uv mypy
       - name: Setup venv
         run: |
           uv venv --python 3.11
@@ -34,5 +34,4 @@ jobs:
       - name: Check types with mypy
         run: |
           source .venv/bin/activate
-          pip install mypy
           mypy .

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -34,4 +34,4 @@ jobs:
       - name: Check types with mypy
         run: |
           source .venv/bin/activate
-          mypy .
+          mypy --python-version 3.11 .

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -2,9 +2,9 @@ name: mypy
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
 
 permissions:
   contents: read
@@ -13,20 +13,26 @@ jobs:
   build:
     strategy:
       matrix:
-        version: ["3.10"]
+        version: ["3.11"]
 
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.version }}
-    - name: Install dependencies
-      run: |
-        python3 -m pip install --upgrade pip
-    - name: Check types with mypy
-      run: |
-        pip install mypy
-        mypy .
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.version }}
+      - name: Install dependencies
+        run: |
+          python3 -m pip install --upgrade pip uv
+      - name: Setup venv
+        run: |
+          uv venv --python 3.11
+          source .venv/bin/activate
+          uv pip install -r requirements.in
+      - name: Check types with mypy
+        run: |
+          source .venv/bin/activate
+          pip install mypy
+          mypy .

--- a/.github/workflows/umu-python.yml
+++ b/.github/workflows/umu-python.yml
@@ -32,17 +32,21 @@ jobs:
           pip install python-xlib
           pip install filelock
           pip install uv
+      - name: Lint umu_*.py files with Ruff
+        run: |
+          pip install ruff
+          ruff check --output-format github ./umu/umu_*.py
       - name: Setup venv
         run: |
           uv venv --python 3.11
           source .venv/bin/activate
           uv pip install -r requirements.in
-      - name: Lint umu_*.py files with Ruff
-        run: |
-          pip install ruff
-          ruff check --output-format github ./umu/umu_*.py
       - name: Test with unittest
-        run: python3 ./umu/umu_test.py
+        run: |
+          source .venv/bin/activate
+          python3 ./umu/umu_test.py
       - name: Test with unittest for plugins
         if: ${{ matrix.version == '3.11' || matrix.version == '3.12' || matrix.version == '3.13' }}
-        run: python3 ./umu/umu_test_plugins.py
+        run: |
+          source .venv/bin/activate
+          python3 ./umu/umu_test_plugins.py

--- a/.github/workflows/umu-python.yml
+++ b/.github/workflows/umu-python.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Setup venv
         run: |
           uv venv --python 3.11
-          source .venv/bin/activate.fish
+          source .venv/bin/activate.sh
           uv pip install -r requirements.in
       - name: Lint umu_*.py files with Ruff
         run: |

--- a/.github/workflows/umu-python.yml
+++ b/.github/workflows/umu-python.yml
@@ -35,6 +35,7 @@ jobs:
       - name: Setup venv
         run: |
           uv venv --python 3.11
+          source .venv/bin/activate.fish
           uv pip install -r requirements.in
       - name: Lint umu_*.py files with Ruff
         run: |

--- a/.github/workflows/umu-python.yml
+++ b/.github/workflows/umu-python.yml
@@ -38,9 +38,11 @@ jobs:
           ruff check --output-format github ./umu/umu_*.py
       - name: Setup venv
         run: |
-          uv venv --python 3.11
+          uv venv --python $pyver
           source .venv/bin/activate
           uv pip install -r requirements.in
+        env:
+          pyver: ${{ matrix.version }}
       - name: Test with unittest
         run: |
           source .venv/bin/activate

--- a/.github/workflows/umu-python.yml
+++ b/.github/workflows/umu-python.yml
@@ -2,9 +2,9 @@ name: umu-launcher
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
 
 permissions:
   contents: read
@@ -20,23 +20,28 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.version }}
-    - name: Install dependencies
-      run: |
-        python3 -m pip install --upgrade pip
-        pip install ruff
-        pip install python-xlib
-        pip install filelock
-    - name: Lint umu_*.py files with Ruff
-      run: |
-        pip install ruff
-        ruff check --output-format github ./umu/umu_*.py
-    - name: Test with unittest
-      run: python3 ./umu/umu_test.py
-    - name: Test with unittest for plugins
-      if: ${{ matrix.version == '3.11' || matrix.version == '3.12' || matrix.version == '3.13' }}
-      run: python3 ./umu/umu_test_plugins.py
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.version }}
+      - name: Install dependencies
+        run: |
+          python3 -m pip install --upgrade pip
+          pip install ruff
+          pip install python-xlib
+          pip install filelock
+          pip install uv
+      - name: Setup venv
+        run: |
+          uv venv --python 3.11
+          uv pip install -r requirements.in
+      - name: Lint umu_*.py files with Ruff
+        run: |
+          pip install ruff
+          ruff check --output-format github ./umu/umu_*.py
+      - name: Test with unittest
+        run: python3 ./umu/umu_test.py
+      - name: Test with unittest for plugins
+        if: ${{ matrix.version == '3.11' || matrix.version == '3.12' || matrix.version == '3.13' }}
+        run: python3 ./umu/umu_test_plugins.py

--- a/.github/workflows/umu-python.yml
+++ b/.github/workflows/umu-python.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         # tomllib requires Python 3.11
         # Ubuntu latest (Jammy) provides Python 3.10
-        version: ["3.10", "3.11", "3.12", "3.13"]
+        version: ["3.11", "3.12", "3.13"]
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/umu-python.yml
+++ b/.github/workflows/umu-python.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Setup venv
         run: |
           uv venv --python 3.11
-          source .venv/bin/activate.sh
+          source .venv/bin/activate
           uv pip install -r requirements.in
       - name: Lint umu_*.py files with Ruff
         run: |

--- a/Makefile.in
+++ b/Makefile.in
@@ -101,7 +101,7 @@ umu-launcher-install: umu-launcher-dist-install umu-launcher-bin-install
 
 $(OBJDIR)/.build-umu-vendored: | $(OBJDIR)
 	$(info :: Building vendored dependencies )
-	pip3 install urllib3 -t $(OBJDIR)
+    python3 -m pip install urllib3 -t $(OBJDIR)
 
 .PHONY: umu-vendored
 umu-vendored: $(OBJDIR)/.build-umu-vendored

--- a/Makefile.in
+++ b/Makefile.in
@@ -21,7 +21,7 @@ FLATPAK ?= xfalse
 
 .PHONY: all
 ifeq ($(FLATPAK), xtrue)
-all: umu-dist umu-launcher
+all: umu-dist umu-launcher umu-vendored
 endif
 
 .PHONY: install
@@ -30,8 +30,8 @@ SOURCE_DATE_EPOCH = $(shell LC_ALL=C date --date='@1580601600')
 all: zipapp
 install: zipapp-install
 else
-all: umu-dist umu-docs umu-launcher
-install: umu-install umu-launcher-install
+all: umu-dist umu-docs umu-launcher umu-vendored
+install: umu-install umu-launcher-install umu-vendored-install
 endif
 
 
@@ -99,20 +99,17 @@ umu-launcher-dist-install:
 umu-launcher-install: umu-launcher-dist-install umu-launcher-bin-install
 
 
-$(OBJDIR)/.build-umu-subprojects: | $(OBJDIR)
-	$(info :: Building subprojects )
-	pip3 install -r requirements.in -t $(OBJDIR)
+$(OBJDIR)/.build-umu-vendored: | $(OBJDIR)
+	$(info :: Building vendored dependencies )
+	pip3 install urllib3 -t $(OBJDIR)
 
-.PHONY: umu-subprojects
-umu-subprojects: $(OBJDIR)/.build-umu-subprojects
+.PHONY: umu-vendored
+umu-vendored: $(OBJDIR)/.build-umu-vendored
 
-umu-subprojects-install:
+umu-vendored-install: umu-vendored
 	$(info :: Installing subprojects )
-	install -d $(DESTDIR)$(PYTHONDIR)
-	cp      -r $(OBJDIR)/*-info     $(DESTDIR)$(PYTHONDIR)
-	cp      -r $(OBJDIR)/Xlib       $(DESTDIR)$(PYTHONDIR)
-	cp      -r $(OBJDIR)/filelock   $(DESTDIR)$(PYTHONDIR)
-	cp         $(OBJDIR)/six.py     $(DESTDIR)$(PYTHONDIR)
+	install -d $(DESTDIR)$(PYTHONDIR)/umu/_vendor
+	cp      -r $(OBJDIR)/urllib3 $(DESTDIR)$(PYTHONDIR)/umu/_vendor
 
 $(OBJDIR):
 	@mkdir -p $(@)
@@ -153,7 +150,7 @@ ZIPAPP_VENV := $(OBJDIR)/zipapp_venv
 $(OBJDIR)/.build-zipapp: | $(OBJDIR)
 	$(info :: Building umu-launcher as zipapp )
 	$(PYTHON_INTERPRETER) -m venv $(ZIPAPP_VENV)
-	. $(ZIPAPP_VENV)/bin/activate && python3 -m pip install -t "$(ZIPAPP_STAGING)" -U --no-compile .
+	. $(ZIPAPP_VENV)/bin/activate && python3 -m pip install -t "$(ZIPAPP_STAGING)" -U --no-compile . truststore
 	cp umu/__main__.py "$(ZIPAPP_STAGING)"
 	find "$(ZIPAPP_STAGING)" -exec touch -h -d "$(SOURCE_DATE_EPOCH)" {} +
 	. $(ZIPAPP_VENV)/bin/activate && python3 -m zipapp $(ZIPAPP_STAGING) -o $(ZIPAPP) -p "$(PYTHON_INTERPRETER)" -c

--- a/Makefile.in
+++ b/Makefile.in
@@ -101,7 +101,7 @@ umu-launcher-install: umu-launcher-dist-install umu-launcher-bin-install
 
 $(OBJDIR)/.build-umu-vendored: | $(OBJDIR)
 	$(info :: Building vendored dependencies )
-    python3 -m pip install urllib3 -t $(OBJDIR)
+	python3 -m pip install urllib3 -t $(OBJDIR)
 
 .PHONY: umu-vendored
 umu-vendored: $(OBJDIR)/.build-umu-vendored

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Borderlands 3 from EGS store.
 
 ## Building
 
-Building umu-launcher currently requires `bash`, `make`, and `scdoc` for distribution, as well as the following Python build tools: [build](https://github.com/pypa/build), [hatchling](https://github.com/pypa/hatch), and [installer](https://github.com/pypa/installer).
+Building umu-launcher currently requires `bash`, `make`, and `scdoc` for distribution, as well as the following Python build tools: [build](https://github.com/pypa/build), [hatchling](https://github.com/pypa/hatch), [installer](https://github.com/pypa/installer), and [pip](https://github.com/pypa/pip).
 
 To build umu-launcher, after downloading and extracting the source code from this repository, change into the newly extracted directory
 ```shell
@@ -95,7 +95,7 @@ Change the `--prefix` as fit for your distribution, for example `/usr/local`, or
 Then run `make` to build. After a successful build the resulting files should be available in the `./builddir` directory
 
 
-## Installing 
+## Installing
 
 To install umu-launcher run the following command after completing the steps described above
 ```shell

--- a/packaging/deb/debian/control
+++ b/packaging/deb/debian/control
@@ -13,6 +13,7 @@ Build-Depends:
  python3-hatchling,
  python3-installer,
  python3-build,
+ python3-pip,
 Standards-Version: 4.6.2
 Homepage: https://github.com/Open-Wine-Components/umu-launcher
 Vcs-Browser: https://github.com/Open-Wine-Components/umu-launcher

--- a/packaging/deb/ubuntu/control
+++ b/packaging/deb/ubuntu/control
@@ -13,6 +13,7 @@ Build-Depends:
  python3-hatchling,
  python3-installer,
  python3-build,
+ python3-pip,
 Standards-Version: 4.6.2
 Homepage: https://github.com/Open-Wine-Components/umu-launcher
 Vcs-Browser: https://github.com/Open-Wine-Components/umu-launcher

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,12 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 urls = { repository = "https://github.com/Open-Wine-Components/umu-launcher" }
-dependencies = ["python-xlib>=0.33", "filelock>=3.9.0"]
+dependencies = ["python-xlib>=0.33", "filelock>=3.9.0", "urllib3>=2.0.0,<3.0.0"]
+
+[project.optional-dependencies]
+# Recommended
+# Use the system's CA bundle instead of certifi's
+cli = ["truststore"]
 
 [project.scripts]
 umu-run = "umu.__main__:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = ["python-xlib>=0.33", "filelock>=3.9.0", "urllib3>=2.0.0,<3.0.0"]
 
 [project.optional-dependencies]
 # Recommended
-# Use the system's CA bundle instead of certifi's
+# For network requests, use the system's CA bundle instead of certifi's
 cli = ["truststore"]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,8 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 urls = { repository = "https://github.com/Open-Wine-Components/umu-launcher" }
+# Note: urllib3 is a vendored dependency. When using our Makefile, it will be
+# installed automatically.
 dependencies = ["python-xlib>=0.33", "filelock>=3.9.0", "urllib3>=2.0.0,<3.0.0"]
 
 [project.optional-dependencies]

--- a/requirements.in
+++ b/requirements.in
@@ -1,2 +1,3 @@
 python-xlib>=0.33
-filelock>=3.15.4 
+filelock>=3.15.4
+urllib3>=2.0.0,<3.0.0

--- a/umu/__main__.py
+++ b/umu/__main__.py
@@ -1,5 +1,13 @@
 import os
 import sys
+from zipfile import is_zipfile
+
+if not is_zipfile(os.path.dirname(__file__)):  # noqa: PTH120
+    sys.path = [
+        f"{os.path.dirname(os.path.realpath(__file__, strict=True))}/_vendor",  # noqa: PTH120
+        *sys.path,
+    ]
+
 from argparse import ArgumentParser, Namespace, RawTextHelpFormatter
 
 from umu import __version__

--- a/umu/__main__.py
+++ b/umu/__main__.py
@@ -3,10 +3,10 @@ import sys
 from zipfile import is_zipfile
 
 if not is_zipfile(os.path.dirname(__file__)):  # noqa: PTH120
-    sys.path = [
+    sys.path.insert(
+        0,
         f"{os.path.dirname(os.path.realpath(__file__, strict=True))}/_vendor",  # noqa: PTH120
-        *sys.path,
-    ]
+    )
 
 from argparse import ArgumentParser, Namespace, RawTextHelpFormatter
 

--- a/umu/umu_proton.py
+++ b/umu/umu_proton.py
@@ -241,7 +241,12 @@ def _fetch_proton(
 
         log.debug("Digest: %s", digest)
         if hashsum.hexdigest() != digest:
-            err: str = f"Digest mismatched: {tarball}"
+            parts.unlink(missing_ok=True)
+            err: str = (
+                f"Digest mismatched: {tarball}\n"
+                "Possible reason: cached file corrupted or failed to acquire upstream digest\n"
+                f"Link: {tar_url}"
+            )
             raise ValueError(err)
 
         log.info("%s: SHA512 is OK", tarball)

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -861,7 +861,14 @@ def umu_run(args: Namespace | tuple[str, list[str]]) -> int:
 
         try:
             future.result()
-        except (MaxRetryError, NewConnectionError, TimeoutErrorUrllib3):
+        except (
+            # Network errors
+            MaxRetryError,
+            NewConnectionError,
+            TimeoutErrorUrllib3,
+            # Digest mismatched for runtime
+            ValueError,
+        ):
             if not has_umu_setup():
                 err: str = (
                     "umu has not been setup for the user\n"

--- a/umu/umu_runtime.py
+++ b/umu/umu_runtime.py
@@ -199,6 +199,10 @@ def _install_umu(
         log.debug("Digest: %s", digest)
         if hashsum.hexdigest() != digest:
             err: str = f"Digest mismatched: {archive}"
+            # Remove our cached file because it had probably got corrupted
+            # somehow since the last launch. Abort the update then continue
+            # to launch using existing runtime
+            cached_parts.unlink(missing_ok=True)
             raise ValueError(err)
 
         log.info("%s: SHA256 is OK", archive)

--- a/umu/umu_runtime.py
+++ b/umu/umu_runtime.py
@@ -198,11 +198,14 @@ def _install_umu(
 
         log.debug("Digest: %s", digest)
         if hashsum.hexdigest() != digest:
-            err: str = f"Digest mismatched: {archive}"
             # Remove our cached file because it had probably got corrupted
             # somehow since the last launch. Abort the update then continue
             # to launch using existing runtime
             cached_parts.unlink(missing_ok=True)
+            err: str = (
+                f"Digest mismatched: {archive}\n"
+                "Possible reason: cached file corrupted or failed to acquire upstream digest"
+            )
             raise ValueError(err)
 
         log.info("%s: SHA256 is OK", archive)

--- a/umu/umu_runtime.py
+++ b/umu/umu_runtime.py
@@ -153,7 +153,7 @@ def _install_umu(
 
         # Resume from our cached file, if we were interrupted previously
         if cached_parts.is_file():
-            log.info("Found '%s' in cache, resuming...", cached_parts)
+            log.info("Found '%s' in cache, resuming...", cached_parts.name)
             headers = {"Range": f"bytes={cached_parts.stat().st_size}-"}
             parts = cached_parts
             # Rebuild our hashed progress

--- a/umu/umu_runtime.py
+++ b/umu/umu_runtime.py
@@ -517,7 +517,8 @@ def _restore_umu_platformid(
         )
         return None
 
-    return resp.data.decode(encoding="utf-8")
+    # False positive from mypy.
+    return resp.data.decode(encoding="utf-8")  # type: ignore
 
 
 def _update_umu_platform(

--- a/umu/umu_runtime.py
+++ b/umu/umu_runtime.py
@@ -204,7 +204,8 @@ def _install_umu(
             cached_parts.unlink(missing_ok=True)
             err: str = (
                 f"Digest mismatched: {archive}\n"
-                "Possible reason: cached file corrupted or failed to acquire upstream digest"
+                "Possible reason: cached file corrupted or failed to acquire upstream digest\n"
+                f"Link: {host}{endpoint}/{archive}"
             )
             raise ValueError(err)
 

--- a/umu/umu_runtime.py
+++ b/umu/umu_runtime.py
@@ -1,42 +1,42 @@
 import os
-import sys
 from collections.abc import Callable
 from concurrent.futures import Future, ThreadPoolExecutor
-from hashlib import sha256
-from http.client import HTTPException, HTTPResponse, HTTPSConnection
+from hashlib import file_digest, sha256
 
 try:
     from importlib.resources.abc import Traversable
 except ModuleNotFoundError:
     from importlib.abc import Traversable
 
-from http import HTTPStatus
+from http import HTTPMethod, HTTPStatus
 from pathlib import Path
 from secrets import token_urlsafe
 from shutil import move, rmtree
 from subprocess import run
-from tarfile import open as taropen
 from tempfile import TemporaryDirectory, mkdtemp
 
 from filelock import FileLock
+from urllib3.exceptions import HTTPError
+from urllib3.exceptions import TimeoutError as TimeoutErrorUrllib3
+from urllib3.poolmanager import PoolManager
+from urllib3.response import BaseHTTPResponse
 
 from umu.umu_consts import UMU_CACHE, UMU_LOCAL
 from umu.umu_log import log
-from umu.umu_util import https_connection, run_zenity
-
-try:
-    from tarfile import tar_filter
-
-    has_data_filter: bool = True
-except ImportError:
-    has_data_filter: bool = False
-
+from umu.umu_util import (
+    extract_tarfile,
+    has_umu_setup,
+    run_zenity,
+    write_file_chunks,
+)
 
 Codename = str
 
 Variant = str
 
 RuntimeVersion = tuple[Codename, Variant]
+
+SessionPools = tuple[ThreadPoolExecutor, PoolManager]
 
 
 def create_shim(file_path: Path | None = None):
@@ -87,13 +87,12 @@ def create_shim(file_path: Path | None = None):
 
 def _install_umu(
     runtime_ver: RuntimeVersion,
-    thread_pool: ThreadPoolExecutor,
-    client_session: HTTPSConnection,
+    session_pools: SessionPools,
 ) -> None:
-    resp: HTTPResponse
+    resp: BaseHTTPResponse
     tmp: Path = Path(mkdtemp())
     ret: int = 0  # Exit code from zenity
-    # Codename for the runtime (e.g., 'sniper')
+    thread_pool, http_pool = session_pools
     codename, variant = runtime_ver
     # Archive containing the runtime
     archive: str = f"SteamLinuxRuntime_{codename}.tar.xz"
@@ -102,7 +101,11 @@ def _install_umu(
         "/snapshots/latest-container-runtime-public-beta"
     )
     token: str = f"?versions={token_urlsafe(16)}"
-    log.debug("URL: %s", base_url)
+    host: str = "repo.steampowered.com"
+    parts: Path = tmp.joinpath(f"{archive}.parts")
+    log.debug("Using endpoint '%s' for requests", base_url)
+
+    UMU_CACHE.mkdir(parents=True, exist_ok=True)
 
     # Download the runtime and optionally create a popup with zenity
     if os.environ.get("UMU_ZENITY") == "1":
@@ -130,107 +133,119 @@ def _install_umu(
             "/snapshots/latest-container-runtime-public-beta"
         )
         hashsum = sha256()
+        headers: dict[str, str] | None = None
+        cached_parts: Path = UMU_CACHE.joinpath(parts.name)
 
         # Get the digest for the runtime archive
-        client_session.request("GET", f"{endpoint}/SHA256SUMS{token}")
+        resp = http_pool.request(
+            HTTPMethod.GET, f"{host}{endpoint}/SHA256SUMS{token}"
+        )
+        if resp.status != HTTPStatus.OK:
+            err: str = (
+                f"{resp.getheader('Host')} returned the status: {resp.status}"
+            )
+            raise HTTPError(err)
 
-        with client_session.getresponse() as resp:
-            if resp.status != HTTPStatus.OK:
-                err: str = (
-                    f"repo.steampowered.com returned the status: {resp.status}"
-                )
-                raise HTTPException(err)
+        # Parse SHA256SUMS
+        for line in resp.data.decode(encoding="utf-8").splitlines():
+            if line.endswith(archive):
+                digest = line.split(" ")[0]
 
-            # Parse SHA256SUMS
-            for line in resp.read().decode("utf-8").splitlines():
-                if line.endswith(archive):
-                    digest = line.split(" ")[0]
-                    break
+        # Resume from our cached file, if we were interrupted previously
+        if cached_parts.is_file():
+            log.info("Found '%s' in cache, resuming...", cached_parts)
+            headers = {"Range": f"bytes={cached_parts.stat().st_size}-"}
+            parts = cached_parts
+            # Rebuild our hashed progress
+            with parts.open("rb") as fp:
+                hashsum = file_digest(fp, hashsum.name)
+        else:
+            log.info("Downloading %s (latest), please wait...", variant)
+
+        resp = http_pool.request(
+            HTTPMethod.GET,
+            f"{host}{endpoint}/{archive}{token}",
+            preload_content=False,
+            headers=headers,
+        )
+
+        # Bail out for unexpected status codes
+        if resp.status not in {
+            HTTPStatus.OK,
+            HTTPStatus.PARTIAL_CONTENT,
+            HTTPStatus.REQUESTED_RANGE_NOT_SATISFIABLE,
+        }:
+            err: str = (
+                f"{resp.getheader('Host')} returned the status: {resp.status}"
+            )
+            raise HTTPError(err)
 
         # Download the runtime
-        log.info("Downloading %s (latest), please wait...", variant)
-        client_session.request("GET", f"{endpoint}/{archive}{token}")
-
-        with (
-            client_session.getresponse() as resp,
-            tmp.joinpath(archive).open(mode="ab+", buffering=0) as file,
-        ):
-            if resp.status != HTTPStatus.OK:
-                err: str = (
-                    f"repo.steampowered.com returned the status: {resp.status}"
+        if resp.status != HTTPStatus.REQUESTED_RANGE_NOT_SATISFIABLE:
+            try:
+                log.debug("Writing: %s", parts)
+                hashsum = write_file_chunks(parts, resp, hashsum)
+            except TimeoutErrorUrllib3:
+                log.error("Aborting steamrt install due to network error")
+                log.info(
+                    "Moving '%s' to cache for future resumption", parts.name
                 )
-                raise HTTPException(err)
+                move(parts, UMU_CACHE)
+                raise
 
-            chunk_size: int = 64 * 1024  # 64 KB
-            buffer: bytearray = bytearray(chunk_size)
-            view: memoryview = memoryview(buffer)
-            while size := resp.readinto(buffer):
-                file.write(view[:size])
-                hashsum.update(view[:size])
+        # Release conn to the pool
+        resp.release_conn()
 
-            # Verify the runtime digest
-            if hashsum.hexdigest() != digest:
-                err: str = f"Digest mismatched: {archive}"
-                raise ValueError(err)
+        log.debug("Digest: %s", digest)
+        if hashsum.hexdigest() != digest:
+            err: str = f"Digest mismatched: {archive}"
+            raise ValueError(err)
 
         log.info("%s: SHA256 is OK", archive)
 
-    # Open the tar file and move the files
-    log.debug("Opening: %s", tmp.joinpath(archive))
+        # Remove the .parts suffix
+        move(parts, parts.with_suffix(""))
+        parts = parts.with_suffix("")
 
-    UMU_CACHE.mkdir(parents=True, exist_ok=True)
+    # Open the tar file and move the files
+    log.debug("Opening: %s", parts)
 
     with TemporaryDirectory(dir=UMU_CACHE) as tmpcache:
+        futures: list[Future] = []
+        var: Path = UMU_LOCAL.joinpath("var")
         log.debug("Created: %s", tmpcache)
         log.debug("Moving: %s -> %s", tmp.joinpath(archive), tmpcache)
-        move(tmp.joinpath(archive), tmpcache)
+        move(parts, tmpcache)
 
-        with (
-            taropen(f"{tmpcache}/{archive}", "r:xz") as tar,
-        ):
-            futures: list[Future] = []
+        # Ensure the target directory exists
+        UMU_LOCAL.mkdir(parents=True, exist_ok=True)
+        log.debug("Extracting: %s -> %s", f"{tmpcache}/{archive}", tmpcache)
+        extract_tarfile(Path(tmpcache, archive), Path(tmpcache))
 
-            if has_data_filter:
-                log.debug("Using filter for archive")
-                tar.extraction_filter = tar_filter
-            else:
-                log.warning("Python: %s", sys.version)
-                log.warning("Using no data filter for archive")
-                log.warning("Archive will be extracted insecurely")
+        # Move the files to the correct location
+        source_dir: Path = Path(tmpcache, f"SteamLinuxRuntime_{codename}")
+        var: Path = UMU_LOCAL.joinpath("var")
+        log.debug("Source: %s", source_dir)
+        log.debug("Destination: %s", UMU_LOCAL)
 
-            # Ensure the target directory exists
-            UMU_LOCAL.mkdir(parents=True, exist_ok=True)
+        # Move each file to the dest dir, overwriting if exists
+        futures.extend(
+            [
+                thread_pool.submit(_move, file, source_dir, UMU_LOCAL)
+                for file in source_dir.glob("*")
+            ]
+        )
 
-            # Extract the entirety of the archive w/ or w/o the data filter
-            log.debug(
-                "Extracting: %s -> %s", f"{tmpcache}/{archive}", tmpcache
-            )
-            tar.extractall(path=tmpcache)  # noqa: S202
+        if var.is_dir():
+            log.debug("Removing: %s", var)
+            # Remove the variable directory to avoid Steam Linux Runtime
+            # related errors when creating it. Supposedly, it only happens
+            # when going from umu-launcher 0.1-RC4 -> 1.1.1+
+            # See https://github.com/Open-Wine-Components/umu-launcher/issues/213#issue-2576708738
+            thread_pool.submit(rmtree, str(var))
 
-            # Move the files to the correct location
-            source_dir: Path = Path(tmpcache, f"SteamLinuxRuntime_{codename}")
-            var: Path = UMU_LOCAL.joinpath("var")
-            log.debug("Source: %s", source_dir)
-            log.debug("Destination: %s", UMU_LOCAL)
-
-            # Move each file to the dest dir, overwriting if exists
-            futures.extend(
-                [
-                    thread_pool.submit(_move, file, source_dir, UMU_LOCAL)
-                    for file in source_dir.glob("*")
-                ]
-            )
-
-            if var.is_dir():
-                log.debug("Removing: %s", var)
-                # Remove the variable directory to avoid Steam Linux Runtime
-                # related errors when creating it. Supposedly, it only happens
-                # when going from umu-launcher 0.1-RC4 -> 1.1.1+
-                # See https://github.com/Open-Wine-Components/umu-launcher/issues/213#issue-2576708738
-                thread_pool.submit(rmtree, str(var))
-
-            for future in futures:
-                future.result()
+        for future in futures:
+            future.result()
 
     # Rename _v2-entry-point
     log.debug("Renaming: _v2-entry-point -> umu")
@@ -246,25 +261,23 @@ def setup_umu(
     root: Traversable,
     local: Path,
     runtime_ver: RuntimeVersion,
-    thread_pool: ThreadPoolExecutor,
+    session_pools: SessionPools,
 ) -> None:
     """Install or update the runtime for the current user."""
     log.debug("Root: %s", root)
     log.debug("Local: %s", local)
-    host: str = "repo.steampowered.com"
 
     # New install or umu dir is empty
-    if not local.exists() or not any(local.iterdir()):
+    if not has_umu_setup(local):
         log.debug("New install detected")
         log.info("Setting up Unified Launcher for Windows Games on Linux...")
         local.mkdir(parents=True, exist_ok=True)
-        with https_connection(host) as client_session:
-            _restore_umu(
-                runtime_ver,
-                thread_pool,
-                lambda: local.joinpath("umu").is_file(),
-                client_session,
-            )
+        _restore_umu(
+            local,
+            runtime_ver,
+            session_pools,
+            lambda: local.joinpath("umu").is_file(),
+        )
         log.info("Using %s (latest)", runtime_ver[1])
         return
 
@@ -272,15 +285,13 @@ def setup_umu(
         log.info("%s updates disabled, skipping", runtime_ver[1])
         return
 
-    with https_connection(host) as client_session:
-        _update_umu(local, runtime_ver, thread_pool, client_session)
+    _update_umu(local, runtime_ver, session_pools)
 
 
 def _update_umu(
     local: Path,
     runtime_ver: RuntimeVersion,
-    thread_pool: ThreadPoolExecutor,
-    client_session: HTTPSConnection,
+    session_pools: SessionPools,
 ) -> None:
     """For existing installations, check for updates to the runtime.
 
@@ -288,20 +299,21 @@ def _update_umu(
     the local VERSIONS.txt against the remote one.
     """
     runtime: Path
-    resp: HTTPResponse
+    resp: BaseHTTPResponse
+    _, http_pool = session_pools
     codename, variant = runtime_ver
     endpoint: str = (
         f"/steamrt-images-{codename}"
         "/snapshots/latest-container-runtime-public-beta"
     )
+    # Create a token and append it to the URL to avoid the Cloudflare cache
+    # Avoids infinite updates to the runtime each launch
+    # See https://github.com/Open-Wine-Components/umu-launcher/issues/188
     token: str = f"?version={token_urlsafe(16)}"
+    host: str = "repo.steampowered.com"
     log.debug("Existing install detected")
     log.debug("Using container runtime '%s' aka '%s'", variant, codename)
-    log.debug(
-        "Checking updates for '%s', requesting '%s'...",
-        variant,
-        client_session.host,
-    )
+    log.debug("Checking updates for '%s'...", variant)
 
     # Find the runtime directory (e.g., sniper_platform_0.20240530.90143)
     # Assume the directory begins with the variant
@@ -310,27 +322,28 @@ def _update_umu(
             file for file in local.glob(f"{codename}*") if file.is_dir()
         )
     except ValueError:
-        log.warning("*_platform_* directory missing in '%s'", local)
+        log.critical("*_platform_* directory missing in '%s'", local)
         log.info("Restoring Runtime Platform...")
         _restore_umu(
+            local,
             runtime_ver,
-            thread_pool,
+            session_pools,
             lambda: len(
                 [file for file in local.glob(f"{codename}*") if file.is_dir()]
             )
             > 0,
-            client_session,
         )
         return
 
+    # Restore the runtime when pressure-vessel is missing
     if not local.joinpath("pressure-vessel").is_dir():
-        log.warning("pressure-vessel directory missing in '%s'", local)
+        log.critical("pressure-vessel directory missing in '%s'", local)
         log.info("Restoring Runtime Platform...")
         _restore_umu(
+            local,
             runtime_ver,
-            thread_pool,
+            session_pools,
             lambda: local.joinpath("pressure-vessel").is_dir(),
-            client_session,
         )
         return
 
@@ -338,115 +351,36 @@ def _update_umu(
     # When the file is missing, the request for the image will need to be made
     # to the endpoint of the specific snapshot
     if not local.joinpath("VERSIONS.txt").is_file():
-        url: str
-        release: Path = runtime.joinpath("files", "lib", "os-release")
-        versions: str = f"SteamLinuxRuntime_{codename}.VERSIONS.txt"
-
-        log.warning("VERSIONS.txt file missing in '%s'", local)
-
-        # Restore the runtime if os-release is missing, otherwise pressure
-        # vessel will crash when creating the variable directory
-        if not release.is_file():
-            log.warning("os-release file missing in *_platform_*")
-            log.warning("Runtime Platform corrupt")
-            log.info("Restoring Runtime Platform...")
+        log.critical("VERSIONS.txt file missing in '%s'", local)
+        platformid: str | None = _restore_umu_platformid(
+            runtime, runtime_ver, session_pools
+        )
+        if platformid is None:
             _restore_umu(
+                local,
                 runtime_ver,
-                thread_pool,
+                session_pools,
                 lambda: local.joinpath("VERSIONS.txt").is_file(),
-                client_session,
             )
             return
+        local.joinpath("VERSIONS.txt").write_text(platformid)
 
-        # Get the BUILD_ID value in os-release
-        with release.open(mode="r", encoding="utf-8") as file:
-            for line in file:
-                if line.startswith("BUILD_ID"):
-                    # Get the value after 'BUILD_ID=' and strip the quotes
-                    build_id: str = (
-                        line.removeprefix("BUILD_ID=").rstrip().strip('"')
-                    )
-                    url = (
-                        f"/steamrt-images-{codename}" f"/snapshots/{build_id}"
-                    )
-                    break
+    # Fetch the version file
+    url: str = (
+        f"{host}{endpoint}/SteamLinuxRuntime_{codename}.VERSIONS.txt{token}"
+    )
+    log.debug("Sending request to '%s' for 'VERSIONS.txt'...", url)
+    resp = http_pool.request(HTTPMethod.GET, url)
+    if resp.status != HTTPStatus.OK:
+        log.error(
+            "%s returned the status: %s", resp.getheader("Host"), resp.status
+        )
+        return
 
-        client_session.request("GET", f"{url}{token}")
+    # Update our runtime
+    _update_umu_platform(local, runtime, runtime_ver, session_pools, resp)
 
-        with client_session.getresponse() as resp:
-            # Handle the redirect
-            if resp.status == HTTPStatus.MOVED_PERMANENTLY:
-                location: str = resp.getheader("Location", "")
-                log.debug("Location: %s", resp.getheader("Location"))
-                # The stdlib requires reading the entire response body before
-                # making another request
-                resp.read()
-
-                # Make a request to the new location
-                client_session.request("GET", f"{location}/{versions}{token}")
-                with client_session.getresponse() as resp_redirect:
-                    if resp_redirect.status != HTTPStatus.OK:
-                        log.warning(
-                            "repo.steampowered.com returned the status: %s",
-                            resp_redirect.status,
-                        )
-                        return
-                    local.joinpath("VERSIONS.txt").write_text(
-                        resp.read().decode()
-                    )
-
-    # Update the runtime if necessary by comparing VERSIONS.txt to the remote.
-    # repo.steampowered currently sits behind a Cloudflare proxy, which may
-    # respond with cf-cache-status: HIT in the header for subsequent requests
-    # indicating the response was found in the cache and was returned. Valve
-    # has control over the CDN's cache control behavior, so we must not assume
-    # all of the cache will be purged after new files are uploaded. Therefore,
-    # always avoid the cache by appending a unique query to the URI to avoid
-    # redownloading the runtime each launch
-    # See https://github.com/Open-Wine-Components/umu-launcher/issues/188
-    url: str = f"{endpoint}/SteamLinuxRuntime_{codename}.VERSIONS.txt{token}"
-    client_session.request("GET", url)
-
-    # Attempt to compare the digests
-    with client_session.getresponse() as resp:
-        if resp.status != HTTPStatus.OK:
-            log.warning(
-                "repo.steampowered.com returned the status: %s", resp.status
-            )
-            return
-
-        steamrt_latest_digest: bytes = sha256(resp.read()).digest()
-        steamrt_local_digest: bytes = sha256(
-            local.joinpath("VERSIONS.txt").read_bytes()
-        ).digest()
-        steamrt_versions: Path = local.joinpath("VERSIONS.txt")
-
-        log.debug("Source: %s", url)
-        log.debug("Digest: %s", steamrt_latest_digest)
-        log.debug("Source: %s", steamrt_versions)
-        log.debug("Digest: %s", steamrt_local_digest)
-
-        if steamrt_latest_digest != steamrt_local_digest:
-            lock: FileLock = FileLock(f"{local}/umu.lock")
-            log.info("Updating %s to latest...", variant)
-            log.debug("Acquiring file lock '%s'...", lock.lock_file)
-
-            with lock:
-                log.debug("Acquired file lock '%s'", lock.lock_file)
-                # Once another process acquires the lock, check if the latest
-                # runtime has already been downloaded
-                if (
-                    steamrt_latest_digest
-                    == sha256(steamrt_versions.read_bytes()).digest()
-                ):
-                    log.debug("Released file lock '%s'", lock.lock_file)
-                    return
-                _install_umu(runtime_ver, thread_pool, client_session)
-                log.debug("Removing: %s", runtime)
-                rmtree(str(runtime))
-                log.debug("Released file lock '%s'", lock.lock_file)
-
-    # Restore shim
+    # Restore shim if missing
     if not local.joinpath("umu-shim").is_file():
         create_shim()
 
@@ -490,8 +424,8 @@ def check_runtime(src: Path, runtime_ver: RuntimeVersion) -> int:
             file for file in src.glob(f"{codename}*") if file.is_dir()
         )
     except ValueError:
-        log.warning("%s validation failed", variant)
-        log.warning("Could not find *_platform_* in '%s'", src)
+        log.critical("%s validation failed", variant)
+        log.critical("Could not find *_platform_* in '%s'", src)
         return ret
 
     if not pv_verify.is_file():
@@ -520,16 +454,99 @@ def check_runtime(src: Path, runtime_ver: RuntimeVersion) -> int:
 
 
 def _restore_umu(
+    local: Path,
     runtime_ver: RuntimeVersion,
-    thread_pool: ThreadPoolExecutor,
+    session_pools: SessionPools,
     callback_fn: Callable[[], bool],
-    client_session: HTTPSConnection,
 ) -> None:
-    with FileLock(f"{UMU_LOCAL}/umu.lock") as lock:
+    with FileLock(f"{local}/umu.lock") as lock:
         log.debug("Acquired file lock '%s'...", lock.lock_file)
         if callback_fn():
             log.debug("Released file lock '%s'", lock.lock_file)
             log.info("%s was restored", runtime_ver[1])
             return
-        _install_umu(runtime_ver, thread_pool, client_session)
+        _install_umu(runtime_ver, session_pools)
         log.debug("Released file lock '%s'", lock.lock_file)
+
+
+def _restore_umu_platformid(
+    runtime_base: Path,
+    runtime_ver: RuntimeVersion,
+    session_pools: SessionPools,
+) -> None | str:
+    url: str = ""
+    _, http_pool = session_pools
+    codename, _ = runtime_ver
+    release: Path = runtime_base.joinpath("files", "lib", "os-release")
+    versions: str = f"SteamLinuxRuntime_{codename}.VERSIONS.txt"
+    host: str = "repo.steampowered.com"
+
+    # Restore the runtime if os-release is missing, otherwise pressure
+    # vessel will crash when creating the variable directory
+    if not release.is_file():
+        log.critical("os-release file missing in *_platform_*")
+        log.critical("Runtime Platform corrupt")
+        log.info("Restoring Runtime Platform...")
+        return None
+
+    # Get the BUILD_ID value in os-release so we can get VERSIONS.txt
+    with release.open(mode="r", encoding="utf-8") as file:
+        for line in file:
+            if line.startswith("BUILD_ID"):
+                # Get the value after 'BUILD_ID=' and strip the quotes
+                build_id: str = (
+                    line.removeprefix("BUILD_ID=").rstrip().strip('"')
+                )
+                url = f"/steamrt-images-{codename}" f"/snapshots/{build_id}"
+                break
+
+    if not url:
+        log.critical("Failed to parse os-release for BUILD_ID in *_platform_*")
+        log.critical("Runtime Platform corrupt")
+        log.info("Restoring Runtime Platform...")
+        return None
+
+    # Make the request to the VERSIONS.txt endpoint. It's fine to hit the
+    # cache for this endpoint, as it differs to the latest-beta endpoint
+    resp = http_pool.request(HTTPMethod.GET, f"{host}{url}{versions}")
+    if resp.status != HTTPStatus.OK:
+        log.error(
+            "%s returned the status: %s",
+            resp.getheader("Host"),
+            resp.status,
+        )
+        return None
+
+    return resp.data.decode(encoding="utf-8")
+
+
+def _update_umu_platform(
+    local: Path,
+    runtime: Path,
+    runtime_ver: RuntimeVersion,
+    session_pools: SessionPools,
+    resp: BaseHTTPResponse,
+) -> None:
+    _, variant = runtime_ver
+    latest: bytes = sha256(resp.data).digest()
+    current: bytes = sha256(
+        local.joinpath("VERSIONS.txt").read_bytes()
+    ).digest()
+    versions: Path = local.joinpath("VERSIONS.txt")
+    lock: FileLock = FileLock(f"{local}/umu.lock")
+
+    # Compare our version file to upstream's, updating if different
+    if latest != current:
+        log.info("Updating %s to latest...", variant)
+        log.debug("Acquiring file lock '%s'...", lock.lock_file)
+        with lock:
+            log.debug("Acquired file lock '%s'", lock.lock_file)
+            # Once another process acquires the lock, check if the latest
+            # runtime has already been downloaded
+            if latest == sha256(versions.read_bytes()).digest():
+                log.debug("Released file lock '%s'", lock.lock_file)
+                return
+            _install_umu(runtime_ver, session_pools)
+            log.debug("Removing: %s", runtime)
+            rmtree(str(runtime))
+            log.debug("Released file lock '%s'", lock.lock_file)

--- a/umu/umu_test.py
+++ b/umu/umu_test.py
@@ -475,6 +475,32 @@ class TestGameLauncher(unittest.TestCase):
             )
             self.assertEqual(result, "foo", f"Expected foo, received {result}")
 
+    def test_write_file_chunks_none(self):
+        """Test write_file_chunks when not passing a chunk size."""
+        with NamedTemporaryFile() as file1, TemporaryFile("rb+") as file2:
+            chunk_size = 8
+            mock_file = Path(file1.name)
+            hasher = hashlib.blake2b()
+            file2.write(os.getrandom(chunk_size))
+            # Pass a buffered reader as our fake http response
+            umu_util.write_file_chunks(mock_file, file2, hasher)
+            self.assertTrue(
+                hasher.digest(), "Expected hashed data > 0, received 0"
+            )
+
+    def test_write_file_chunks(self):
+        """Test write_file_chunks."""
+        with NamedTemporaryFile() as file1, TemporaryFile("rb+") as file2:
+            chunk_size = 8
+            mock_file = Path(file1.name)
+            hasher = hashlib.blake2b()
+            file2.write(os.getrandom(chunk_size))
+            # Pass a buffered reader as our fake http response
+            umu_util.write_file_chunks(mock_file, file2, hasher, chunk_size)
+            self.assertTrue(
+                hasher.digest(), "Expected hashed data > 0, received 0"
+            )
+
     def test_get_gamescope_baselayer_appid_err(self):
         """Test get_gamescope_baselayer_appid on error.
 

--- a/umu/umu_test.py
+++ b/umu/umu_test.py
@@ -234,6 +234,74 @@ class TestGameLauncher(unittest.TestCase):
                 "Expected callback to be called",
             )
 
+    def test_setup_umu_update(self):
+        """Test setup_umu when updating the runtime."""
+        result = MagicMock()
+
+        # Mock a new install
+        with TemporaryDirectory() as file1, TemporaryDirectory() as file2:
+            # Populate our fake $XDG_DATA_HOME/umu
+            Path(file2, "umu").touch()
+            # Mock the runtime ver
+            mock_runtime_ver = ("sniper", "steamrt3")
+            # Mock our thread and conn pool
+            mock_session_pools = (MagicMock(), MagicMock())
+            with patch.object(umu_runtime, "_update_umu"):
+                result = umu_runtime.setup_umu(
+                    Path(file1),
+                    Path(file2),
+                    mock_runtime_ver,
+                    mock_session_pools,
+                )
+            self.assertTrue(
+                result is None, f"Expected None, received {result}"
+            )
+
+    def test_setup_umu_noupdate(self):
+        """Test setup_umu when setting runtime updates are disabled."""
+        result = MagicMock()
+        os.environ["UMU_RUNTIME_UPDATE"] = "0"
+
+        # Mock a new install
+        with TemporaryDirectory() as file1, TemporaryDirectory() as file2:
+            # Populate our fake $XDG_DATA_HOME/umu
+            Path(file2, "umu").touch()
+            # Mock the runtime ver
+            mock_runtime_ver = ("sniper", "steamrt3")
+            # Mock our thread and conn pool
+            mock_session_pools = (MagicMock(), MagicMock())
+            with patch.object(umu_runtime, "_restore_umu"):
+                result = umu_runtime.setup_umu(
+                    Path(file1),
+                    Path(file2),
+                    mock_runtime_ver,
+                    mock_session_pools,
+                )
+            self.assertTrue(
+                result is None, f"Expected None, received {result}"
+            )
+
+    def test_setup_umu(self):
+        """Test setup_umu on new install."""
+        result = MagicMock()
+
+        # Mock a new install
+        with TemporaryDirectory() as file1, TemporaryDirectory() as file2:
+            # Mock the runtime ver
+            mock_runtime_ver = ("sniper", "steamrt3")
+            # Mock our thread and conn pool
+            mock_session_pools = (MagicMock(), MagicMock())
+            with patch.object(umu_runtime, "_restore_umu"):
+                result = umu_runtime.setup_umu(
+                    Path(file1),
+                    Path(file2),
+                    mock_runtime_ver,
+                    mock_session_pools,
+                )
+            self.assertTrue(
+                result is None, f"Expected None, received {result}"
+            )
+
     def test_get_gamescope_baselayer_appid_err(self):
         """Test get_gamescope_baselayer_appid on error.
 

--- a/umu/umu_test.py
+++ b/umu/umu_test.py
@@ -302,6 +302,179 @@ class TestGameLauncher(unittest.TestCase):
                 result is None, f"Expected None, received {result}"
             )
 
+    def test_restore_umu_platformid_status_err(self):
+        """Test _restore_umu_platformid when the server returns a non-200 status code."""
+        result = None
+        # Mock os-release data
+        mock_osrel = (
+            'PRETTY_NAME="Steam Runtime 3 (sniper)""\n'
+            'NAME="Steam Runtime"\n'
+            'VERSION_ID="3"\n'
+            'VERSION="3 (sniper)"\n'
+            "VERSION_CODENAME=sniper\n"
+            "ID=steamrt\n"
+            "ID_LIKE=debian\n"
+            'HOME_URL="https://store.steampowered.com/"\n'
+            'SUPPORT_URL="https://help.steampowered.com/"\n'
+            'BUG_REPORT_URL="https://github.com/ValveSoftware/steam-runtime/issues"\n'
+            'BUILD_ID="0.20241118.108552"\n'
+            "VARIANT=Platform\n"
+            'VARIANT_ID="com.valvesoftware.steamruntime.platform-amd64_i386-sniper"\n'
+        )
+        # Mock the response
+        mock_resp = MagicMock()
+        mock_resp.status = 404
+        mock_resp.data = b"foo"
+        mock_resp.getheader.return_value = "foo"
+
+        # Mock the conn pool
+        mock_hp = MagicMock()
+        mock_hp.request.return_value = mock_resp
+
+        # Mock thread pool
+        mock_tp = MagicMock()
+
+        # Mock runtime ver
+        mock_runtime_ver = ("sniper", "steamrt3")
+
+        with TemporaryDirectory() as file:
+            mock_runtime_base = Path(file)
+            mock_osrel_file = mock_runtime_base.joinpath(
+                "files", "lib", "os-release"
+            )
+            mock_runtime_base.joinpath("files", "lib").mkdir(parents=True)
+            mock_osrel_file.touch(exist_ok=True)
+            mock_osrel_file.write_text(mock_osrel)
+            result = umu_runtime._restore_umu_platformid(
+                mock_runtime_base, mock_runtime_ver, (mock_tp, mock_hp)
+            )
+            self.assertTrue(
+                result is None, f"Expected None, received {result}"
+            )
+
+    def test_restore_umu_platformid_osrel_none(self):
+        """Test _restore_umu_platformid when the os-release file is missing."""
+        result = None
+        # Mock the response
+        mock_resp = MagicMock()
+        mock_resp.status = 200
+        mock_resp.data = b"foo"
+
+        # Mock the conn pool
+        mock_hp = MagicMock()
+        mock_hp.request.return_value = mock_resp
+
+        # Mock thread pool
+        mock_tp = MagicMock()
+
+        # Mock runtime ver
+        mock_runtime_ver = ("sniper", "steamrt3")
+
+        with TemporaryDirectory() as file:
+            mock_runtime_base = Path(file)
+            mock_runtime_base.joinpath("files", "lib").mkdir(parents=True)
+            result = umu_runtime._restore_umu_platformid(
+                mock_runtime_base, mock_runtime_ver, (mock_tp, mock_hp)
+            )
+            self.assertTrue(
+                result is None, f"Expected None, received {result}"
+            )
+
+    def test_restore_umu_platformid_osrel_err(self):
+        """Test _restore_umu_platformid on error parsing os-release."""
+        result = None
+        # Mock os-release data. Remove the BUILD_ID field to error
+        mock_osrel = (
+            'PRETTY_NAME="Steam Runtime 3 (sniper)""\n'
+            'NAME="Steam Runtime"\n'
+            'VERSION_ID="3"\n'
+            'VERSION="3 (sniper)"\n'
+            "VERSION_CODENAME=sniper\n"
+            "ID=steamrt\n"
+            "ID_LIKE=debian\n"
+            'HOME_URL="https://store.steampowered.com/"\n'
+            'SUPPORT_URL="https://help.steampowered.com/"\n'
+            'BUG_REPORT_URL="https://github.com/ValveSoftware/steam-runtime/issues"\n'
+            "VARIANT=Platform\n"
+            'VARIANT_ID="com.valvesoftware.steamruntime.platform-amd64_i386-sniper"\n'
+        )
+        # Mock the response
+        mock_resp = MagicMock()
+        mock_resp.status = 200
+        mock_resp.data = b"foo"
+
+        # Mock the conn pool
+        mock_hp = MagicMock()
+        mock_hp.request.return_value = mock_resp
+
+        # Mock thread pool
+        mock_tp = MagicMock()
+
+        # Mock runtime ver
+        mock_runtime_ver = ("sniper", "steamrt3")
+
+        with TemporaryDirectory() as file:
+            mock_runtime_base = Path(file)
+            mock_runtime_base.joinpath("files", "lib").mkdir(parents=True)
+            mock_osrel_file = mock_runtime_base.joinpath(
+                "files", "lib", "os-release"
+            )
+            mock_osrel_file.touch(exist_ok=True)
+            mock_osrel_file.write_text(mock_osrel)
+            result = umu_runtime._restore_umu_platformid(
+                mock_runtime_base, mock_runtime_ver, (mock_tp, mock_hp)
+            )
+            self.assertTrue(
+                result is None, f"Expected None, received {result}"
+            )
+
+    def test_restore_umu_platformid(self):
+        """Test _restore_umu_platformid."""
+        result = None
+        # Mock os-release data
+        mock_osrel = (
+            'PRETTY_NAME="Steam Runtime 3 (sniper)""\n'
+            'NAME="Steam Runtime"\n'
+            'VERSION_ID="3"\n'
+            'VERSION="3 (sniper)"\n'
+            "VERSION_CODENAME=sniper\n"
+            "ID=steamrt\n"
+            "ID_LIKE=debian\n"
+            'HOME_URL="https://store.steampowered.com/"\n'
+            'SUPPORT_URL="https://help.steampowered.com/"\n'
+            'BUG_REPORT_URL="https://github.com/ValveSoftware/steam-runtime/issues"\n'
+            'BUILD_ID="0.20241118.108552"\n'
+            "VARIANT=Platform\n"
+            'VARIANT_ID="com.valvesoftware.steamruntime.platform-amd64_i386-sniper"\n'
+        )
+        # Mock the response
+        mock_resp = MagicMock()
+        mock_resp.status = 200
+        mock_resp.data = b"foo"
+
+        # Mock the conn pool
+        mock_hp = MagicMock()
+        mock_hp.request.return_value = mock_resp
+
+        # Mock thread pool
+        mock_tp = MagicMock()
+
+        # Mock runtime ver
+        mock_runtime_ver = ("sniper", "steamrt3")
+
+        with TemporaryDirectory() as file:
+            mock_runtime_base = Path(file)
+            mock_osrel_file = mock_runtime_base.joinpath(
+                "files", "lib", "os-release"
+            )
+            mock_runtime_base.joinpath("files", "lib").mkdir(parents=True)
+            mock_osrel_file.touch(exist_ok=True)
+            mock_osrel_file.write_text(mock_osrel)
+            result = umu_runtime._restore_umu_platformid(
+                mock_runtime_base, mock_runtime_ver, (mock_tp, mock_hp)
+            )
+            self.assertEqual(result, "foo", f"Expected foo, received {result}")
+
     def test_get_gamescope_baselayer_appid_err(self):
         """Test get_gamescope_baselayer_appid on error.
 

--- a/umu/umu_test_plugins.py
+++ b/umu/umu_test_plugins.py
@@ -7,7 +7,7 @@ import unittest
 from argparse import Namespace
 from pathlib import Path
 from shutil import copy, copytree, rmtree
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from tomllib import TOMLDecodeError
 
@@ -201,12 +201,11 @@ class TestGameLauncherPlugins(unittest.TestCase):
         with (
             patch.object(umu_runtime, "_install_umu", return_value=None),
         ):
-            # TODO
             umu_runtime.setup_umu(
                 self.test_user_share,
                 self.test_local_share,
                 self.test_runtime_version,
-                None,
+                (MagicMock(), MagicMock()),
             )
             copytree(
                 Path(self.test_user_share, "sniper_platform_0.20240125.75305"),
@@ -284,7 +283,7 @@ class TestGameLauncherPlugins(unittest.TestCase):
                 self.test_user_share,
                 self.test_local_share,
                 self.test_runtime_version,
-                None,
+                (MagicMock(), MagicMock()),
             )
             copytree(
                 Path(self.test_user_share, "sniper_platform_0.20240125.75305"),
@@ -369,7 +368,7 @@ class TestGameLauncherPlugins(unittest.TestCase):
                 self.test_user_share,
                 self.test_local_share,
                 self.test_runtime_version,
-                None,
+                (MagicMock(), MagicMock()),
             )
             copytree(
                 Path(self.test_user_share, "sniper_platform_0.20240125.75305"),

--- a/umu/umu_util.py
+++ b/umu/umu_util.py
@@ -7,14 +7,11 @@ from pathlib import Path
 from re import Pattern
 from re import compile as re_compile
 from shutil import which
-from ssl import SSLContext, create_default_context
 from subprocess import PIPE, STDOUT, Popen, TimeoutExpired
 
 from Xlib import display
 
 from umu.umu_log import log
-
-ssl_context: SSLContext | None = None
 
 
 @lru_cache
@@ -170,26 +167,6 @@ def is_winetricks_verb(
             return False
 
     return True
-
-
-@contextmanager
-def https_connection(host: str):
-    """Create an HTTPSConnection."""
-    global ssl_context
-    conn: HTTPSConnection
-
-    if not ssl_context:
-        ssl_context = create_default_context()
-
-    conn = HTTPSConnection(host, context=ssl_context)
-
-    if os.environ.get("UMU_LOG") in {"1", "debug"}:
-        conn.set_debuglevel(1)
-
-    try:
-        yield conn
-    finally:
-        conn.close()
 
 
 @contextmanager


### PR DESCRIPTION
Closes https://github.com/Open-Wine-Components/umu-launcher/issues/264.

Adds urllib3 version 2 as the network backend for umu-launcher to ensure more reliable installation and updates of the runtime for users. All network requests will be subject to a strict 5 second timeout to ensure users will not hang, and requests that return a 301 or similar will be auto redirected for any endpoint. When the connection suddenly drops, umu-launcher will retry the connection a total of 2 times and save the downloaded file in $XDG_CACHE_HOME/umu where it will be picked up for resumption on the next launch.  

urllib2 will be a **vendored dependency** as, understandably, most Linux distributions do not package v2. For maintainers, **python3-pip** or similar will be an additional build dependency to install it. However, [once HTTPX makes its async dependencies optional](https://github.com/encode/httpx/pull/2858), we'll consider opting to use that instead and dropping urllib3. Additionally, [truststore](https://github.com/sethmlarson/truststore) will be an **optional** dependency to allow the usage of the system's native CA bundle instead of certifi's for network requests.