### PR TITLE
perf: improve shared library path search

### DIFF
--- a/umu/umu_util.py
+++ b/umu/umu_util.py
@@ -88,10 +88,10 @@ def get_library_paths() -> set[str]:
             if not proc.stdout:
                 return library_paths
             for line in proc.stdout:
-                line = line.split()
+                lines = line.split()
                 if not line:
                     continue
-                line = line[-1]
+                line = lines[-1]
                 prefix = line[: line.rfind(root)]
                 if not line.startswith(root) or prefix in paths:
                     continue

--- a/umu/umu_util.py
+++ b/umu/umu_util.py
@@ -63,7 +63,9 @@ def get_libc() -> str:
 def get_library_paths() -> set[str]:
     """Find the shared library paths from the user's system."""
     library_paths: set[str] = set()
+    paths: set[str] = set()
     ldconfig: str = which("ldconfig") or ""
+    root = "/"
 
     if not ldconfig:
         log.warning("ldconfig not found in $PATH, cannot find library paths")
@@ -81,15 +83,20 @@ def get_library_paths() -> set[str]:
             text=True,
             encoding="utf-8",
             stdout=PIPE,
-            stderr=PIPE,
             env={"LC_ALL": "C", "LANG": "C"},
         ) as proc:
-            stdout, _ = proc.communicate()
-            library_paths |= {
-                os.path.realpath(line[: line.rfind("/")])
-                for line in stdout.split()
-                if line.startswith("/")
-            }
+            if not proc.stdout:
+                return library_paths
+            for line in proc.stdout:
+                line = line.split()
+                if not line:
+                    continue
+                line = line[-1]
+                prefix = line[: line.rfind(root)]
+                if not line.startswith(root) or prefix in paths:
+                    continue
+                paths.add(prefix)
+                library_paths.add(os.path.realpath(prefix))
     except OSError as e:
         log.exception(e)
 


### PR DESCRIPTION
umu-launcher was resolving the absolute paths returned from ldconfig for paths that it has already seen before. We can improve this a bit by not waiting for the subprocess to complete, and keeping track of paths that it has already seen before.

Benchmarks (before):
```
command,mean,stddev,median,user,system,min,max
./main2.py,0.03786203996999999,0.0006822470454129799,0.03774224728,0.025316989999999998,0.01252311160000001,0.03673033328,0.03996890628
```

Benchmarks (after):
```
command,mean,stddev,median,user,system,min,max
./main.py,0.025430914940000007,0.0005238838854464152,0.025448714980000002,0.01914935,0.006586064800000005,0.024382776480000003,0.027405606480000004
```

main.py:
```
#!/usr/bin/env python3

import os
from subprocess import Popen, PIPE
from shutil import which

def main() -> set[str]:
    library_paths: set[str] = set()
    paths: set[str] = set()
    ldconfig: str = which("ldconfig") or ""
    root = "/"

    if not ldconfig:
        return library_paths

    try:
        # Here, opt to using the ld.so cache similar to the stdlib
        # implementation of _findSoname_ldconfig.
        with Popen(
            (ldconfig, "-p"),
            text=True,
            encoding="utf-8",
            stdout=PIPE,
            env={"LC_ALL": "C", "LANG": "C"},
        ) as proc:
            if not proc.stdout:
                return library_paths
            for line in proc.stdout:
                line = line.split()
                if not line:
                    continue
                line = line[-1]
                prefix = line[: line.rfind(root)]
                if not line.startswith(root) or prefix in paths:
                    continue
                paths.add(prefix)
                library_paths.add(os.path.realpath(prefix))
    except OSError as e:
        print(e)

    return library_paths

if __name__ == "__main__":
    main()
```

Benchmarks were collected from `hyperfine` with the sample size run of 100.
