### PR TITLE
docs(nix): pkgs.system -> pkgs.stdenv.hostPlatform.system

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ and in your `configuration.nix`
 let
   inherit (pkgs.stdenv.hostPlatform) system;
   umu = inputs.umu.packages.${system}.umu.override {
-    version = "${inputs.umu.shortRev}";
+    version = inputs.umu.shortRev;
     truststore = true;
   };
 in

--- a/README.md
+++ b/README.md
@@ -154,8 +154,14 @@ If you want to add umu-launcher as a flake add this to your inputs in `flake.nix
 and in your `configuration.nix`
 ```nix
 {inputs, pkgs, ... }:
+let
+  umu = inputs.umu.packages.${pkgs.stdenv.hostPlatform.system}.umu.override {
+    version = "${inputs.umu.shortRev}";
+    truststore = true;
+  };
+in
 {
-  environment.systemPackages = [  (inputs.umu.packages.${pkgs.stdenv.hostPlatform.system}.umu.override {version = "${inputs.umu.shortRev}"; truststore = true;})  ];
+  environment.systemPackages = [ umu ];
 }
 ```
 > truststore is an optional dependency that is enabled by default if you want to keep it that way you can remove the `truststore = true;` part

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ and in your `configuration.nix`
 ```nix
 {inputs, pkgs, ... }:
 {
-  environment.systemPackages = [  (inputs.umu.packages.${pkgs.system}.umu.override {version = "${inputs.umu.shortRev}"; truststore = true;})  ];
+  environment.systemPackages = [  (inputs.umu.packages.${pkgs.stdenv.hostPlatform.system}.umu.override {version = "${inputs.umu.shortRev}"; truststore = true;})  ];
 }
 ```
 > truststore is an optional dependency that is enabled by default if you want to keep it that way you can remove the `truststore = true;` part

--- a/README.md
+++ b/README.md
@@ -168,6 +168,24 @@ in
 > [!NOTE]
 > truststore is an optional dependency that is enabled by default if you want to keep it that way you can remove the `truststore = true;` part
 
+> [!NOTE]
+> The example above relies on having your flake's `inputs` passed through to your nixos configuration.
+> This can be done with `specialArgs` or `_module.args`, e.g:
+> ```nix
+> {
+>   # inputs omitted ...
+>
+>   # Assign a name to the input args using @inputs
+>   outputs = { self, nixpkgs, ... }@inputs: {
+>     nixosConfiurations."your-hostname" = nixpkgs.lib.nixosSystem {
+>       system = "x86_64-linux";
+>       specialArgs = { inherit self inputs; };
+>       # modules omitted ...
+>     };
+>   };
+> }
+> ```
+
 ## Contributing
 
 Contributions are welcome and appreciated. To get started, install [ruff](https://github.com/astral-sh/ruff) from your distribution and enable [ruff server](https://github.com/astral-sh/ruff/blob/main/crates/ruff_server/README.md) in your editor.

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ If you want to add umu-launcher as a flake add this to your inputs in `flake.nix
 ```nix
   inputs = {
     umu= {
-      url = "git+https://github.com/Open-Wine-Components/umu-launcher/?dir=packaging\/nix&submodules=1";
+      url = "github:Open-Wine-Components/umu-launcher?dir=packaging/nix";
       inputs.nixpkgs.follows = "nixpkgs";
     };
   }

--- a/README.md
+++ b/README.md
@@ -155,7 +155,8 @@ and in your `configuration.nix`
 ```nix
 {inputs, pkgs, ... }:
 let
-  umu = inputs.umu.packages.${pkgs.stdenv.hostPlatform.system}.umu.override {
+  inherit (pkgs.stdenv.hostPlatform) system;
+  umu = inputs.umu.packages.${system}.umu.override {
     version = "${inputs.umu.shortRev}";
     truststore = true;
   };

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ If there is any problem with the flake feel free to open a bug report and tag an
 If you want to add umu-launcher as a flake add this to your inputs in `flake.nix`
 ```nix
   inputs = {
-    umu= {
+    umu = {
       url = "github:Open-Wine-Components/umu-launcher?dir=packaging/nix";
       inputs.nixpkgs.follows = "nixpkgs";
     };

--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ in
   environment.systemPackages = [ umu ];
 }
 ```
+> [!NOTE]
 > truststore is an optional dependency that is enabled by default if you want to keep it that way you can remove the `truststore = true;` part
 
 ## Contributing


### PR DESCRIPTION
General improvements & expansions to the nix installation instructions. I've gone over the nix installation instructions and added a few minor cleanups and expansions, including:

`pkgs.system` is not generally recommended. It's usually better to explicitly using the "host platform" system from `pkgs.stdenv`.

This is required to support cross-compile, for example.

For example, we can use nix's preferred flakeref syntax instead of a `git+` URI.

Also, `pkgs.system` is soft-deprecated: for example, using `stdenv.hostPlatform` will allow configurations to be remote/cross compiled. Therefore I've switched the example to using this.

I tried to make things a little more readable using a `let-in` block.

I added a note that `inputs` must be manually passed from your flake to your nixos configuration eval.

I updated the existing note to use [github-flavoured markdown admonitions](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts).

Note: I've kept this as several very atomic commits so that it may be easier to review and/or drop any changes that are not wanted. Happy to squash some/all or leave as-is; please advise :upside_down_face: 

cc @beh-10257