### PR TITLE
fix: guide for nixos install

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,10 +147,7 @@ If there is any problem with the flake feel free to open a bug report and tag an
 If you want to add umu-launcher as a flake add this to your inputs in `flake.nix`
 ```nix
   inputs = {
-    umu = {
-      url = "github:Open-Wine-Components/umu-launcher?dir=packaging/nix";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
+    umu.url = "github:Open-Wine-Components/umu-launcher?dir=packaging/nix";
   }
 ```
 and in your `configuration.nix`


### PR DESCRIPTION
closes #324 

NixOs stable(nixpkgs 24.11) rustc version is at 1.82 which was causing the issue. 
Tho, is 1.83 really needed? Rust MSRV should be lower for easier packaging upstream.