### PR TITLE
Revert "fix: fallback to $XDG_DATA_HOME instead of $HOME/.local/share for Flatpak"

### DIFF
--- a/packaging/flatpak/org.openwinecomponents.umu.umu-launcher.yml
+++ b/packaging/flatpak/org.openwinecomponents.umu.umu-launcher.yml
@@ -64,9 +64,6 @@ finish-args:
   # Pressure Vessel
   # See https://github.com/flathub/com.valvesoftware.Steam/commit/0538256facdb0837c33232bc65a9195a8a5bc750
   - --env=XDG_DATA_DIRS=/app/share:/usr/lib/extensions/vulkan/share:/usr/share:/usr/share/runtime/share:/run/host/user-share:/run/host/share:/usr/lib/pressure-vessel/overrides/share
-  # umu
-  # Use host's $XDG_DATA_HOME, otherwise Flatpak's
-  - --filesystem=xdg-data/umu:create
 
 add-extensions:
   org.freedesktop.Platform.Compat.i386:

--- a/umu/umu_consts.py
+++ b/umu/umu_consts.py
@@ -72,7 +72,7 @@ if os.environ.get("container") == "flatpak":  # noqa: SIM112
     XDG_DATA_HOME: Path = (
         Path(os.environ["HOST_XDG_DATA_HOME"])
         if os.environ.get("HOST_XDG_DATA_HOME")
-        else Path(os.environ["XDG_DATA_HOME"])
+        else Path.home().joinpath(".local", "share")
     )
 elif os.environ.get("SNAP"):
     XDG_DATA_HOME: Path = Path(os.environ["SNAP_REAL_HOME"])


### PR DESCRIPTION
Reverts Open-Wine-Components/umu-launcher#290