### PR TITLE
Support compatibility tools other than Proton out-of-the-box.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "subprojects/python-xlib"]
 	path = subprojects/python-xlib
 	url = https://github.com/python-xlib/python-xlib.git
+[submodule "subprojects/vdf"]
+	path = subprojects/vdf
+	url = https://github.com/ValvePython/vdf.git

--- a/Makefile.in
+++ b/Makefile.in
@@ -23,6 +23,7 @@ FLATPAK ?= xfalse
 # Ex. Arch and Fedora have pyzstd but ubuntu and debian don't
 USE_SYSTEM_PYZSTD ?= xfalse
 USE_SYSTEM_URLLIB ?= xfalse
+USE_SYSTEM_VDF ?= xfalse
 
 INSTALLER_ARGS := -m installer $(OBJDIR)/umu_launcher*.whl
 ifdef DESTDIR
@@ -85,11 +86,15 @@ umu-install: umu-dist-install umu-delta-install umu-docs-install
 endif
 
 
+
 $(OBJDIR)/.build-umu-vendored: | $(OBJDIR)
 	$(info :: Building vendored dependencies )
 	@if [ "$(USE_SYSTEM_PYZSTD)" != "xtrue" ]; then \
 		sed -i 's/setuptools>=64,<74/setuptools/' subprojects/pyzstd/pyproject.toml; \
 		cd subprojects/pyzstd && $(PYTHON_INTERPRETER) -m build -wn -C=--build-option=--dynamic-link-zstd --outdir=$(OBJDIR); \
+	fi
+	@if [ "$(USE_SYSTEM_VDF)" != "xtrue" ]; then \
+		cd subprojects/vdf && $(PYTHON_INTERPRETER) -m build -wn --outdir=$(OBJDIR); \
 	fi
 	@if [ "$(USE_SYSTEM_URLLIB)" != "xtrue" ]; then \
 		cd subprojects/urllib3 && \
@@ -107,6 +112,10 @@ umu-vendored-install: umu-vendored
 	@if [ "$(USE_SYSTEM_PYZSTD)" != "xtrue" ]; then \
 		$(PYTHON_INTERPRETER) -m installer --destdir=$(DESTDIR)$(PYTHONDIR)/umu/_vendor subprojects/pyzstd/$(OBJDIR)/pyzstd*.whl; \
 		find $(DESTDIR)$(PYTHONDIR)/umu/_vendor -type d -name pyzstd | xargs -I {} mv {} $(DESTDIR)$(PYTHONDIR)/umu/_vendor; \
+	fi
+	@if [ "$(USE_SYSTEM_VDF)" != "xtrue" ]; then \
+		$(PYTHON_INTERPRETER) -m installer --destdir=$(DESTDIR)$(PYTHONDIR)/umu/_vendor subprojects/vdf/$(OBJDIR)/vdf*.whl; \
+		find $(DESTDIR)$(PYTHONDIR)/umu/_vendor -type d -name vdf | xargs -I {} mv {} $(DESTDIR)$(PYTHONDIR)/umu/_vendor; \
 	fi
 	@if [ "$(USE_SYSTEM_URLLIB)" != "xtrue" ]; then \
 		$(PYTHON_INTERPRETER) -m installer --destdir=$(DESTDIR)$(PYTHONDIR)/umu/_vendor subprojects/urllib3/$(OBJDIR)/urllib3*.whl; \

--- a/README.md
+++ b/README.md
@@ -84,6 +84,13 @@ Borderlands 3 from EGS store.
 3. In our umu unified database, we create a 'title' column, 'store' column, 'codename' column, 'umu-ID' column. We add a line for Borderlands 3 and fill in the details for each column.
 4. Now the launcher can search 'Catnip' and 'egs' as the codename and store in the database and correlate it with Borderlands 3 and umu-12345. It can then feed umu-12345 to the `umu-run` script.
 
+## Reporting issues
+
+When reporting issues for games that fail to run, be sure to attach a log with your issue report. To acquire a log from umu, add `UMU_LOG=1` to your environment variables for verbose logging. Furthermore, you can use `PROTON_LOG=1` for proton to create a verbose log in your `$HOME` directory. The log will be named `steam-<appid>.log`, where `<appid>` will be `default` if you haven't set a `GAMEID` or a number, depending on what you have set for `GAMEID`.
+
+Do **NOT** report issues when using `UMU_NO_RUNTIME=1`, this option is provided for convenience for compatibility tools that do not set their runtime requirements, such as Proton < `5.13`, and they do not work with any of the supported runtimes.
+This mode does not make use of a container runtime, and issues while using it are irrelevant to umu-launcher in general. Thus such issues will be automatically closed.
+
 ## Building
 
 Building umu-launcher currently requires `bash`, `make`, and `scdoc` for distribution, as well as the following Python build tools: [build](https://github.com/pypa/build), [hatchling](https://github.com/pypa/hatch), [installer](https://github.com/pypa/installer), and [pip](https://github.com/pypa/pip).

--- a/configure.sh
+++ b/configure.sh
@@ -75,6 +75,9 @@ function configure() {
     if [[ -n "$arg_use_system_urllib" ]]; then
       echo "USE_SYSTEM_URLLIB := xtrue"
     fi
+    if [[ -n "$arg_use_system_vdf" ]]; then
+      echo "USE_SYSTEM_VDF := xtrue"
+    fi
 
     # Prefix was specified, baking it into the Makefile
     if [[ -n $arg_prefix ]]; then
@@ -98,6 +101,7 @@ arg_user_install=""
 arg_help=""
 arg_use_system_pyzstd=""
 arg_use_system_urllib=""
+arg_use_system_vdf=""
 function parse_args() {
   local arg;
   local val;
@@ -147,6 +151,8 @@ function parse_args() {
       arg_use_system_pyzstd="1"
     elif [[ $arg = --use-system-urllib ]]; then
       arg_use_system_urllib="1"
+    elif [[ $arg = --use-system-vdf ]]; then
+      arg_use_system_vdf="1"
     else
       err "Unrecognized option $arg"
       return 1

--- a/docs/umu.1.scd
+++ b/docs/umu.1.scd
@@ -186,6 +186,13 @@ _UMU_HTTP_RETRIES_
 
 	Set _0_ to disable retries for HTTP requests. Set a positive integer to override the default.
 
+_UMU_NO_RUNTIME_
+	Optional. Allows for the configured compatibility tool to run outside of the Steam Linux Runtime.
+	This option is effective only if the compatibility tool doesn't require a runtime through its configuration.
+	On compatibility tools that require a runtime, this option is ignored.
+
+	Set _1_ to silence umu's error that it couldn't resolve a runtime to use, and run using the host's libraries.
+
 # SEE ALSO
 
 _umu_(5), _winetricks_(1)

--- a/packaging/nix/unwrapped.nix
+++ b/packaging/nix/unwrapped.nix
@@ -2,6 +2,7 @@
   # Dependencies
   lib,
   rustPlatform,
+  python3Packages,
   umu-launcher-unwrapped,
   version,
   # Freeform overrides
@@ -19,6 +20,7 @@ assert lib.assertMsg (lib.versionAtLeast umu-launcher-unwrapped.version "1.2.0")
   overrideArgs = builtins.removeAttrs args [
     "lib"
     "rustPlatform"
+    "python3Packages"
     "umu-launcher-unwrapped"
     "version"
   ];
@@ -30,12 +32,24 @@ assert lib.assertMsg (lib.versionAtLeast umu-launcher-unwrapped.version "1.2.0")
     then umu-launcher-unwrapped
     else umu-launcher-unwrapped.override overrideArgs;
 in
-  package.overridePythonAttrs {
+  package.overridePythonAttrs (old: {
     inherit version;
     src = ../../.;
     cargoDeps = rustPlatform.importCargoLock {
       lockFile = ../../Cargo.lock;
     };
+
+    pythonPath =
+      (old.pythonPath or [])
+      ++ [
+        python3Packages.vdf
+      ];
+
+    configureFlags =
+      (old.configureFlags or [])
+      ++ [
+        "--use-system-vdf"
+      ];
 
     # Specify ourselves which tests are disabled
     disabledTests = [
@@ -47,5 +61,14 @@ in
       # Broken? Tests parse_args with no options (./umu_run.py)
       # Fails with AssertionError: SystemExit not raised
       "test_parse_args_noopts"
+
+      # FileNotFoundError: [Errno 2] No such file or directory: .local/share/umu/toolmanifest.vdf
+      "test_build_command"
+      "test_build_command_linux_exe"
+      "test_build_command_nopv"
+
+      # TypeError: cannot unpack non-iterable ThreadPoolExecutor object
+      "test_env_nowine_noproton"
+      "test_env_wine_noproton"
     ];
-  }
+  })

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ classifiers = [
 urls = { repository = "https://github.com/Open-Wine-Components/umu-launcher" }
 # Note: urllib3 is a vendored dependency. When using our Makefile, it will be
 # installed automatically.
-dependencies = ["python-xlib>=0.33", "urllib3>=2.0.0"]
+dependencies = ["python-xlib>=0.33", "urllib3>=2.0.0", "vdf>=3.4"]
 
 [project.optional-dependencies]
 # Recommended

--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,6 @@
 python-xlib>=0.33
 urllib3>=2.0.0,<3.0.0
+vdf>=3.4
 xxhash>=3.2.0
 pyzstd>=0.16.2
 cbor2>=5.4.6

--- a/tests/test_config.sh
+++ b/tests/test_config.sh
@@ -19,5 +19,6 @@ store = 'gog'
 " >> "$tmp"
 
 
+# This works only for an existing prefix, the prefix `~/Games/umu/umu-0` is created in the previous workflow steps
 RUNTIMEPATH=steamrt3 UMU_LOG=debug GAMEID=umu-1141086411 STORE=gog "$PWD/.venv/bin/python" "$HOME/.local/bin/umu-run" --config "$tmp" 2> /tmp/umu-log.txt && grep -E "INFO: Non-steam game Silent Hill 4: The Room \(umu-1141086411\)" /tmp/umu-log.txt
 # Run the 'game' using UMU-Proton9.0-3.2 and ensure the protonfixes module finds its fix in umu-database.csv

--- a/umu/umu_plugins.py
+++ b/umu/umu_plugins.py
@@ -52,9 +52,9 @@ def set_env_toml(
     _check_env_toml(toml)
 
     # Required environment variables
-    env["WINEPREFIX"] = toml["umu"]["prefix"]
-    env["PROTONPATH"] = toml["umu"]["proton"]
-    env["EXE"] = toml["umu"]["exe"]
+    env["WINEPREFIX"] = str(Path(toml["umu"]["prefix"]).expanduser())
+    env["PROTONPATH"] = str(Path(toml["umu"]["proton"]).expanduser())
+    env["EXE"] = str(Path(toml["umu"]["exe"]).expanduser())
     # Optional
     env["GAMEID"] = toml["umu"].get("game_id", "")
     env["STORE"] = toml["umu"].get("store", "")

--- a/umu/umu_proton.py
+++ b/umu/umu_proton.py
@@ -56,6 +56,7 @@ class ProtonVersion(Enum):
     UMUScout = "umu-scout"
     UMUSoldier = "umu-soldier"
     UMUSniper = "umu-sniper"
+    UMUSteamRT4 = "umu-steamrt4"
 
 
 def get_umu_proton(env: dict[str, str], session_pools: SessionPools) -> dict[str, str]:
@@ -110,7 +111,11 @@ def _get_umu_runtime_tool(env: dict[str, str], name: str) -> dict[str, str] | No
     When 'PROTONPATH' is 'umu-soldier' or 'umu-sniper', create a shim compatibility
     tool that requires the respective runtime and launches the application in that runtime.
     """
-    if not (name and name in {ProtonVersion.UMUSoldier.value, ProtonVersion.UMUSniper.value}):
+    if not (name and name in {
+        ProtonVersion.UMUSoldier.value,
+        ProtonVersion.UMUSniper.value,
+        ProtonVersion.UMUSteamRT4.value
+    }):
         return None
 
     rt_appid = RUNTIME_VERSIONS[RUNTIME_NAMES[name.removeprefix("umu-")]].appid

--- a/umu/umu_proton.py
+++ b/umu/umu_proton.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 import time
 from concurrent.futures import ALL_COMPLETED, FIRST_EXCEPTION, ThreadPoolExecutor
 from concurrent.futures import wait as futures_wait
@@ -13,6 +14,7 @@ from shutil import move
 from tempfile import TemporaryDirectory, mkdtemp
 from typing import Any
 
+import vdf
 from urllib3.exceptions import HTTPError
 from urllib3.poolmanager import PoolManager
 from urllib3.response import BaseHTTPResponse
@@ -27,6 +29,7 @@ from umu.umu_consts import (
     HTTPMethod,
 )
 from umu.umu_log import log
+from umu.umu_runtime import RUNTIME_NAMES, RUNTIME_VERSIONS
 from umu.umu_util import (
     extract_tarfile,
     file_digest,
@@ -50,6 +53,9 @@ class ProtonVersion(Enum):
     UMU = "UMU-Proton"
     GELatest = "GE-Latest"
     UMULatest = "UMU-Latest"
+    UMUScout = "umu-scout"
+    UMUSoldier = "umu-soldier"
+    UMUSniper = "umu-sniper"
 
 
 def get_umu_proton(env: dict[str, str], session_pools: SessionPools) -> dict[str, str]:
@@ -84,6 +90,8 @@ def get_umu_proton(env: dict[str, str], session_pools: SessionPools) -> dict[str
     with TemporaryDirectory(dir=UMU_CACHE) as tmpcache:
         tmpdirs: SessionCaches = (get_tempdir(), Path(tmpcache))
         compatdirs = (UMU_COMPAT, STEAM_COMPAT)
+        if _get_umu_runtime_tool(env, os.environ.get("PROTONPATH", "")) is env:
+            return env
         if _get_delta(env, UMU_COMPAT, patch, assets, session_pools) is env:
             return env
         if _get_latest(env, compatdirs, tmpdirs, assets, session_pools) is env:
@@ -95,6 +103,64 @@ def get_umu_proton(env: dict[str, str], session_pools: SessionPools) -> dict[str
 
     return env
 
+
+def _get_umu_runtime_tool(env: dict[str, str], name: str) -> dict[str, str] | None:
+    """Create  a 'passthrough' compatibility tool for native linux applications.
+
+    When 'PROTONPATH' is 'umu-soldier' or 'umu-sniper', create a shim compatibility
+    tool that requires the respective runtime and launches the application in that runtime.
+    """
+    if not (name and name in {ProtonVersion.UMUSoldier.value, ProtonVersion.UMUSniper.value}):
+        return None
+
+    rt_appid = RUNTIME_VERSIONS[RUNTIME_NAMES[name.removeprefix("umu-")]].appid
+    tool_path: Path = UMU_COMPAT.joinpath(name)
+    entry_point_file: Path = tool_path.joinpath("entry-point")
+    compatibilitytool_file: Path = tool_path.joinpath("compatibilitytool.vdf")
+    toolmanifest_file: Path = tool_path.joinpath("toolmanifest.vdf")
+    files = (entry_point_file, compatibilitytool_file, toolmanifest_file)
+
+    if tool_path.is_dir():
+        if all(f.is_file() for f in files):
+            os.environ["PROTONPATH"] = str(tool_path)
+            env["PROTONPATH"] = os.environ["PROTONPATH"]
+            return env
+        shutil.rmtree(tool_path)
+
+    entry_point = "#!/bin/sh\nexec \"$@\"\n"
+    compatibilitytool = {
+        "compatibilitytools": {
+            "compat_tools": {
+                name: {"display_name": name, "install_path": ".", "from_oslist": "linux", "to_oslist": "linux",}
+            }
+        }
+    }
+    toolmanifest = {
+        "manifest": {
+            "version": "2",
+            "commandline": "/entry-point",
+            "require_tool_appid": rt_appid,
+            "use_sessions": "1",
+            "compatmanager_layer_name": "umu-passthrough",
+        }
+    }
+
+    if not tool_path.is_dir():
+        tool_path.mkdir(parents=True, exist_ok=True)
+
+    with entry_point_file.open("w") as fd:
+        fd.write(entry_point)
+    entry_point_file.chmod(0o700)
+
+    with compatibilitytool_file.open("w") as fd:
+        vdf.dump(compatibilitytool, fd, pretty=True)
+
+    with toolmanifest_file.open("w") as fd:
+        vdf.dump(toolmanifest, fd, pretty=True)
+
+    os.environ["PROTONPATH"] = str(tool_path)
+    env["PROTONPATH"] = str(tool_path)
+    return env
 
 def _fetch_patch(session_pools: SessionPools) -> bytes:
     resp: BaseHTTPResponse
@@ -164,6 +230,9 @@ def _fetch_releases(
     }:
         repo = "/repos/GloriousEggroll/proton-ge-custom/releases/latest"
 
+    if os.environ.get("PROTONPATH") in {ProtonVersion.UMUScout.value}:
+        repo = "/repos/loathingKernel/umu-scout/releases/latest"
+
     resp = http_pool.request(HTTPMethod.GET.value, f"{url}{repo}", headers=headers)
     if resp.status != HTTPStatus.OK:
         return ()
@@ -177,8 +246,8 @@ def _fetch_releases(
             digest_asset = (release["name"], release["browser_download_url"])
             asset_count += 1
             continue
-        if release["name"].endswith("tar.gz") and release["name"].startswith(
-            ("UMU-Proton", "GE-Proton")
+        if release["name"].endswith(("tar.gz", "tar.xz")) and release["name"].startswith(
+            ("UMU-Proton", "GE-Proton", "umu-scout")
         ):
             proton_asset = (release["name"], release["browser_download_url"])
             asset_count += 1
@@ -206,7 +275,8 @@ def _fetch_proton(
     _, http_pool = session_pools
     proton_hash, proton_hash_url = assets[0]
     tarball, tar_url = assets[1]
-    proton: str = tarball.removesuffix(".tar.gz")
+    # remove any combination of .abc.xy suffix (realistically .tar.gz|xz)
+    proton = ".".join(tarball.split(".")[:-2])
     ret: int = 0  # Exit code from zenity
     digest: str = ""  # Digest of the Proton archive
     hashsum = sha512()
@@ -384,10 +454,12 @@ def _get_latest(
         return None
 
     tarball = assets[1][0]
-    proton = tarball.removesuffix(".tar.gz")
+    # remove any combination of .abc.xy suffix (realistically .tar.gz|xz)
+    proton = ".".join(tarball.split(".")[:-2])
     latest_candidates = {
         ProtonVersion.GELatest.value,
         ProtonVersion.UMULatest.value,
+        ProtonVersion.UMUScout.value
     }
 
     if os.environ.get("PROTONPATH") in {member.value for member in ProtonVersion}:
@@ -453,6 +525,7 @@ def _install_proton(
     latest_candidates: set[str] = {
         ProtonVersion.GELatest.value,
         ProtonVersion.UMULatest.value,
+        ProtonVersion.UMUScout.value,
     }
 
     # Move our file and extract within our cache
@@ -475,19 +548,15 @@ def _install_proton(
 
     # Move decompressed archive to compatibilitytools.d or
     # $XDG_DATA_HOME/umu/compatibilitytools
+    # remove any combination of .abc.xy suffix (realistically .tar.gz|xz)
+    name = ".".join(tarball.split(".")[:-2])
+    folder = cache.joinpath(name)
     if os.environ.get("PROTONPATH") in latest_candidates:
-        log.info(
-            "%s -> %s", cache.joinpath(tarball.removesuffix(".tar.gz")), umu_compat
-        )
-        move(
-            cache.joinpath(tarball.removesuffix(".tar.gz")),
-            umu_compat / os.environ["PROTONPATH"],
-        )
+        log.info("%s -> %s", folder, umu_compat)
+        move(folder, umu_compat / os.environ["PROTONPATH"])
     else:
-        log.info(
-            "%s -> %s", cache.joinpath(tarball.removesuffix(".tar.gz")), steam_compat
-        )
-        move(cache.joinpath(tarball.removesuffix(".tar.gz")), steam_compat)
+        log.info("%s -> %s", folder, steam_compat)
+        move(folder, steam_compat)
 
 
 def _get_delta(

--- a/umu/umu_proton.py
+++ b/umu/umu_proton.py
@@ -141,6 +141,7 @@ def _get_umu_runtime_tool(env: dict[str, str], name: str) -> dict[str, str] | No
             "commandline": "/entry-point",
             "require_tool_appid": rt_appid,
             "use_sessions": "1",
+            # special value, see CompatLayer.layer_name()
             "compatmanager_layer_name": "umu-passthrough",
         }
     }

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -839,7 +839,9 @@ def umu_run(args: Namespace | tuple[str, list[str]]) -> int:
             f"Failed to match '{os.environ.get('PROTONPATH')}' with a container runtime"
         )
         raise ValueError(err)
-    os.environ["RUNTIMEPATH"] = runtime_version[1]
+    # runtime_name, runtime_variant, runtime_appid
+    _, runtime_variant, _ = runtime_version
+    os.environ["RUNTIMEPATH"] = runtime_variant
 
     # Opt to use the system's native CA bundle rather than certifi's
     with suppress(ModuleNotFoundError):
@@ -883,11 +885,11 @@ def umu_run(args: Namespace | tuple[str, list[str]]) -> int:
         # Setup the launcher and runtime files
         _, do_download = check_env(env)
 
-        if runtime_version[1] != "host":
-            UMU_LOCAL.joinpath(runtime_version[1]).mkdir(parents=True, exist_ok=True)
+        if runtime_variant != "host":
+            UMU_LOCAL.joinpath(runtime_variant).mkdir(parents=True, exist_ok=True)
 
             future: Future = thread_pool.submit(
-                setup_umu, UMU_LOCAL / runtime_version[1], runtime_version, session_pools
+                setup_umu, UMU_LOCAL / runtime_variant, runtime_version, session_pools
             )
 
             download_proton(do_download, env, session_pools)
@@ -929,7 +931,7 @@ def umu_run(args: Namespace | tuple[str, list[str]]) -> int:
         sys.exit(1)
 
     # Build the command
-    command: tuple[Path | str, ...] = build_command(env, UMU_LOCAL, runtime_version[1], opts)
+    command: tuple[Path | str, ...] = build_command(env, UMU_LOCAL, runtime_variant, opts)
     log.debug("%s", command)
 
     # Run the command

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -732,6 +732,7 @@ def umu_run(args: Namespace | tuple[str, list[str]]) -> int:
         "STEAM_COMPAT_CLIENT_INSTALL_PATH": "",
         "STEAM_COMPAT_DATA_PATH": "",
         "STEAM_COMPAT_SHADER_PATH": "",
+        "STEAM_COMPAT_LAUNCHER_SERVICE": "",
         "FONTCONFIG_PATH": "",
         "EXE": "",
         "SteamAppId": "",
@@ -884,6 +885,7 @@ def umu_run(args: Namespace | tuple[str, list[str]]) -> int:
                 setup_pfx(cdata_path)
 
         # Configure the environment
+        env["STEAM_COMPAT_LAUNCHER_SERVICE"] = layer.layer_name
         set_env(env, args)
 
         # Set all environment variables

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -1,3 +1,4 @@
+import hashlib
 import os
 import signal
 import sys
@@ -246,6 +247,9 @@ def set_env(
     env["WINEPREFIX"] = str(pfx)
     env["STEAM_COMPAT_DATA_PATH"] = str(pfx)
     env["STEAM_COMPAT_APP_ID"] = str(pfx).replace("/", "_")
+    prefix_md5 = hashlib.md5(str(pfx).encode("utf-8")).hexdigest()  # noqa: S324
+    proton_md5 = hashlib.md5(str(protonpath).encode("utf-8")).hexdigest()  # noqa: S324
+    env["STEAM_COMPAT_APP_ID"] = f"{prefix_md5}_{proton_md5}"
     env["STEAM_COMPAT_SHADER_PATH"] = str(pfx.joinpath("shadercache"))
     env["PROTONPATH"] = str(protonpath)
     env["STEAM_COMPAT_TOOL_PATHS"] = ":".join(

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -342,11 +342,6 @@ def build_command(
     if env.get("UMU_NO_PROTON") == "1":
         return *entry_point, env["EXE"], *opts
 
-    # Will run the game outside the Steam Runtime w/ Proton
-    if env.get("UMU_NO_RUNTIME") == "1":
-        log.warning("Runtime Platform disabled")
-        return proton, env["PROTON_VERB"], env["EXE"], *opts
-
     return (
         *entry_point,
         shim,
@@ -735,7 +730,10 @@ def get_umu_version_from_manifest(
                 break
 
     if not appid:
-        return "host", "host", "host"
+        if os.environ.get("UMU_NO_RUNTIME", None) == "1":
+            log.warning("Runtime Platform disabled")
+            return "host", "host", "host"
+        return None
 
     if appid not in set(filter(None, appids)):
         return None

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -246,10 +246,10 @@ def set_env(
     # PATHS
     env["WINEPREFIX"] = str(pfx)
     env["STEAM_COMPAT_DATA_PATH"] = str(pfx)
-    env["STEAM_COMPAT_APP_ID"] = str(pfx).replace("/", "_")
     prefix_md5 = hashlib.md5(str(pfx).encode("utf-8")).hexdigest()  # noqa: S324
-    proton_md5 = hashlib.md5(str(protonpath).encode("utf-8")).hexdigest()  # noqa: S324
-    env["STEAM_COMPAT_APP_ID"] = f"{prefix_md5}_{proton_md5}"
+    # proton_md5 = hashlib.md5(str(protonpath).encode("utf-8")).hexdigest()  # noqa: RUF100,S324
+    # env["STEAM_COMPAT_APP_ID"] = f"{prefix_md5}_{proton_md5}"
+    env["STEAM_COMPAT_APP_ID"] = f"{prefix_md5}"
     env["STEAM_COMPAT_SHADER_PATH"] = str(pfx.joinpath("shadercache"))
     env["PROTONPATH"] = str(protonpath)
     env["STEAM_COMPAT_TOOL_PATHS"] = ":".join(

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -39,7 +39,7 @@ from umu.umu_consts import (
 from umu.umu_log import log
 from umu.umu_plugins import set_env_toml
 from umu.umu_proton import get_umu_proton
-from umu.umu_runtime import setup_umu
+from umu.umu_runtime import create_shim, setup_umu
 from umu.umu_util import (
     get_libc,
     get_library_paths,
@@ -88,9 +88,7 @@ def setup_pfx(path: str) -> None:
         wineuser.symlink_to("steamuser")
 
 
-def check_env(
-    env: dict[str, str], session_pools: tuple[ThreadPoolExecutor, PoolManager]
-) -> dict[str, str] | dict[str, Any]:
+def check_env(env: dict[str, str]) -> tuple[dict[str, str] | dict[str, Any], bool]:
     """Before executing a game, check for environment variables and set them.
 
     GAMEID is strictly required and the client is responsible for setting this.
@@ -122,9 +120,10 @@ def check_env(
 
     env["WINEPREFIX"] = os.environ.get("WINEPREFIX", "")
 
+    do_download = False
     # Skip Proton if running a native Linux executable
     if os.environ.get("UMU_NO_PROTON") == "1":
-        return env
+        return env, do_download
 
     # Proton Version
     path: Path = STEAM_COMPAT.joinpath(os.environ.get("PROTONPATH", ""))
@@ -133,24 +132,34 @@ def check_env(
 
     # Proton Codename
     if os.environ.get("PROTONPATH") in {"GE-Proton", "GE-Latest", "UMU-Latest"}:
-        get_umu_proton(env, session_pools)
+        do_download = True
 
     if "PROTONPATH" not in os.environ:
         os.environ["PROTONPATH"] = ""
-        get_umu_proton(env, session_pools)
+        do_download = True
 
     env["PROTONPATH"] = os.environ["PROTONPATH"]
 
+    return env, do_download
+
+
+def download_proton(download: bool, env: dict[str, str], session_pools: tuple[ThreadPoolExecutor, PoolManager]) -> None:
+    """Check if umu should download proton and check if PROTONPATH is set.
+
+    I am not gonna lie about it, this only exists to satisfy the tests, because downloading
+    was previously nested in `check_env()`
+    """
+    if download:
+        get_umu_proton(env, session_pools)
+
     # If download fails/doesn't exist in the system, raise an error
-    if not os.environ["PROTONPATH"]:
+    if os.environ.get("UMU_NO_PROTON") != "1" and not os.environ["PROTONPATH"]:
         err: str = (
             "Environment variable not set or is empty: PROTONPATH\n"
             f"Possible reason: GE-Proton or UMU-Proton not found in '{STEAM_COMPAT}'"
             " or network error"
         )
         raise FileNotFoundError(err)
-
-    return env
 
 
 def set_env(
@@ -288,12 +297,17 @@ def enable_steam_game_drive(env: dict[str, str]) -> dict[str, str]:
 def build_command(
     env: dict[str, str],
     local: Path,
-    opts: list[str] = [],
+    version: str,
+    opts: list[str] | None = None,
 ) -> tuple[Path | str, ...]:
     """Build the command to be executed."""
     shim: Path = local.joinpath("umu-shim")
     proton: Path = Path(env["PROTONPATH"], "proton")
-    entry_point: Path = local.joinpath("umu")
+    entry_point: tuple[Path, str, str, str] | tuple[()] = (
+        local.joinpath(version, "umu"), "--verb", env["PROTON_VERB"], "--"
+    ) if version != "host" else ()
+    if opts is None:
+        opts = []
 
     if env.get("UMU_NO_PROTON") != "1" and not proton.is_file():
         err: str = "The following file was not found in PROTONPATH: proton"
@@ -302,7 +316,7 @@ def build_command(
     # Exit if the entry point is missing
     # The _v2-entry-point script and container framework tools are included in
     # the same image, so this can happen if the image failed to download
-    if not entry_point.is_file():
+    if entry_point and not entry_point[0].is_file():
         err: str = (
             f"_v2-entry-point (umu) cannot be found in '{local}'\n"
             "Runtime Platform missing or download incomplete"
@@ -314,10 +328,7 @@ def build_command(
         # The position of arguments matter for winetricks
         # Usage: ./winetricks [options] [command|verb|path-to-verb] ...
         return (
-            entry_point,
-            "--verb",
-            env["PROTON_VERB"],
-            "--",
+            *entry_point,
             proton,
             env["PROTON_VERB"],
             env["EXE"],
@@ -329,7 +340,7 @@ def build_command(
     # Ideally, for reliability, executables should be compiled within
     # the Steam Runtime
     if env.get("UMU_NO_PROTON") == "1":
-        return (entry_point, "--verb", env["PROTON_VERB"], "--", env["EXE"], *opts)
+        return *entry_point, env["EXE"], *opts
 
     # Will run the game outside the Steam Runtime w/ Proton
     if env.get("UMU_NO_RUNTIME") == "1":
@@ -337,10 +348,7 @@ def build_command(
         return proton, env["PROTON_VERB"], env["EXE"], *opts
 
     return (
-        entry_point,
-        "--verb",
-        env["PROTON_VERB"],
-        "--",
+        *entry_point,
         shim,
         proton,
         env["PROTON_VERB"],
@@ -703,6 +711,9 @@ def resolve_umu_version(runtimes: tuple[RuntimeVersion, ...]) -> RuntimeVersion 
     path = Path(os.environ["PROTONPATH"], "toolmanifest.vdf").resolve()
     if path.is_file():
         version = get_umu_version_from_manifest(path, runtimes)
+    else:
+        err: str = f"PROTONPATH '{os.environ['PROTONPATH']}' is not valid, toolmanifest.vdf not found"
+        raise FileNotFoundError(err)
 
     return version
 
@@ -724,7 +735,7 @@ def get_umu_version_from_manifest(
                 break
 
     if not appid:
-        return None
+        return "host", "host", "host"
 
     if appid not in set(filter(None, appids)):
         return None
@@ -812,6 +823,12 @@ def umu_run(args: Namespace | tuple[str, list[str]]) -> int:
         )
         raise RuntimeError(err)
 
+    if isinstance(args, Namespace):
+        env, opts = set_env_toml(env, args)
+        os.environ.update({k: v for k, v in env.items() if bool(v)})
+    else:
+        opts = args[1]  # Reference the executable options
+
     # Resolve the runtime version for PROTONPATH
     version = resolve_umu_version(__runtime_versions__)
     if not version:
@@ -849,6 +866,9 @@ def umu_run(args: Namespace | tuple[str, list[str]]) -> int:
     else:
         timeouts = NET_TIMEOUT
 
+    # ensure base directory exists
+    UMU_LOCAL.mkdir(parents=True, exist_ok=True)
+
     thread_pool = ThreadPoolExecutor()
     http_pool = PoolManager(
         timeout=Timeout(connect=timeouts, read=timeouts),
@@ -858,17 +878,29 @@ def umu_run(args: Namespace | tuple[str, list[str]]) -> int:
         session_pools: tuple[ThreadPoolExecutor, PoolManager] = (thread_pool, http_pool)
 
         # Setup the launcher and runtime files
-        future: Future = thread_pool.submit(
-            setup_umu, UMU_LOCAL / version[1], version, session_pools
-        )
+        _, do_download = check_env(env)
 
-        if isinstance(args, Namespace):
-            env, opts = set_env_toml(env, args)
-        else:
-            opts = args[1]  # Reference the executable options
-            check_env(env, session_pools)
+        if version[1] != "host":
+            UMU_LOCAL.joinpath(version[1]).mkdir(parents=True, exist_ok=True)
 
-        UMU_LOCAL.joinpath(version[1]).mkdir(parents=True, exist_ok=True)
+            future: Future = thread_pool.submit(
+                setup_umu, UMU_LOCAL / version[1], version, session_pools
+            )
+
+            download_proton(do_download, env, session_pools)
+
+            try:
+                future.result()
+            except HTTPError as e:
+                if not has_umu_setup():
+                    err: str = (
+                        "umu has not been setup for the user\n"
+                        "An internet connection is required to setup umu"
+                    )
+                    raise RuntimeError(err)
+                log.debug(e)
+            except Exception as e:
+                log.exception(e)
 
         # Prepare the prefix
         with unix_flock(f"{UMU_LOCAL}/{FileLock.Prefix.value}"):
@@ -877,24 +909,15 @@ def umu_run(args: Namespace | tuple[str, list[str]]) -> int:
         # Configure the environment
         set_env(env, args)
 
+        # Restore shim if missing
+        if not UMU_LOCAL.joinpath("umu-shim").is_file():
+            create_shim(UMU_LOCAL / "umu-shim")
+
         # Set all environment variables
         # NOTE: `env` after this block should be read only
         for key, val in env.items():
             log.debug("%s=%s", key, val)
             os.environ[key] = val
-
-        try:
-            future.result()
-        except HTTPError as e:
-            if not has_umu_setup():
-                err: str = (
-                    "umu has not been setup for the user\n"
-                    "An internet connection is required to setup umu"
-                )
-                raise RuntimeError(err)
-            log.debug(e)
-        except Exception as e:
-            log.exception(e)
 
     # Exit if the winetricks verb is already installed to avoid reapplying it
     if env["EXE"].endswith("winetricks") and is_installed_verb(
@@ -903,7 +926,7 @@ def umu_run(args: Namespace | tuple[str, list[str]]) -> int:
         sys.exit(1)
 
     # Build the command
-    command: tuple[Path | str, ...] = build_command(env, UMU_LOCAL / version[1], opts)
+    command: tuple[Path | str, ...] = build_command(env, UMU_LOCAL, version[1], opts)
     log.debug("%s", command)
 
     # Run the command

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -733,7 +733,10 @@ def get_umu_version_from_manifest(
 
     if not appid:
         if os.environ.get("UMU_NO_RUNTIME", None) == "1":
-            log.warning("Runtime Platform disabled")
+            log.warning(
+                "Runtime Platform disabled. This mode is UNSUPPORTED by umu and remains only for convenience. "
+                "Issues created while using this mode will be automatically closed."
+            )
             return "host", "host", "host"
         return None
 

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -138,7 +138,7 @@ def check_env(env: dict[str, str]) -> tuple[dict[str, str] | dict[str, Any], boo
 
     # Proton Codename
     if os.environ.get("PROTONPATH") in {
-        "GE-Proton", "GE-Latest", "UMU-Latest", "umu-scout", "umu-soldier", "umu-sniper"
+        "GE-Proton", "GE-Latest", "UMU-Latest", "umu-scout", "umu-soldier", "umu-sniper", "umu-steamrt4"
     }:
         do_download = True
 
@@ -688,6 +688,7 @@ def resolve_runtime() -> RuntimeVersion | None:
         os.environ["PROTONPATH"] = "UMU-Latest"
 
     named_runtimes = {
+        RUNTIME_NAMES["steamrt4"]: {"umu-steamrt4"},
         RUNTIME_NAMES["sniper"]: {"GE-Proton", "GE-Latest", "UMU-Latest", "umu-sniper"},
         RUNTIME_NAMES["soldier"]: {"umu-scout", "umu-soldier"},
     }

--- a/umu/umu_runtime.py
+++ b/umu/umu_runtime.py
@@ -442,6 +442,7 @@ class UmuRuntime:
         """Return if the runtime's path has been populated."""
         return self.path.is_dir() and self.path.joinpath("mtree.txt.gz").is_file()
 
+
 RUNTIME_VERSIONS = {
     "host":    UmuRuntime("host",    ""        ),
     "1070560": UmuRuntime("scout",   "steamrt1"),
@@ -467,6 +468,7 @@ class CompatLayer:
             if self.required_tool_appid is not None
             else None
         )
+
         _path = Path(path)
         if _path.joinpath("compatibilitytool.vdf").exists():
             with _path.joinpath("compatibilitytool.vdf").open(encoding="utf-8") as f:
@@ -507,19 +509,18 @@ class CompatLayer:
         """Return the tool specific entry point."""
         tool_path = os.path.normpath(self.tool_path)
         cmd = "".join([shlex.quote(tool_path), self.tool_manifest["commandline"]])
-        # # Temporary override for backwards compatibility
-        # if self.tool_path == str(UMU_LOCAL):
-        #     cmd = cmd.replace("_v2-entry-point", "umu")
+        # Temporary override entry point for backwards compatibility
+        if self.layer_name in {"container-runtime"}:
+            cmd = cmd.replace("_v2-entry-point", "umu")
         cmd = cmd.replace("%verb%", verb)
-        cmd = shlex.split(cmd)
-        return cmd
+        return shlex.split(cmd)
 
     def command(self, verb: str) -> list[str]:
         """Return the fully qualified command for the runtime.
 
         If the runtime uses another runtime, its entry point is prepended to the local command.
         """
-        log.info("Running '%s' using runtime '%s'", self.display_name, self.required_runtime.name)
+        log.info("Running '%s' using runtime on '%s'", self.display_name, self.required_runtime.name)
         cmd = self.runtime.command(verb) if self.runtime is not None else []
         target = self._command(verb)
         if self.layer_name in {"container-runtime"}:
@@ -532,3 +533,4 @@ class CompatLayer:
 
     def as_str(self, verb: str):  # noqa: D102
         return " ".join(map(shlex.quote, self.command(verb)))
+

--- a/umu/umu_runtime.py
+++ b/umu/umu_runtime.py
@@ -452,7 +452,7 @@ RUNTIME_VERSIONS = {
     "host":    UmuRuntime("host",    ""        , ""   ),
     "1391110": UmuRuntime("soldier", "steamrt2", "1391110"),
     "1628350": UmuRuntime("sniper",  "steamrt3", "1628350"),
-    # ""       : UmuRuntime("medic",   "steamrt4"),
+    "4183110": UmuRuntime("steamrt4","steamrt4", "4183110"),
 }
 
 

--- a/umu/umu_runtime.py
+++ b/umu/umu_runtime.py
@@ -496,9 +496,9 @@ class CompatLayer:
         return RUNTIME_VERSIONS[self.required_tool_appid]
 
     @property
-    def layer_name(self) -> str | None:  # noqa: D102
-        layer_name = str(ret) if (ret := self.tool_manifest.get("compatmanager_layer_name")) else None
-        if layer_name == "umu-passthrough":
+    def layer_name(self) -> str:  # noqa: D102
+        layer_name = str(ret) if (ret := self.tool_manifest.get("compatmanager_layer_name")) else ""
+        if layer_name == "umu-passthrough" and self.runtime is not None:
             layer_name = self.runtime.tool_manifest.get("compatmanager_layer_name")
         return layer_name
 

--- a/umu/umu_runtime.py
+++ b/umu/umu_runtime.py
@@ -226,7 +226,6 @@ def _install_umu(
         finally:
             log.debug("Linking: umu -> _v2-entry-point")
             local.joinpath("umu").symlink_to("_v2-entry-point")
-            create_shim(local.joinpath("umu-shim"))
 
 
 def setup_umu(
@@ -329,10 +328,6 @@ def _update_umu(
 
     # Update our runtime
     _update_umu_platform(local, runtime_ver, session_pools, resp)
-
-    # Restore shim if missing
-    if not local.joinpath("umu-shim").is_file():
-        create_shim(local / "umu-shim")
 
     log.info("%s is up to date", variant)
 

--- a/umu/umu_runtime.py
+++ b/umu/umu_runtime.py
@@ -497,7 +497,10 @@ class CompatLayer:
 
     @property
     def layer_name(self) -> str | None:  # noqa: D102
-        return str(ret) if (ret := self.tool_manifest.get("compatmanager_layer_name")) else None
+        layer_name = str(ret) if (ret := self.tool_manifest.get("compatmanager_layer_name")) else None
+        if layer_name == "umu-passthrough":
+            layer_name = self.runtime.tool_manifest.get("compatmanager_layer_name")
+        return layer_name
 
     @property
     def is_proton(self) -> bool:  # noqa: D102

--- a/umu/umu_runtime.py
+++ b/umu/umu_runtime.py
@@ -503,6 +503,15 @@ class CompatLayer:
         return layer_name
 
     @property
+    def launch_client(self) -> str | None:
+        """Expose pv's launch-client path depending on the tool's container runtime."""
+        if self.tool_manifest.get("compatmanager_layer_name") == "container-runtime":
+            return f"{self.tool_path}/pressure-vessel/bin/steam-runtime-launch-client"
+        if self.runtime:
+            return self.runtime.launch_client
+        return None
+
+    @property
     def is_proton(self) -> bool:  # noqa: D102
         return self.layer_name == "proton"
 

--- a/umu/umu_test.py
+++ b/umu/umu_test.py
@@ -2565,7 +2565,7 @@ class TestGameLauncher(unittest.TestCase):
             os.environ["GAMEID"] = self.test_file
             os.environ["STORE"] = self.test_file
             os.environ["UMU_NO_RUNTIME"] = "1"
-            version = umu_run.resolve_umu_version(self.test_runtime_versions)
+            version = umu_run.resolve_runtime(self.test_runtime_versions)
             os.environ["RUNTIMEPATH"] = version[1]
             # Args
             result_args = __main__.parse_args()
@@ -2665,7 +2665,7 @@ class TestGameLauncher(unittest.TestCase):
             os.environ["GAMEID"] = self.test_file
             os.environ["STORE"] = self.test_file
             os.environ["UMU_NO_RUNTIME"] = "1"
-            version = umu_run.resolve_umu_version(self.test_runtime_versions)
+            version = umu_run.resolve_runtime(self.test_runtime_versions)
             os.environ["RUNTIMEPATH"] = version[1]
             # Args
             result_args = __main__.parse_args()

--- a/umu/umu_test.py
+++ b/umu/umu_test.py
@@ -2571,7 +2571,7 @@ class TestGameLauncher(unittest.TestCase):
             result_args = __main__.parse_args()
             # Config
             _, result_dl = umu_run.check_env(self.env)
-            if version[1] != "host":
+            if version[1]:
                 umu_run.download_proton(result_dl, self.env, thread_pool)
             # Prefix
             umu_run.setup_pfx(self.env["WINEPREFIX"])
@@ -2671,7 +2671,7 @@ class TestGameLauncher(unittest.TestCase):
             result_args = __main__.parse_args()
             # Config
             _, result_dl = umu_run.check_env(self.env)
-            if version[1] != "host":
+            if version[1]:
                 umu_run.download_proton(result_dl, self.env, thread_pool)
             # Prefix
             umu_run.setup_pfx(self.env["WINEPREFIX"])

--- a/umu/umu_test.py
+++ b/umu/umu_test.py
@@ -1893,7 +1893,8 @@ class TestGameLauncher(unittest.TestCase):
             os.environ["WINEPREFIX"] = self.test_file
             os.environ["GAMEID"] = self.test_file
             os.environ["PROTONPATH"] = "GE-Proton"
-            umu_run.check_env(self.env, self.test_session_pools)
+            result_env, result_dl = umu_run.check_env(self.env)
+            umu_run.download_proton(result_dl, result_env, self.test_session_pools)
             self.assertEqual(
                 self.env["PROTONPATH"],
                 self.test_compat.joinpath(
@@ -1920,7 +1921,8 @@ class TestGameLauncher(unittest.TestCase):
             os.environ["WINEPREFIX"] = self.test_file
             os.environ["GAMEID"] = self.test_file
             os.environ["PROTONPATH"] = "GE-Proton"
-            umu_run.check_env(self.env, mock_session_pools)
+            result_env, result_dl = umu_run.check_env(self.env)
+            umu_run.download_proton(result_dl, result_env, mock_session_pools)
             self.assertFalse(os.environ.get("PROTONPATH"), "Expected empty string")
 
     def test_latest_interrupt(self):
@@ -2219,7 +2221,7 @@ class TestGameLauncher(unittest.TestCase):
             # Args
             args = __main__.parse_args()
             # Config
-            umu_run.check_env(self.env, self.test_session_pools)
+            result_env, result_dl = umu_run.check_env(self.env)
             # Prefix
             umu_run.setup_pfx(self.env["WINEPREFIX"])
             # Env
@@ -2283,7 +2285,8 @@ class TestGameLauncher(unittest.TestCase):
             # Args
             args = __main__.parse_args()
             # Config
-            umu_run.check_env(self.env, thread_pool)
+            result_env, result_dl = umu_run.check_env(self.env)
+            umu_run.download_proton(result_dl, result_env, thread_pool)
             # Prefix
             umu_run.setup_pfx(self.env["WINEPREFIX"])
             # Env
@@ -2380,7 +2383,8 @@ class TestGameLauncher(unittest.TestCase):
             # Args
             args = __main__.parse_args()
             # Config
-            umu_run.check_env(self.env, thread_pool)
+            result_env, result_dl = umu_run.check_env(self.env)
+            umu_run.download_proton(result_dl, result_env, thread_pool)
             # Prefix
             umu_run.setup_pfx(self.env["WINEPREFIX"])
             # Env
@@ -2460,7 +2464,8 @@ class TestGameLauncher(unittest.TestCase):
             # Args
             result_args = __main__.parse_args()
             # Config
-            umu_run.check_env(self.env, thread_pool)
+            result_env, result_dl = umu_run.check_env(self.env)
+            umu_run.download_proton(result_dl, result_env, thread_pool)
             # Prefix
             umu_run.setup_pfx(self.env["WINEPREFIX"])
             # Env
@@ -2499,7 +2504,7 @@ class TestGameLauncher(unittest.TestCase):
             )
 
         # Build
-        test_command = umu_run.build_command(self.env, self.test_local_share)
+        test_command = umu_run.build_command(self.env, self.test_local_share_parent, self.test_runtime_version[1])
         self.assertIsInstance(
             test_command, tuple, "Expected a tuple from build_command"
         )
@@ -2547,7 +2552,8 @@ class TestGameLauncher(unittest.TestCase):
             # Args
             result_args = __main__.parse_args()
             # Config
-            umu_run.check_env(self.env, thread_pool)
+            result_env, result_dl = umu_run.check_env(self.env)
+            umu_run.download_proton(result_dl, result_env, thread_pool)
             # Prefix
             umu_run.setup_pfx(self.env["WINEPREFIX"])
             # Env
@@ -2586,7 +2592,7 @@ class TestGameLauncher(unittest.TestCase):
         os.environ |= self.env
 
         # Build
-        test_command = umu_run.build_command(self.env, self.test_local_share)
+        test_command = umu_run.build_command(self.env, self.test_local_share_parent, self.test_runtime_version[1])
         self.assertIsInstance(
             test_command, tuple, "Expected a tuple from build_command"
         )
@@ -2625,7 +2631,8 @@ class TestGameLauncher(unittest.TestCase):
             # Args
             result_args = __main__.parse_args()
             # Config
-            umu_run.check_env(self.env, thread_pool)
+            result_env, result_dl = umu_run.check_env(self.env)
+            umu_run.download_proton(result_dl, result_env, thread_pool)
             # Prefix
             umu_run.setup_pfx(self.env["WINEPREFIX"])
             # Env
@@ -2640,7 +2647,7 @@ class TestGameLauncher(unittest.TestCase):
 
         # Since we didn't create the proton file, an exception should be raised
         with self.assertRaises(FileNotFoundError):
-            umu_run.build_command(self.env, self.test_local_share)
+            umu_run.build_command(self.env, self.test_local_share, self.test_runtime_version[1])
 
     def test_build_command(self):
         """Test build command.
@@ -2658,7 +2665,7 @@ class TestGameLauncher(unittest.TestCase):
         Path(self.test_file, "proton").touch()
 
         # Mock the shim file
-        shim_path = Path(self.test_local_share, "umu-shim")
+        shim_path = Path(self.test_local_share_parent, "umu-shim")
         shim_path.touch()
 
         with (
@@ -2673,7 +2680,8 @@ class TestGameLauncher(unittest.TestCase):
             # Args
             result_args = __main__.parse_args()
             # Config
-            umu_run.check_env(self.env, thread_pool)
+            result_env, result_dl = umu_run.check_env(self.env)
+            umu_run.download_proton(result_dl, result_env, thread_pool)
             # Prefix
             umu_run.setup_pfx(self.env["WINEPREFIX"])
             # Env
@@ -2713,7 +2721,7 @@ class TestGameLauncher(unittest.TestCase):
             )
 
         # Build
-        test_command = umu_run.build_command(self.env, self.test_local_share)
+        test_command = umu_run.build_command(self.env, self.test_local_share_parent, self.test_runtime_version[1])
         self.assertIsInstance(
             test_command, tuple, "Expected a tuple from build_command"
         )
@@ -2765,7 +2773,8 @@ class TestGameLauncher(unittest.TestCase):
             # Args
             result = __main__.parse_args()
             # Check
-            umu_run.check_env(self.env, thread_pool)
+            result_env, result_dl = umu_run.check_env(self.env)
+            umu_run.download_proton(result_dl, result_env, thread_pool)
             # Prefix
             umu_run.setup_pfx(self.env["WINEPREFIX"])
 
@@ -2846,7 +2855,8 @@ class TestGameLauncher(unittest.TestCase):
             # Args
             result = __main__.parse_args()
             # Check
-            umu_run.check_env(self.env, thread_pool)
+            result_env, result_dl = umu_run.check_env(self.env)
+            umu_run.download_proton(result_dl, result_env, thread_pool)
             # Prefix
             umu_run.setup_pfx(self.env["WINEPREFIX"])
             # Env
@@ -2954,7 +2964,8 @@ class TestGameLauncher(unittest.TestCase):
             # Args
             result = __main__.parse_args()
             # Check
-            umu_run.check_env(self.env, thread_pool)
+            result_env, result_dl = umu_run.check_env(self.env)
+            umu_run.download_proton(result_dl, result_env, thread_pool)
             # Prefix
             umu_run.setup_pfx(self.env["WINEPREFIX"])
             # Env
@@ -3070,7 +3081,8 @@ class TestGameLauncher(unittest.TestCase):
             # Args
             result = __main__.parse_args()
             # Check
-            umu_run.check_env(self.env, thread_pool)
+            result_env, result_dl = umu_run.check_env(self.env)
+            umu_run.download_proton(result_dl, result_env, thread_pool)
             # Prefix
             umu_run.setup_pfx(self.env["WINEPREFIX"])
             # Env
@@ -3200,7 +3212,8 @@ class TestGameLauncher(unittest.TestCase):
             # Args
             result = __main__.parse_args()
             # Check
-            umu_run.check_env(self.env, thread_pool)
+            result_env, result_dl = umu_run.check_env(self.env)
+            umu_run.download_proton(result_dl, result_env, thread_pool)
             # Prefix
             umu_run.setup_pfx(self.env["WINEPREFIX"])
             # Env
@@ -3684,12 +3697,11 @@ class TestGameLauncher(unittest.TestCase):
         Expects the directory $HOME/Games/umu/$GAMEID to not be created
         when UMU_NO_PROTON=1 and GAMEID is set in the host environment.
         """
-        result = None
+        result_env, result_dl = None, None
         # Mock $HOME
         mock_home = Path(self.test_file)
 
         with (
-            ThreadPoolExecutor() as thread_pool,
             # Mock the internal call to Path.home(). Otherwise, some of our
             # assertions may fail when running this test suite locally if
             # the user already has that dir
@@ -3697,8 +3709,8 @@ class TestGameLauncher(unittest.TestCase):
         ):
             os.environ["UMU_NO_PROTON"] = "1"
             os.environ["GAMEID"] = "foo"
-            result = umu_run.check_env(self.env, thread_pool)
-            self.assertTrue(result is self.env)
+            result_env, result_dl = umu_run.check_env(self.env)
+            self.assertTrue(result_env is self.env)
             path = mock_home.joinpath("Games", "umu", os.environ["GAMEID"])
             # Ensure we did not create the target nor its parents up to $HOME
             self.assertFalse(path.exists(), f"Expected {path} to not exist")
@@ -3717,20 +3729,17 @@ class TestGameLauncher(unittest.TestCase):
         Expects the WINE prefix directory to not be created when
         UMU_NO_PROTON=1 and WINEPREFIX is set in the host environment.
         """
-        result = None
+        result_env, result_dl = None, None
 
-        with (
-            ThreadPoolExecutor() as thread_pool,
-        ):
-            os.environ["WINEPREFIX"] = "123"
-            os.environ["UMU_NO_PROTON"] = "1"
-            os.environ["GAMEID"] = "foo"
-            result = umu_run.check_env(self.env, thread_pool)
-            self.assertTrue(result is self.env)
-            self.assertFalse(
-                Path(os.environ["WINEPREFIX"]).exists(),
-                f"Expected directory {os.environ['WINEPREFIX']} to not exist",
-            )
+        os.environ["WINEPREFIX"] = "123"
+        os.environ["UMU_NO_PROTON"] = "1"
+        os.environ["GAMEID"] = "foo"
+        result_env, result_dl = umu_run.check_env(self.env)
+        self.assertTrue(result_env is self.env)
+        self.assertFalse(
+            Path(os.environ["WINEPREFIX"]).exists(),
+            f"Expected directory {os.environ['WINEPREFIX']} to not exist",
+        )
 
     def test_env_proton_nodir(self):
         """Test check_env when $PROTONPATH in the case we failed to set it.
@@ -3745,7 +3754,8 @@ class TestGameLauncher(unittest.TestCase):
         ):
             os.environ["WINEPREFIX"] = self.test_file
             os.environ["GAMEID"] = self.test_file
-            umu_run.check_env(self.env, thread_pool)
+            result_env, result_dl = umu_run.check_env(self.env)
+            umu_run.download_proton(result_dl, result_env, thread_pool)
 
     def test_env_wine_empty(self):
         """Test check_env when $WINEPREFIX is empty.
@@ -3761,7 +3771,8 @@ class TestGameLauncher(unittest.TestCase):
         ):
             os.environ["WINEPREFIX"] = ""
             os.environ["GAMEID"] = self.test_file
-            umu_run.check_env(self.env, thread_pool)
+            result_env, result_dl = umu_run.check_env(self.env)
+            umu_run.download_proton(result_dl, result_env, thread_pool)
 
     def test_env_gameid_empty(self):
         """Test check_env when $GAMEID is empty.
@@ -3777,7 +3788,8 @@ class TestGameLauncher(unittest.TestCase):
         ):
             os.environ["WINEPREFIX"] = ""
             os.environ["GAMEID"] = ""
-            umu_run.check_env(self.env, thread_pool)
+            result_env, result_dl = umu_run.check_env(self.env)
+            umu_run.download_proton(result_dl, result_env, thread_pool)
 
     def test_env_wine_dir(self):
         """Test check_env when $WINEPREFIX is not a directory.
@@ -3798,7 +3810,8 @@ class TestGameLauncher(unittest.TestCase):
         )
 
         with ThreadPoolExecutor() as thread_pool:
-            umu_run.check_env(self.env, thread_pool)
+            result_env, result_dl = umu_run.check_env(self.env)
+            umu_run.download_proton(result_dl, result_env, thread_pool)
 
         # After this, the WINEPREFIX and new dirs should be created
         self.assertTrue(
@@ -3827,15 +3840,16 @@ class TestGameLauncher(unittest.TestCase):
             path_to_tmp,
         )
 
-        result = None
+        result_env, result_dl = None, None
         os.environ["WINEPREFIX"] = unexpanded_path
         os.environ["GAMEID"] = self.test_file
         os.environ["PROTONPATH"] = unexpanded_path
 
         with ThreadPoolExecutor() as thread_pool:
-            result = umu_run.check_env(self.env, thread_pool)
+            result_env, result_dl = umu_run.check_env(self.env)
+            umu_run.download_proton(result_dl, result_env, thread_pool)
 
-        self.assertTrue(result is self.env, "Expected the same reference")
+        self.assertTrue(result_env is self.env, "Expected the same reference")
         self.assertEqual(
             self.env["WINEPREFIX"],
             unexpanded_path,
@@ -3852,15 +3866,16 @@ class TestGameLauncher(unittest.TestCase):
 
     def test_env_vars(self):
         """Test check_env when setting $WINEPREFIX, $GAMEID and $PROTONPATH."""
-        result = None
+        result_env, result_dl = None, None
         os.environ["WINEPREFIX"] = self.test_file
         os.environ["GAMEID"] = self.test_file
         os.environ["PROTONPATH"] = self.test_file
 
         with ThreadPoolExecutor() as thread_pool:
-            result = umu_run.check_env(self.env, thread_pool)
+            result_env, result_dl = umu_run.check_env(self.env)
+            umu_run.download_proton(result_dl, result_env, thread_pool)
 
-        self.assertTrue(result is self.env, "Expected the same reference")
+        self.assertTrue(result_env is self.env, "Expected the same reference")
         self.assertEqual(
             self.env["WINEPREFIX"],
             self.test_file,
@@ -3891,8 +3906,9 @@ class TestGameLauncher(unittest.TestCase):
             ):
                 os.environ["WINEPREFIX"] = self.test_file
                 os.environ["GAMEID"] = self.test_file
-                result = umu_run.check_env(self.env, thread_pool)
-                self.assertTrue(result is self.env, "Expected the same reference")
+                result_env, result_dl = umu_run.check_env(self.env)
+                umu_run.download_proton(result_dl, result_env, thread_pool)
+                self.assertTrue(result_env is self.env, "Expected the same reference")
                 self.assertFalse(os.environ["PROTONPATH"])
 
     def test_env_vars_wine(self):
@@ -3900,7 +3916,7 @@ class TestGameLauncher(unittest.TestCase):
 
         Expects GAMEID and PROTONPATH to be set for the command line:
         """
-        result = None
+        result_env, result_dl = None, None
         mock_gameid = "umu-default"
         mock_protonpath = str(self.test_proton_dir)
 
@@ -3913,8 +3929,8 @@ class TestGameLauncher(unittest.TestCase):
         # and the GAMEID is 'umu-default'
         with patch.object(umu_run, "get_umu_proton", new_callable=mock_get_umu_proton):
             os.environ["WINEPREFIX"] = self.test_file
-            result = umu_run.check_env(self.env, self.test_session_pools)
-            self.assertTrue(result, self.env)
+            result_env, result_dl = umu_run.check_env(self.env)
+            self.assertTrue(result_env, self.env)
             self.assertEqual(os.environ["GAMEID"], mock_gameid)
             self.assertEqual(os.environ["GAMEID"], self.env["GAMEID"])
             self.assertEqual(os.environ["PROTONPATH"], mock_protonpath)
@@ -3928,7 +3944,7 @@ class TestGameLauncher(unittest.TestCase):
 
         Expects PROTONPATH, GAMEID, and WINEPREFIX to be set
         """
-        result = None
+        result_env, result_dl = None, None
         mock_gameid = "umu-default"
         mock_protonpath = str(self.test_proton_dir)
         mock_wineprefix = "/home/foo/Games/umu/umu-default"
@@ -3948,8 +3964,8 @@ class TestGameLauncher(unittest.TestCase):
             patch.object(umu_run, "get_umu_proton", new_callable=mock_get_umu_proton),
             patch.object(Path, "mkdir", return_value=mock_set_wineprefix()),
         ):
-            result = umu_run.check_env(self.env, self.test_session_pools)
-            self.assertTrue(result, self.env)
+            result_env, result_dl = umu_run.check_env(self.env)
+            self.assertTrue(result_env, self.env)
             self.assertEqual(os.environ["GAMEID"], mock_gameid)
             self.assertEqual(os.environ["GAMEID"], self.env["GAMEID"])
             self.assertEqual(os.environ["PROTONPATH"], mock_protonpath)

--- a/umu/umu_test.py
+++ b/umu/umu_test.py
@@ -99,10 +99,14 @@ class TestGameLauncher(unittest.TestCase):
         # /usr/share/umu
         self.test_user_share = Path("./tmp.BXk2NnvW2m")
         # ~/.local/share/Steam/compatibilitytools.d
-        self.test_runtime_version = ("sniper", "steamrt3", "1628350")
+        self.test_runtime_versions = (
+            ("sniper", "steamrt3", "1628350"),
+            ("soldier", "steamrt2", "1391110"),
+        )
+        self.test_runtime_default = self.test_runtime_versions[0]
         self.test_local_share_parent = Path("./tmp.aDl73CbQCP")
         self.test_local_share = self.test_local_share_parent.joinpath(
-            self.test_runtime_version[1]
+            self.test_runtime_default[1]
         )
         # Wine prefix
         self.test_winepfx = Path("./tmp.AlfLPDhDvA")
@@ -1380,7 +1384,7 @@ class TestGameLauncher(unittest.TestCase):
         # Mock a new install
         with TemporaryDirectory() as file:
             # Populate our fake $XDG_DATA_HOME/umu
-            mock_subdir = Path(file, self.test_runtime_version[1])
+            mock_subdir = Path(file, self.test_runtime_default[1])
             mock_subdir.mkdir()
             mock_subdir.joinpath("umu").touch()
             # Mock the runtime ver
@@ -1403,7 +1407,7 @@ class TestGameLauncher(unittest.TestCase):
         # Mock a new install
         with TemporaryDirectory() as file:
             # Populate our fake $XDG_DATA_HOME/umu
-            mock_subdir = Path(file, self.test_runtime_version[1])
+            mock_subdir = Path(file, self.test_runtime_default[1])
             mock_subdir.mkdir()
             mock_subdir.joinpath("umu").touch()
             # Mock the runtime ver
@@ -1424,7 +1428,7 @@ class TestGameLauncher(unittest.TestCase):
 
         # Mock a new install
         with TemporaryDirectory() as file:
-            mock_subdir = Path(file, self.test_runtime_version[1])
+            mock_subdir = Path(file, self.test_runtime_default[1])
             mock_subdir.mkdir()
             mock_subdir.joinpath("umu").touch()
             # Mock the runtime ver
@@ -1755,7 +1759,7 @@ class TestGameLauncher(unittest.TestCase):
         """
         self.test_user_share.joinpath("pressure-vessel", "bin", "pv-verify").unlink()
         result = umu_runtime.check_runtime(
-            self.test_user_share, self.test_runtime_version
+            self.test_user_share, self.test_runtime_default
         )
         self.assertEqual(result, 1, "Expected the exit code 1")
 
@@ -1764,7 +1768,7 @@ class TestGameLauncher(unittest.TestCase):
         mock = CompletedProcess(["foo"], 0)
         with patch.object(umu_runtime, "run", return_value=mock):
             result = umu_runtime.check_runtime(
-                self.test_user_share, self.test_runtime_version
+                self.test_user_share, self.test_runtime_default
             )
             self.assertEqual(result, 0, "Expected the exit code 0")
 
@@ -1782,7 +1786,7 @@ class TestGameLauncher(unittest.TestCase):
         mock = CompletedProcess(["foo"], 1)
         with patch.object(umu_runtime, "run", return_value=mock):
             result = umu_runtime.check_runtime(
-                self.test_user_share, self.test_runtime_version
+                self.test_user_share, self.test_runtime_default
             )
             self.assertEqual(result, 1, "Expected the exit code 1")
 
@@ -2217,7 +2221,7 @@ class TestGameLauncher(unittest.TestCase):
             os.environ["PROTONPATH"] = self.test_file
             os.environ["GAMEID"] = self.test_file
             os.environ["STORE"] = self.test_file
-            os.environ["RUNTIMEPATH"] = self.test_runtime_version[1]
+            os.environ["RUNTIMEPATH"] = self.test_runtime_default[1]
             # Args
             args = __main__.parse_args()
             # Config
@@ -2281,7 +2285,7 @@ class TestGameLauncher(unittest.TestCase):
             os.environ["PROTONPATH"] = self.test_file
             os.environ["GAMEID"] = self.test_file
             os.environ["STORE"] = self.test_file
-            os.environ["RUNTIMEPATH"] = self.test_runtime_version[1]
+            os.environ["RUNTIMEPATH"] = self.test_runtime_default[1]
             # Args
             args = __main__.parse_args()
             # Config
@@ -2379,7 +2383,7 @@ class TestGameLauncher(unittest.TestCase):
             os.environ["PROTONPATH"] = self.test_file
             os.environ["GAMEID"] = self.test_file
             os.environ["STORE"] = self.test_file
-            os.environ["RUNTIMEPATH"] = self.test_runtime_version[1]
+            os.environ["RUNTIMEPATH"] = self.test_runtime_default[1]
             # Args
             args = __main__.parse_args()
             # Config
@@ -2460,7 +2464,7 @@ class TestGameLauncher(unittest.TestCase):
             os.environ["GAMEID"] = self.test_file
             os.environ["STORE"] = self.test_file
             os.environ["UMU_NO_PROTON"] = "1"
-            os.environ["RUNTIMEPATH"] = self.test_runtime_version[1]
+            os.environ["RUNTIMEPATH"] = self.test_runtime_default[1]
             # Args
             result_args = __main__.parse_args()
             # Config
@@ -2481,7 +2485,7 @@ class TestGameLauncher(unittest.TestCase):
         ):
             umu_runtime.setup_umu(
                 self.test_local_share,
-                self.test_runtime_version,
+                self.test_runtime_default,
                 self.test_session_pools,
             )
             copytree(
@@ -2504,7 +2508,7 @@ class TestGameLauncher(unittest.TestCase):
             )
 
         # Build
-        test_command = umu_run.build_command(self.env, self.test_local_share_parent, self.test_runtime_version[1])
+        test_command = umu_run.build_command(self.env, self.test_local_share_parent, self.test_runtime_default[1])
         self.assertIsInstance(
             test_command, tuple, "Expected a tuple from build_command"
         )
@@ -2525,19 +2529,32 @@ class TestGameLauncher(unittest.TestCase):
         self.assertEqual(sep, "--", "Expected --")
         self.assertEqual(exe, self.env["EXE"], "Expected the EXE")
 
-    def test_build_command_nopv(self):
-        """Test build_command when disabling Pressure Vessel.
+    def test_build_command_nopv_appid(self):
+        """Test build_command when disabling Pressure Vessel but the tool requests a runtime.
 
-        UMU_NO_RUNTIME=1 disables Pressure Vessel, allowing
-        the launcher to run Proton on the host -- Flatpak environment.
+        UMU_NO_RUNTIME=1 disables Pressure Vessel, but the tool needs
+        a runtime, so use the correct runtime disregarding the env variable.
 
-        Expects the list to contain 3 string elements.
+        Expects the list to contain 8 string elements.
         """
         result_args = None
         test_command = []
 
         # Mock the proton file
         Path(self.test_file, "proton").touch()
+        # Mock a runtime toolmanifest.vdf
+        Path(self.test_file, "toolmanifest.vdf").write_text(
+            '''
+            "manifest"
+            {
+              "version" "2"
+              "commandline" "/proton %verb%"
+              "require_tool_appid" "1628350"
+              "use_sessions" "1"
+              "compatmanager_layer_name" "proton"
+            }
+            '''
+        )
 
         with (
             patch("sys.argv", ["", self.test_exe]),
@@ -2548,12 +2565,14 @@ class TestGameLauncher(unittest.TestCase):
             os.environ["GAMEID"] = self.test_file
             os.environ["STORE"] = self.test_file
             os.environ["UMU_NO_RUNTIME"] = "1"
-            os.environ["RUNTIMEPATH"] = self.test_runtime_version[1]
+            version = umu_run.resolve_umu_version(self.test_runtime_versions)
+            os.environ["RUNTIMEPATH"] = version[1]
             # Args
             result_args = __main__.parse_args()
             # Config
-            result_env, result_dl = umu_run.check_env(self.env)
-            umu_run.download_proton(result_dl, result_env, thread_pool)
+            _, result_dl = umu_run.check_env(self.env)
+            if version[1] != "host":
+                umu_run.download_proton(result_dl, self.env, thread_pool)
             # Prefix
             umu_run.setup_pfx(self.env["WINEPREFIX"])
             # Env
@@ -2567,7 +2586,7 @@ class TestGameLauncher(unittest.TestCase):
         ):
             umu_runtime.setup_umu(
                 self.test_local_share,
-                self.test_runtime_version,
+                self.test_runtime_default,
                 self.test_session_pools,
             )
             copytree(
@@ -2592,16 +2611,16 @@ class TestGameLauncher(unittest.TestCase):
         os.environ |= self.env
 
         # Build
-        test_command = umu_run.build_command(self.env, self.test_local_share_parent, self.test_runtime_version[1])
+        test_command = umu_run.build_command(self.env, self.test_local_share_parent, version[1])
         self.assertIsInstance(
             test_command, tuple, "Expected a tuple from build_command"
         )
         self.assertEqual(
             len(test_command),
-            3,
+            8,
             f"Expected 3 elements, received {len(test_command)}",
         )
-        proton, verb, exe, *_ = [*test_command]
+        _, _, verb, _, _, proton, _, exe = [*test_command]
         self.assertIsInstance(proton, os.PathLike, "Expected proton to be PathLike")
         self.assertEqual(
             proton,
@@ -2610,6 +2629,107 @@ class TestGameLauncher(unittest.TestCase):
         )
         self.assertEqual(verb, "waitforexitandrun", "Expected PROTON_VERB")
         self.assertEqual(exe, self.env["EXE"], "Expected EXE")
+
+    def test_build_command_nopv_noappid(self):
+        """Test build_command when disabling Pressure Vessel and the tool doesn't request a runtime.
+
+        UMU_NO_RUNTIME=1 disables Pressure Vessel, and the tool doesn't set
+        a runtime, allow the tool to run using the host's libraries as it expects.
+
+        Expects the list to contain 4 string elements.
+        """
+        result_args = None
+        test_command = []
+
+        # Mock the proton file
+        Path(self.test_file, "proton").touch()
+        # Mock a non-runtime toolmanifest.vdf
+        Path(self.test_file, "toolmanifest.vdf").write_text(
+            '''
+            "manifest"
+            {
+              "version" "2"
+              "commandline" "/proton %verb%"
+              "use_sessions" "1"
+              "compatmanager_layer_name" "proton"
+            }
+            '''
+        )
+
+        with (
+            patch("sys.argv", ["", self.test_exe]),
+            ThreadPoolExecutor() as thread_pool,
+        ):
+            os.environ["WINEPREFIX"] = self.test_file
+            os.environ["PROTONPATH"] = self.test_file
+            os.environ["GAMEID"] = self.test_file
+            os.environ["STORE"] = self.test_file
+            os.environ["UMU_NO_RUNTIME"] = "1"
+            version = umu_run.resolve_umu_version(self.test_runtime_versions)
+            os.environ["RUNTIMEPATH"] = version[1]
+            # Args
+            result_args = __main__.parse_args()
+            # Config
+            _, result_dl = umu_run.check_env(self.env)
+            if version[1] != "host":
+                umu_run.download_proton(result_dl, self.env, thread_pool)
+            # Prefix
+            umu_run.setup_pfx(self.env["WINEPREFIX"])
+            # Env
+            umu_run.set_env(self.env, result_args)
+            # Game drive
+            umu_run.enable_steam_game_drive(self.env)
+
+        # Mock setting up the runtime
+        with (
+            patch.object(umu_runtime, "_install_umu", return_value=None),
+        ):
+            umu_runtime.setup_umu(
+                self.test_local_share,
+                self.test_runtime_default,
+                self.test_session_pools,
+            )
+            copytree(
+                Path(self.test_user_share, "sniper_platform_0.20240125.75305"),
+                Path(self.test_local_share, "sniper_platform_0.20240125.75305"),
+                dirs_exist_ok=True,
+                symlinks=True,
+            )
+            copy(
+                Path(self.test_user_share, "run"),
+                Path(self.test_local_share, "run"),
+            )
+            copy(
+                Path(self.test_user_share, "run-in-sniper"),
+                Path(self.test_local_share, "run-in-sniper"),
+            )
+            copy(
+                Path(self.test_user_share, "umu"),
+                Path(self.test_local_share, "umu"),
+            )
+
+        os.environ |= self.env
+
+        # Build
+        test_command = umu_run.build_command(self.env, self.test_local_share_parent, version[1])
+        self.assertIsInstance(
+            test_command, tuple, "Expected a tuple from build_command"
+        )
+        self.assertEqual(
+            len(test_command),
+            4,
+            f"Expected 3 elements, received {len(test_command)}",
+        )
+        _, proton, verb, exe, *_ = [*test_command]
+        self.assertIsInstance(proton, os.PathLike, "Expected proton to be PathLike")
+        self.assertEqual(
+            proton,
+            Path(self.env["PROTONPATH"], "proton"),
+            "Expected PROTONPATH",
+        )
+        self.assertEqual(verb, "waitforexitandrun", "Expected PROTON_VERB")
+        self.assertEqual(exe, self.env["EXE"], "Expected EXE")
+
 
     def test_build_command_noproton(self):
         """Test build_command when $PROTONPATH/proton is not found.
@@ -2627,7 +2747,7 @@ class TestGameLauncher(unittest.TestCase):
             os.environ["GAMEID"] = self.test_file
             os.environ["STORE"] = self.test_file
             os.environ["UMU_NO_RUNTIME"] = "pressure-vessel"
-            os.environ["RUNTIMEPATH"] = self.test_runtime_version[1]
+            os.environ["RUNTIMEPATH"] = self.test_runtime_default[1]
             # Args
             result_args = __main__.parse_args()
             # Config
@@ -2647,7 +2767,7 @@ class TestGameLauncher(unittest.TestCase):
 
         # Since we didn't create the proton file, an exception should be raised
         with self.assertRaises(FileNotFoundError):
-            umu_run.build_command(self.env, self.test_local_share, self.test_runtime_version[1])
+            umu_run.build_command(self.env, self.test_local_share, self.test_runtime_default[1])
 
     def test_build_command(self):
         """Test build command.
@@ -2676,7 +2796,7 @@ class TestGameLauncher(unittest.TestCase):
             os.environ["PROTONPATH"] = self.test_file
             os.environ["GAMEID"] = self.test_file
             os.environ["STORE"] = self.test_file
-            os.environ["RUNTIMEPATH"] = self.test_runtime_version[1]
+            os.environ["RUNTIMEPATH"] = self.test_runtime_default[1]
             # Args
             result_args = __main__.parse_args()
             # Config
@@ -2698,7 +2818,7 @@ class TestGameLauncher(unittest.TestCase):
         ):
             umu_runtime.setup_umu(
                 self.test_local_share,
-                self.test_runtime_version,
+                self.test_runtime_default,
                 self.test_session_pools,
             )
             copytree(
@@ -2721,7 +2841,7 @@ class TestGameLauncher(unittest.TestCase):
             )
 
         # Build
-        test_command = umu_run.build_command(self.env, self.test_local_share_parent, self.test_runtime_version[1])
+        test_command = umu_run.build_command(self.env, self.test_local_share_parent, self.test_runtime_default[1])
         self.assertIsInstance(
             test_command, tuple, "Expected a tuple from build_command"
         )
@@ -2769,7 +2889,7 @@ class TestGameLauncher(unittest.TestCase):
             os.environ["GAMEID"] = test_str
             os.environ["STORE"] = test_str
             os.environ["PROTON_VERB"] = self.test_verb
-            os.environ["RUNTIMEPATH"] = self.test_runtime_version[1]
+            os.environ["RUNTIMEPATH"] = self.test_runtime_default[1]
             # Args
             result = __main__.parse_args()
             # Check
@@ -2851,7 +2971,7 @@ class TestGameLauncher(unittest.TestCase):
             os.environ["GAMEID"] = umu_id
             os.environ["STORE"] = test_str
             os.environ["PROTON_VERB"] = self.test_verb
-            os.environ["RUNTIMEPATH"] = self.test_runtime_version[1]
+            os.environ["RUNTIMEPATH"] = self.test_runtime_default[1]
             # Args
             result = __main__.parse_args()
             # Check
@@ -2929,7 +3049,7 @@ class TestGameLauncher(unittest.TestCase):
                 self.env["PROTONPATH"]
                 + ":"
                 + Path.home()
-                .joinpath(".local", "share", "umu", self.test_runtime_version[1])
+                .joinpath(".local", "share", "umu", self.test_runtime_default[1])
                 .as_posix(),
                 "Expected STEAM_COMPAT_TOOL_PATHS to be set",
             )
@@ -2960,7 +3080,7 @@ class TestGameLauncher(unittest.TestCase):
             os.environ["GAMEID"] = test_str
             os.environ["STORE"] = test_str
             os.environ["PROTON_VERB"] = self.test_verb
-            os.environ["RUNTIMEPATH"] = self.test_runtime_version[1]
+            os.environ["RUNTIMEPATH"] = self.test_runtime_default[1]
             # Args
             result = __main__.parse_args()
             # Check
@@ -3046,7 +3166,7 @@ class TestGameLauncher(unittest.TestCase):
                 self.env["PROTONPATH"]
                 + ":"
                 + Path.home()
-                .joinpath(".local", "share", "umu", self.test_runtime_version[1])
+                .joinpath(".local", "share", "umu", self.test_runtime_default[1])
                 .as_posix(),
                 "Expected STEAM_COMPAT_TOOL_PATHS to be set",
             )
@@ -3077,7 +3197,7 @@ class TestGameLauncher(unittest.TestCase):
             os.environ["STORE"] = test_str
             os.environ["PROTON_VERB"] = self.test_verb
             os.environ["UMU_RUNTIME_UPDATE"] = "0"
-            os.environ["RUNTIMEPATH"] = self.test_runtime_version[1]
+            os.environ["RUNTIMEPATH"] = self.test_runtime_default[1]
             # Args
             result = __main__.parse_args()
             # Check
@@ -3168,7 +3288,7 @@ class TestGameLauncher(unittest.TestCase):
                 self.env["PROTONPATH"]
                 + ":"
                 + Path.home()
-                .joinpath(".local", "share", "umu", self.test_runtime_version[1])
+                .joinpath(".local", "share", "umu", self.test_runtime_default[1])
                 .as_posix(),
                 "Expected STEAM_COMPAT_TOOL_PATHS to be set",
             )
@@ -3208,7 +3328,7 @@ class TestGameLauncher(unittest.TestCase):
             os.environ["PROTONPATH"] = test_dir.as_posix()
             os.environ["GAMEID"] = test_str
             os.environ["PROTON_VERB"] = proton_verb
-            os.environ["RUNTIMEPATH"] = self.test_runtime_version[1]
+            os.environ["RUNTIMEPATH"] = self.test_runtime_default[1]
             # Args
             result = __main__.parse_args()
             # Check
@@ -3298,7 +3418,7 @@ class TestGameLauncher(unittest.TestCase):
                 self.env["PROTONPATH"]
                 + ":"
                 + Path.home()
-                .joinpath(".local", "share", "umu", self.test_runtime_version[1])
+                .joinpath(".local", "share", "umu", self.test_runtime_default[1])
                 .as_posix(),
                 "Expected STEAM_COMPAT_TOOL_PATHS to be set",
             )

--- a/umu/umu_test_plugins.py
+++ b/umu/umu_test_plugins.py
@@ -64,11 +64,14 @@ class TestGameLauncherPlugins(unittest.TestCase):
         # /usr/share/umu
         self.test_user_share = Path("./tmp.jl3W4MtO57")
         # ~/.local/share/Steam/compatibilitytools.d
-        self.test_local_share = Path("./tmp.WUaQAk7hQJ")
         self.test_runtime_version = ("sniper", "steamrt3", "1628350")
+        self.test_local_share_parent = Path("./tmp.WUaQAk7hQJ")
+        self.test_local_share = self.test_local_share_parent.joinpath(
+            self.test_runtime_version[1]
+        )
 
         self.test_user_share.mkdir(exist_ok=True)
-        self.test_local_share.mkdir(exist_ok=True)
+        self.test_local_share.mkdir(parents=True, exist_ok=True)
         self.test_cache.mkdir(exist_ok=True)
         self.test_compat.mkdir(exist_ok=True)
         self.test_proton_dir.mkdir(exist_ok=True)
@@ -223,7 +226,7 @@ class TestGameLauncherPlugins(unittest.TestCase):
 
         # Build
         with self.assertRaisesRegex(FileNotFoundError, "_v2-entry-point"):
-            umu_run.build_command(self.env, self.test_local_share, test_command)
+            umu_run.build_command(self.env, self.test_local_share_parent, self.test_runtime_version[1], test_command)
 
     def test_build_command_proton(self):
         """Test build_command.
@@ -301,7 +304,7 @@ class TestGameLauncherPlugins(unittest.TestCase):
 
         # Build
         with self.assertRaisesRegex(FileNotFoundError, "proton"):
-            umu_run.build_command(self.env, self.test_local_share, test_command)
+            umu_run.build_command(self.env, self.test_local_share_parent, self.test_runtime_version[1], test_command)
 
     def test_build_command_toml(self):
         """Test build_command.
@@ -326,7 +329,7 @@ class TestGameLauncherPlugins(unittest.TestCase):
         Path(toml_path).touch()
 
         # Mock the shim file
-        shim_path = Path(self.test_local_share, "umu-shim")
+        shim_path = Path(self.test_local_share_parent, "umu-shim")
         shim_path.touch()
 
         with Path(toml_path).open(mode="w", encoding="utf-8") as file:
@@ -381,7 +384,7 @@ class TestGameLauncherPlugins(unittest.TestCase):
             os.environ[key] = val
 
         # Build
-        test_command = umu_run.build_command(self.env, self.test_local_share)
+        test_command = umu_run.build_command(self.env, self.test_local_share_parent, self.test_runtime_version[1])
 
         # Verify contents of the command
         entry_point, opt1, verb, opt2, shim, proton, verb2, exe = [*test_command]
@@ -619,23 +622,23 @@ class TestGameLauncherPlugins(unittest.TestCase):
             # prepare for building the command
             self.assertEqual(
                 self.env["EXE"],
-                unexpanded_exe,
-                "Expected path not to be expanded",
+                str(Path(unexpanded_exe).expanduser()),
+                "Expected path to be expanded",
             )
             self.assertEqual(
                 self.env["PROTONPATH"],
-                unexpanded_path,
-                "Expected path not to be expanded",
+                str(Path(unexpanded_path).expanduser()),
+                "Expected path to be expanded",
             )
             self.assertEqual(
                 self.env["WINEPREFIX"],
-                unexpanded_path,
-                "Expected path not to be expanded",
+                str(Path(unexpanded_path).expanduser()),
+                "Expected path to be expanded",
             )
             self.assertEqual(
                 self.env["GAMEID"],
                 unexpanded_path,
-                "Expectd path not to be expanded",
+                "Expected path to be expanded",
             )
 
     def test_set_env_toml_opts(self):
@@ -699,12 +702,12 @@ class TestGameLauncherPlugins(unittest.TestCase):
             self.assertTrue(self.env["EXE"], "Expected EXE to be set")
             self.assertEqual(
                 self.env["PROTONPATH"],
-                self.test_file,
+                str(Path(self.test_file).expanduser()),
                 "Expected PROTONPATH to be set",
             )
             self.assertEqual(
                 self.env["WINEPREFIX"],
-                self.test_file,
+                str(Path(self.test_file).expanduser()),
                 "Expected WINEPREFIX to be set",
             )
             self.assertEqual(
@@ -753,12 +756,12 @@ class TestGameLauncherPlugins(unittest.TestCase):
             self.assertTrue(self.env["EXE"], "Expected EXE to be set")
             self.assertEqual(
                 self.env["PROTONPATH"],
-                self.test_file,
+                str(Path(self.test_file).expanduser()),
                 "Expected PROTONPATH to be set",
             )
             self.assertEqual(
                 self.env["WINEPREFIX"],
-                self.test_file,
+                str(Path(self.test_file).expanduser()),
                 "Expected WINEPREFIX to be set",
             )
             self.assertEqual(


### PR DESCRIPTION
This PR aims to allow auto-configuration of compatibility tools other than Proton by using the information in `compatibilitytool.vdf` and `toolmanifest.vdf` manifest files. Using this information umu can construct the proper command for each tool based on which runtime the tool depends on (if at all), the entry point of the runtime and the tool, and the type of the tool (important for `winetricks` as it works only on proton). This supersedes environment variables such `UMU_NO_PROTON` (`PROTONPATH` remains as a way to set the tool with expanded meaning) and `UMU_NO_RUNTIME`. These variables are retained only to force a specific configuration if required.

* Important changes: 
  - `vdf` library is now a vendored dependency. It is a pure-python library and thus compatible with `zipapp`.
  - To run linux-native applications in the Steam runtimes, the meaning of `PROTONPATH` has been expanded. It now accepts the `umu-soldier/umu-sniper/umu-steamrt4` values which will run an application in the respective runtimes. This replaces umu's existing `RUNTIMEPATH` which can either be used to provide a path to an alternative (but compatible) runtime or directory of runtimes, or completely removed in the future. Ad-hoc runtime "up/downgrade", i.e. forcing `sniper` when a compat tool requests `soldier` should not be supported.
  - Added support for the [`umu-scout`](https://github.com/loathingKernel/umu-scout) compatibility tool. This is Steam's `scout-on-soldier` runtime pre-packaged to be used with umu-launcher. 
  - `UMU_NO_RUNTIME` is retained as an override if the user wants to explicitly disable the runtime even if the tool requires it. Tools that don't use the runtime do not require this to be set any more.
  - umu checks if the configured tool is a proton-derived tool when using winetricks and exits if it is isn't.
  - `umu-shim` is always prepended to the tool's command. I have not tested this extensively but it didn't cause issues while testing with various tools and protons under X11.
  - Uses `steam-runtime-launch-client` to enable the dbus interface exposed by container runtimes as described [here](https://gitlab.steamos.cloud/steamrt/steam-runtime-tools/-/blob/main/docs/slr-for-game-developers.md?ref_type=heads#inserting-debugging-commands-into-the-container) and re-enter it to run additional executables. The bus's "friendly" name is controlled by `STEAM_COMPAT_APP_ID` and is set to the md5 hash of the `WINEPREFIX` absolute path presently. How this interface is enabled depends on information provided by the compatibility tool's manifest.
  - Handles `SIGINT`/`SIGTERM` signals and relays them to the process tree of launched container/application. Terminating the container can also be achieved through the dbus interface mentioned above.

* Things to consider:
  - The `STEAM_COMPAT_APP_ID` controlling the predictable bus name depends solely on `WINEPREFIX` presently, but launching and application with another proton while the previous one is running, might lead to issues. One way to handle this would be to make it depend on a combination of both `WINERPEFIX` and `PROTONPATH`. This would make it hard to re-enter it using a runtime tool such as `umu-sniper` to run a Linux native application in the same container at the same time.
  - As mentioned, the termination signals are at this moment relayed to the child process tree. For things running in a container, this can also be achieved by using the dbus interface through `steam-runtime-launch-client --bus-name<name> --terminate` which would be my preferred method in the future.

* Examples: 
  - Scout-on-soldier: `GAMEID=0 WINEPREFIX=~/Wine/umu/ UMU_LOG=debug PROTONPATH=umu-scout umu-run xterm`
  - Sniper: `GAMEID=0 WINEPREFIX=~/Wine/umu/ UMU_LOG=debug PROTONPATH=umu-sniper umu-run xterm`
  - Luxtorpeda: `GAMEID=0 WINEPREFIX=~/Wine/umu/ UMU_LOG=debug PROTONPATH=luxtorpeda umu-run`

