### PR TITLE
fix: maintain previous py310 requirement

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -62,6 +62,7 @@ jobs:
           rm -rf "$HOME/.local/share/umu" "$HOME/.local/share/Steam/compatibilitytools.d"
       - name: Test configuration file
         run: |
+          uv venv --python 3.11
           source .venv/bin/activate
           sh tests/test_config.sh
           rm -rf "$HOME/.local/share/umu" "$HOME/Games/umu" "$HOME/.local/share/Steam/compatibilitytools.d" "$HOME/.cache/umu"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -34,7 +34,7 @@ jobs:
           shellcheck tests/*.sh
       - name: Setup venv
         run: |
-          uv venv --python 3.11
+          uv venv --python 3.10
       - name: Test steamrt install
         run: |
           source .venv/bin/activate

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     strategy:
       matrix:
-        version: ["3.11"]
+        version: ["3.10"]
 
     runs-on: ubuntu-latest
 
@@ -28,10 +28,10 @@ jobs:
           python3 -m pip install --upgrade pip uv mypy
       - name: Setup venv
         run: |
-          uv venv --python 3.11
+          uv venv --python 3.10
           source .venv/bin/activate
           uv pip install -r requirements.in
       - name: Check types with mypy
         run: |
           source .venv/bin/activate
-          mypy --python-version 3.11 .
+          mypy .

--- a/.github/workflows/umu-python.yml
+++ b/.github/workflows/umu-python.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         # tomllib requires Python 3.11
         # Ubuntu latest (Jammy) provides Python 3.10
-        version: ["3.11", "3.12", "3.13"]
+        version: ["3.10", "3.11", "3.12", "3.13"]
 
     runs-on: ubuntu-latest
 

--- a/umu/umu_consts.py
+++ b/umu/umu_consts.py
@@ -3,6 +3,32 @@ from enum import Enum
 from pathlib import Path
 
 
+# Copyright (c) 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010,
+# 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022, 2023
+# Python Software Foundation;
+# Source: https://raw.githubusercontent.com/python/cpython/refs/heads/3.11/Lib/http/__init__.py
+# License: https://raw.githubusercontent.com/python/cpython/refs/heads/3.11/LICENSE
+class HTTPMethod(Enum):
+    """HTTP methods and descriptions.
+
+    Methods from the following RFCs are all observed:
+
+        * RFF 9110: HTTP Semantics, obsoletes 7231, which obsoleted 2616
+        * RFC 5789: PATCH Method for HTTP
+
+    """
+
+    CONNECT = "CONNECT"
+    DELETE = "DELETE"
+    GET = "GET"
+    HEAD = "HEAD"
+    OPTIONS = "OPTIONS"
+    PATCH = "PATCH"
+    POST = "POST"
+    PUT = "PUT"
+    TRACE = "TRACE"
+
+
 class GamescopeAtom(Enum):
     """Represent Gamescope-specific X11 atom names."""
 

--- a/umu/umu_proton.py
+++ b/umu/umu_proton.py
@@ -1,7 +1,7 @@
 import os
 from concurrent.futures import Future, ThreadPoolExecutor
-from hashlib import file_digest, sha512
-from http import HTTPMethod, HTTPStatus
+from hashlib import sha512
+from http import HTTPStatus
 from pathlib import Path
 from re import split as resplit
 from shutil import move, rmtree
@@ -14,9 +14,14 @@ from urllib3.exceptions import TimeoutError as TimeoutErrorUrllib3
 from urllib3.poolmanager import PoolManager
 from urllib3.response import BaseHTTPResponse
 
-from umu.umu_consts import STEAM_COMPAT, UMU_CACHE, UMU_LOCAL
+from umu.umu_consts import STEAM_COMPAT, UMU_CACHE, UMU_LOCAL, HTTPMethod
 from umu.umu_log import log
-from umu.umu_util import extract_tarfile, run_zenity, write_file_chunks
+from umu.umu_util import (
+    extract_tarfile,
+    file_digest,
+    run_zenity,
+    write_file_chunks,
+)
 
 SessionPools = tuple[ThreadPoolExecutor, PoolManager]
 
@@ -95,7 +100,9 @@ def _fetch_releases(
     if os.environ.get("PROTONPATH") == "GE-Proton":
         repo = "/repos/GloriousEggroll/proton-ge-custom/releases/latest"
 
-    resp = http_pool.request(HTTPMethod.GET, f"{url}{repo}", headers=headers)
+    resp = http_pool.request(
+        HTTPMethod.GET.value, f"{url}{repo}", headers=headers
+    )
     if resp.status != HTTPStatus.OK:
         return ()
 
@@ -159,7 +166,7 @@ def _fetch_proton(
     # See https://github.com/astral-sh/ruff/issues/7918
     log.info("Downloading %s...", proton_hash)
 
-    resp = http_pool.request(HTTPMethod.GET, proton_hash_url)
+    resp = http_pool.request(HTTPMethod.GET.value, proton_hash_url)
     if resp.status != HTTPStatus.OK:
         err: str = (
             f"Unable to download {proton_hash}\n"
@@ -208,7 +215,10 @@ def _fetch_proton(
             log.info("Downloading %s...", tarball)
 
         resp = http_pool.request(
-            HTTPMethod.GET, tar_url, preload_content=False, headers=headers
+            HTTPMethod.GET.value,
+            tar_url,
+            preload_content=False,
+            headers=headers,
         )
 
         # Bail out for unexpected status codes


### PR DESCRIPTION
For now, maintain 3.10. This fixes our python version specified in pyproject.toml mismatching with the actual Python version (3.11) in the main branch. While we're targeting latest Debian, which is currently Bookworm, we don't have to do this. However, it seems unreasonable to bump it just for a new data type and a function, which can be trivially be re-implemented/backported.