### PR TITLE
build: fix missing urllib3 in RPM

### DIFF
--- a/.github/workflows/build-umu-fedora-40.yml
+++ b/.github/workflows/build-umu-fedora-40.yml
@@ -39,4 +39,4 @@ jobs:
       uses: actions/upload-artifact@v4.0.0
       with:
         name: umu-launcher-rpm-40
-        path: ~/rpmbuild/RPMS/noarch/*.rpm
+        path: ~/rpmbuild/RPMS/x86_64/*.rpm

--- a/.github/workflows/build-umu-fedora-41.yml
+++ b/.github/workflows/build-umu-fedora-41.yml
@@ -39,4 +39,4 @@ jobs:
       uses: actions/upload-artifact@v4.0.0
       with:
         name: umu-launcher-rpm-41
-        path: ~/rpmbuild/RPMS/noarch/*.rpm
+        path: ~/rpmbuild/RPMS/x86_64/*.rpm

--- a/packaging/rpm/umu-launcher.spec
+++ b/packaging/rpm/umu-launcher.spec
@@ -13,7 +13,7 @@
 %global rel_build 1.%{build_timestamp}.%{shortcommit}%{?dist}
 
 Name:           umu-launcher
-Version:        1.2.0
+Version:        1.1.4
 Release:        %{rel_build}
 Summary:        A tool for launching non-steam games with proton
 

--- a/packaging/rpm/umu-launcher.spec
+++ b/packaging/rpm/umu-launcher.spec
@@ -20,7 +20,7 @@ Summary:        A tool for launching non-steam games with proton
 License:        GPLv3
 URL:            https://github.com/Open-Wine-Components/umu-launcher
 
-BuildArch:  noarch
+BuildArch:  arch
 BuildRequires:  meson >= 0.54.0
 BuildRequires:  ninja-build
 BuildRequires:  cmake

--- a/packaging/rpm/umu-launcher.spec
+++ b/packaging/rpm/umu-launcher.spec
@@ -35,6 +35,7 @@ BuildRequires:  python3-installer
 BuildRequires:  python3-hatchling
 BuildRequires:  python
 BuildRequires:  python3
+BuildRequires:  python3-pip
 
 Requires:	python
 Requires:	python3

--- a/packaging/rpm/umu-launcher.spec
+++ b/packaging/rpm/umu-launcher.spec
@@ -20,7 +20,7 @@ Summary:        A tool for launching non-steam games with proton
 License:        GPLv3
 URL:            https://github.com/Open-Wine-Components/umu-launcher
 
-BuildArch:  arch
+BuildArch:  x86_64
 BuildRequires:  meson >= 0.54.0
 BuildRequires:  ninja-build
 BuildRequires:  cmake

--- a/packaging/rpm/umu-launcher.spec
+++ b/packaging/rpm/umu-launcher.spec
@@ -51,7 +51,6 @@ Recommends:	libzstd
 %prep
 git clone --single-branch --branch main https://github.com/Open-Wine-Components/umu-launcher.git
 cd umu-launcher
-git checkout %{tag}
 git submodule update --init --recursive
 
 %build

--- a/packaging/rpm/umu-launcher.spec
+++ b/packaging/rpm/umu-launcher.spec
@@ -13,7 +13,7 @@
 %global rel_build 1.%{build_timestamp}.%{shortcommit}%{?dist}
 
 Name:           umu-launcher
-Version:        1.1.4
+Version:        1.2.0
 Release:        %{rel_build}
 Summary:        A tool for launching non-steam games with proton
 

--- a/packaging/rpm/umu-launcher.spec
+++ b/packaging/rpm/umu-launcher.spec
@@ -2,7 +2,6 @@
 %define manual_commit e9cb4d764013d4c8c3d1166f59581da8f56a3d83
 
 # Optionally define the tag
-# %define tag 1.1.4
 # Check if tag is defined and get the commit hash for the tag, otherwise use manual commit
 %{!?tag: %global commit %{manual_commit}}
 %{?tag: %global commit %(git rev-list -n 1 %{tag} 2>/dev/null || echo %{manual_commit})}

--- a/packaging/rpm/umu-launcher.spec
+++ b/packaging/rpm/umu-launcher.spec
@@ -1,8 +1,8 @@
 # Define the manual commit as a fallback
-%define manual_commit 70645c290dfc6ed10282bf4d2ae38c0bf7b1a3fb
+%define manual_commit e9cb4d764013d4c8c3d1166f59581da8f56a3d83
 
 # Optionally define the tag
-%define tag 1.1.4
+# %define tag 1.1.4
 # Check if tag is defined and get the commit hash for the tag, otherwise use manual commit
 %{!?tag: %global commit %{manual_commit}}
 %{?tag: %global commit %(git rev-list -n 1 %{tag} 2>/dev/null || echo %{manual_commit})}


### PR DESCRIPTION
The urllib3 vendored dependency was discovered to be missing in the RPM. This was because the RPM spec was pinned to 1.1.4, and was missing pip as a build dep. This fixes that and also adds the Rust module, which was fixed along the way.