### PR TITLE
refactor: use custom file lock functionality

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -55,6 +55,11 @@ jobs:
           source .venv/bin/activate
           sh tests/test_proton_resume.sh
           rm -rf "$HOME/.local/share/umu" "$HOME/Games/umu" "$HOME/.local/share/Steam/compatibilitytools.d" "$HOME/.cache/umu"
+      - name: Test File Lock
+        run: |
+          source .venv/bin/activate
+          sh tests/test_flock.sh
+          rm -rf "$HOME/.local/share/umu" "$HOME/Games/umu" "$HOME/.local/share/Steam/compatibilitytools.d" "$HOME/.cache/umu"
       - name: Test winetricks
         run: |
           source .venv/bin/activate

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -55,7 +55,7 @@ jobs:
           source .venv/bin/activate
           sh tests/test_proton_resume.sh
           rm -rf "$HOME/.local/share/umu" "$HOME/Games/umu" "$HOME/.local/share/Steam/compatibilitytools.d" "$HOME/.cache/umu"
-      - name: Test File Lock
+      - name: Test Filelock
         run: |
           source .venv/bin/activate
           sh tests/test_flock.sh

--- a/packaging/deb/debian/control
+++ b/packaging/deb/debian/control
@@ -36,7 +36,6 @@ Depends:
  ${misc:Depends},
  python3,
  python3-xlib (>= 0.33),
- python3-filelock (>= 3.9.0),
  apparmor-profiles,
  libgl1-mesa-dri:i386,
  libglx-mesa0:i386

--- a/packaging/deb/ubuntu/control
+++ b/packaging/deb/ubuntu/control
@@ -36,7 +36,6 @@ Depends:
  ${misc:Depends},
  python3,
  python3-xlib (>= 0.33),
- python3-filelock (>= 3.9.0),
  apparmor-profiles,
  libgl1-mesa-dri:i386,
  libglx-mesa0:i386

--- a/packaging/nix/umu-launcher.nix
+++ b/packaging/nix/umu-launcher.nix
@@ -18,7 +18,6 @@ python3Packages.buildPythonPackage {
     pyth1
     pkgs.bubblewrap
     pkgs.python3Packages.xlib
-    pkgs.python3Packages.filelock
     pkgs.python3Packages.urllib3
   ] ++ lib.optional truststore pkgs.python3Packages.truststore;
   makeFlags = [ "PYTHON_INTERPRETER=${pyth1}/bin/python" "SHELL_INTERPRETER=/run/current-system/sw/bin/bash" "DESTDIR=${placeholder "out"}" ];

--- a/packaging/rpm/umu-launcher.spec
+++ b/packaging/rpm/umu-launcher.spec
@@ -39,7 +39,6 @@ BuildRequires:  python3
 Requires:	python
 Requires:	python3
 Requires:	python3-xlib
-Requires:	python3-filelock
 
 
 %description

--- a/packaging/snap/snap/snapcraft.yaml
+++ b/packaging/snap/snap/snapcraft.yaml
@@ -246,7 +246,6 @@ parts:
     plugin: nil
     stage-packages:
       - python3-xlib
-      - python3-filelock
     prime:
       - usr/lib/python3
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ classifiers = [
 urls = { repository = "https://github.com/Open-Wine-Components/umu-launcher" }
 # Note: urllib3 is a vendored dependency. When using our Makefile, it will be
 # installed automatically.
-dependencies = ["python-xlib>=0.33", "filelock>=3.9.0", "urllib3>=2.0.0,<3.0.0"]
+dependencies = ["python-xlib>=0.33", "urllib3>=2.0.0,<3.0.0"]
 
 [project.optional-dependencies]
 # Recommended

--- a/requirements.in
+++ b/requirements.in
@@ -1,3 +1,2 @@
 python-xlib>=0.33
-filelock>=3.15.4
 urllib3>=2.0.0,<3.0.0

--- a/tests/test_flock.sh
+++ b/tests/test_flock.sh
@@ -16,12 +16,12 @@ wait
 grep "exited with wait status" "$tmp1"
 
 # Ensure the 2nd proc didn't download the runtime
-if ! grep "\(latest\), please wait..." "$tmp2"; then
+if ! grep -E "\(latest\), please wait..." "$tmp2"; then
 	exit 1
 fi
 
 # Ensure the 2nd proc didn't download Proton
 grep "Downloading" "$tmp2" 
-if ! grep "exited with wait status" "$tmp2"; then
+if ! grep -E "exited with wait status" "$tmp2"; then
 	exit 1
 fi

--- a/tests/test_flock.sh
+++ b/tests/test_flock.sh
@@ -16,12 +16,16 @@ wait
 grep "exited with wait status" "$tmp1" && grep -E "exited with wait status" "$tmp2"
 
 # Ensure the 2nd proc didn't download the runtime
-if grep -E "\(latest\), please wait..." "$tmp2"; then
+grep -E "\(latest\), please wait..." "$tmp2"
+exit_code=$?
+if "$exit_code" != 0; then
 	exit 1
 fi
 
 # Ensure the 2nd proc didn't download Proton
-if grep "Downloading" "$tmp2"; then
+grep "Downloading" "$tmp2"
+exit_code=$?
+if "$exit_code" != 0; then
 	exit 1
 fi
 

--- a/tests/test_flock.sh
+++ b/tests/test_flock.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env sh
+set -e
 
 #
 # Ensure umu-launcher does not download its fetched resources more than once
@@ -16,12 +17,9 @@ wait
 grep "exited with wait status" "$tmp1"
 
 # Ensure the 2nd proc didn't download the runtime
-if ! grep -E "\(latest\), please wait..." "$tmp2"; then
-	exit 1
-fi
+! grep -E "\(latest\), please wait..." "$tmp2"
 
 # Ensure the 2nd proc didn't download Proton
-grep "Downloading" "$tmp2" 
-if ! grep -E "exited with wait status" "$tmp2"; then
-	exit 1
-fi
+! grep "Downloading" "$tmp2" 
+
+grep -E "exited with wait status" "$tmp2"

--- a/tests/test_flock.sh
+++ b/tests/test_flock.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env sh
-set -e
 
 #
 # Ensure umu-launcher does not download its fetched resources more than once
@@ -17,9 +16,13 @@ wait
 grep "exited with wait status" "$tmp1"
 
 # Ensure the 2nd proc didn't download the runtime
-! grep -E "\(latest\), please wait..." "$tmp2"
+if ! grep -E "\(latest\), please wait..." "$tmp2"; then
+	exit 1
+fi
 
 # Ensure the 2nd proc didn't download Proton
-! grep "Downloading" "$tmp2" 
+if ! grep "Downloading" "$tmp2"; then
+	exit 1
+fi
 
 grep -E "exited with wait status" "$tmp2"

--- a/tests/test_flock.sh
+++ b/tests/test_flock.sh
@@ -13,16 +13,15 @@ sleep 1
 UMU_LOG=debug GAMEID=umu-0 "$HOME/.local/bin/umu-run" wineboot -u 2> "$tmp2" &
 wait
 
-grep "exited with wait status" "$tmp1"
+grep "exited with wait status" "$tmp1" && grep -E "exited with wait status" "$tmp2"
 
 # Ensure the 2nd proc didn't download the runtime
-if ! grep -E "\(latest\), please wait..." "$tmp2"; then
+if grep -E "\(latest\), please wait..." "$tmp2"; then
 	exit 1
 fi
 
 # Ensure the 2nd proc didn't download Proton
-if ! grep "Downloading" "$tmp2"; then
+if grep "Downloading" "$tmp2"; then
 	exit 1
 fi
 
-grep -E "exited with wait status" "$tmp2"

--- a/tests/test_flock.sh
+++ b/tests/test_flock.sh
@@ -16,15 +16,12 @@ wait
 grep "exited with wait status" "$tmp1"
 
 # Ensure the 2nd proc didn't download the runtime
-grep "\(latest\), please wait..." "$tmp2" 
-if [ $? -ne 0 ]; then
+if ! grep "\(latest\), please wait..." "$tmp2"; then
 	exit 1
 fi
 
-grep "exited with wait status" "$tmp2"
-
 # Ensure the 2nd proc didn't download Proton
 grep "Downloading" "$tmp2" 
-if [ $? -ne 0 ]; then
+if ! grep "exited with wait status" "$tmp2"; then
 	exit 1
 fi

--- a/tests/test_flock.sh
+++ b/tests/test_flock.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env sh
+
+#
+# Ensure umu-launcher does not download its fetched resources more than once
+# when multiple processes of itself are created
+#
+
+tmp1=$(mktemp)
+tmp2=$(mktemp)
+
+UMU_LOG=debug GAMEID=umu-0 "$HOME/.local/bin/umu-run" wineboot -u 2> "$tmp1" &
+sleep 1
+UMU_LOG=debug GAMEID=umu-0 "$HOME/.local/bin/umu-run" wineboot -u 2> "$tmp2" &
+wait
+
+grep "exited with wait status" "$tmp1"
+
+# Ensure the 2nd proc didn't download the runtime
+grep "\(latest\), please wait..." "$tmp2" 
+if [ $? -ne 0 ]; then
+	exit 1
+fi
+
+grep "exited with wait status" "$tmp2"
+
+# Ensure the 2nd proc didn't download Proton
+grep "Downloading" "$tmp2" 
+if [ $? -ne 0 ]; then
+	exit 1
+fi

--- a/tests/test_flock.sh
+++ b/tests/test_flock.sh
@@ -18,14 +18,14 @@ grep "exited with wait status" "$tmp1" && grep -E "exited with wait status" "$tm
 # Ensure the 2nd proc didn't download the runtime
 grep -E "\(latest\), please wait..." "$tmp2"
 exit_code=$?
-if "$exit_code" != 0; then
+if "$exit_code" -ne 0; then
 	exit 1
 fi
 
 # Ensure the 2nd proc didn't download Proton
 grep "Downloading" "$tmp2"
 exit_code=$?
-if "$exit_code" != 0; then
+if "$exit_code" -ne 0; then
 	exit 1
 fi
 

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -25,7 +25,6 @@ from socket import AF_INET, SOCK_DGRAM, socket
 from subprocess import Popen
 from typing import Any
 
-from filelock import FileLock
 from urllib3 import PoolManager, Retry
 from urllib3.exceptions import MaxRetryError, NewConnectionError
 from urllib3.exceptions import TimeoutError as TimeoutErrorUrllib3
@@ -54,6 +53,7 @@ from umu.umu_util import (
     get_library_paths,
     has_umu_setup,
     is_installed_verb,
+    unix_flock,
     xdisplay,
 )
 
@@ -830,7 +830,7 @@ def umu_run(args: Namespace | tuple[str, list[str]]) -> int:
         UMU_LOCAL.mkdir(parents=True, exist_ok=True)
 
         # Prepare the prefix
-        with FileLock(f"{UMU_LOCAL}/pfx.lock"):
+        with unix_flock(f"{UMU_LOCAL}/pfx.lock"):
             setup_pfx(env["WINEPREFIX"])
 
         # Configure the environment

--- a/umu/umu_runtime.py
+++ b/umu/umu_runtime.py
@@ -554,7 +554,7 @@ def _update_umu_platform(
     if latest != current:
         log.info("Updating %s to latest...", variant)
         log.debug("Acquiring file lock '%s'...", lockfile)
-        with unix_flock(lockfile) as lock:
+        with unix_flock(lockfile):
             log.debug("Acquired file lock '%s'", lockfile)
             # Once another process acquires the lock, check if the latest
             # runtime has already been downloaded
@@ -564,4 +564,4 @@ def _update_umu_platform(
             _install_umu(runtime_ver, session_pools)
             log.debug("Removing: %s", runtime)
             rmtree(str(runtime))
-            log.debug("Released file lock '%s'", lock.lock_file)
+            log.debug("Released file lock '%s'", lockfile)

--- a/umu/umu_test.py
+++ b/umu/umu_test.py
@@ -1131,9 +1131,15 @@ class TestGameLauncher(unittest.TestCase):
         files = (("", ""), (self.test_archive.name, ""))
         tmpdirs = (self.test_cache, self.test_cache_home)
 
+        # Mock the context manager object that creates the file lock
+        mock_ctx = MagicMock()
+        mock_ctx.__enter__ = MagicMock(return_value=None)
+        mock_ctx.__exit__ = MagicMock(return_value=None)
+
         with (
             patch("umu.umu_proton._fetch_proton") as mock_function,
             ThreadPoolExecutor(),
+            patch.object(umu_proton, "unix_flock", return_value=mock_ctx),
         ):
             # Mock the interrupt
             # We want the dir we tried to extract to be cleaned
@@ -1164,6 +1170,11 @@ class TestGameLauncher(unittest.TestCase):
         files = (("", ""), (self.test_archive.name, ""))
         tmpdirs = (self.test_cache, self.test_cache_home)
 
+        # Mock the context manager object that creates the file lock
+        mock_ctx = MagicMock()
+        mock_ctx.__enter__ = MagicMock(return_value=None)
+        mock_ctx.__exit__ = MagicMock(return_value=None)
+
         self.assertTrue(
             self.test_archive.is_file(),
             "Expected test file in cache to exist",
@@ -1172,6 +1183,7 @@ class TestGameLauncher(unittest.TestCase):
         with (
             patch("umu.umu_proton._fetch_proton") as mock_function,
             ThreadPoolExecutor(),
+            patch.object(umu_proton, "unix_flock", return_value=mock_ctx),
         ):
             # Mock the interrupt
             mock_function.side_effect = ValueError
@@ -1195,11 +1207,17 @@ class TestGameLauncher(unittest.TestCase):
         files = ()
         tmpdirs = (self.test_cache, self.test_cache_home)
 
+        # Mock the context manager object that creates the file lock
+        mock_ctx = MagicMock()
+        mock_ctx.__enter__ = MagicMock(return_value=None)
+        mock_ctx.__exit__ = MagicMock(return_value=None)
+
         os.environ["PROTONPATH"] = ""
 
         with (
             patch("umu.umu_proton._fetch_proton"),
             ThreadPoolExecutor(),
+            patch.object(umu_proton, "unix_flock", return_value=mock_ctx),
         ):
             result = umu_proton._get_latest(
                 self.env,
@@ -1228,6 +1246,11 @@ class TestGameLauncher(unittest.TestCase):
         files = ((f"{latest}.sha512sum", ""), (f"{latest}.tar.gz", ""))
         tmpdirs = (self.test_cache, self.test_cache_home)
 
+        # Mock the context manager object that creates the file lock
+        mock_ctx = MagicMock()
+        mock_ctx.__enter__ = MagicMock(return_value=None)
+        mock_ctx.__exit__ = MagicMock(return_value=None)
+
         # Mock the latest Proton in /tmp
         test_archive = self.test_cache.joinpath(f"{latest}.tar.gz")
         with tarfile.open(test_archive.as_posix(), "w:gz") as tar:
@@ -1245,6 +1268,7 @@ class TestGameLauncher(unittest.TestCase):
         with (
             patch("umu.umu_proton._fetch_proton"),
             ThreadPoolExecutor(),
+            patch.object(umu_proton, "unix_flock", return_value=mock_ctx),
         ):
             result = umu_proton._get_latest(
                 self.env,
@@ -1287,6 +1311,11 @@ class TestGameLauncher(unittest.TestCase):
         files = ((f"{latest}.sha512sum", ""), (f"{latest}.tar.gz", ""))
         tmpdirs = (self.test_cache, self.test_cache_home)
 
+        # Mock the context manager object that creates the file lock
+        mock_ctx = MagicMock()
+        mock_ctx.__enter__ = MagicMock(return_value=None)
+        mock_ctx.__exit__ = MagicMock(return_value=None)
+
         # Mock the latest Proton in /tmp
         test_archive = self.test_cache.joinpath(f"{latest}.tar.gz")
         with tarfile.open(test_archive.as_posix(), "w:gz") as tar:
@@ -1310,6 +1339,7 @@ class TestGameLauncher(unittest.TestCase):
         with (
             patch("umu.umu_proton._fetch_proton"),
             ThreadPoolExecutor() as thread_pool,
+            patch.object(umu_proton, "unix_flock", return_value=mock_ctx),
         ):
             result = umu_proton._get_latest(
                 self.env,

--- a/umu/umu_util.py
+++ b/umu/umu_util.py
@@ -27,7 +27,6 @@ def unix_flock(path: str):
 
     try:
         fd = os.open(path, os.O_CREAT | os.O_WRONLY, 0o644)
-        # Apply an exclusive lock
         # See https://man7.org/linux/man-pages/man2/flock.2.html
         flock(fd, LOCK_EX)
         yield fd


### PR DESCRIPTION
umu-launcher currently depends on the [filelock](https://github.com/tox-dev/filelock) module to ensure that only 1 active umu-run process downloads Proton or the runtime. However, implementing file locking is relatively trivial and we do not care about cross platform file locking, async support, nor timeout support.
