### PR TITLE
fix build: conditionally pass `--destdir` and `--prefix` to installer

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -19,6 +19,14 @@ DESTDIR ?=
 USERINSTALL ?= xfalse
 FLATPAK ?= xfalse
 
+INSTALLER_ARGS := -m installer $(OBJDIR)/*.whl
+ifdef DESTDIR
+	INSTALLER_ARGS += --destdir=$(DESTDIR)
+endif
+ifdef PREFIX
+	INSTALLER_ARGS += --prefix=$(PREFIX)
+endif
+
 .PHONY: all
 ifeq ($(FLATPAK), xtrue)
 all: umu-dist umu-launcher umu-vendored
@@ -63,7 +71,7 @@ umu-dist: $(OBJDIR)/.build-umu-dist
 umu-dist-install: umu-dist
 	$(info :: Installing umu )
 	install -d $(DESTDIR)$(PYTHONDIR)/$(INSTALLDIR)
-	$(PYTHON_INTERPRETER)  -m installer --destdir=$(DESTDIR) $(OBJDIR)/*.whl
+	$(PYTHON_INTERPRETER) $(INSTALLER_ARGS)
 
 ifeq ($(FLATPAK), xtrue)
 umu-install: umu-dist-install


### PR DESCRIPTION
Ensure PREFIX and DESTDIR are correctly passed to `python -m installer`

`--destdir` and `--prefix` should be used when the respective variable is non-empty.

This fixes issues we encountered while [packaging](https://github.com/NixOS/nixpkgs/pull/369259) umu-launcher for nixpkgs, removing the need for [this patch](https://github.com/nixos/nixpkgs/blob/f552caff7349683083f06985a1db3c434aa27ccd/pkgs/by-name/um/umu-launcher-unwrapped/makefile-installer-prefix.patch)


