### PR TITLE
build(nix): fix `postInstall`

### DIFF
--- a/packaging/nix/umu-launcher.nix
+++ b/packaging/nix/umu-launcher.nix
@@ -46,7 +46,7 @@ python3Packages.buildPythonPackage {
     ++ lib.optional deltaUpdates.cbor2 pkgs.python3Packages.cbor2
     ++ lib.optional deltaUpdates.xxhash pkgs.python3Packages.xxhash
     ++ lib.optional deltaUpdates.zstd pkgs.zstd;
-  makeFlags = ["PYTHON_INTERPRETER=${pyth1}/bin/python" "SHELL_INTERPRETER=/run/current-system/sw/bin/bash" "DESTDIR=${placeholder "out"}"];
+  makeFlags = ["PYTHON_INTERPRETER=${pyth1}/bin/python" "SHELL_INTERPRETER=/run/current-system/sw/bin/bash" "DESTDIR=build"];
   dontUseMesonConfigure = true;
   dontUseNinjaBuild = true;
   dontUseNinjaInstall = true;
@@ -54,9 +54,8 @@ python3Packages.buildPythonPackage {
   configureScript = "./configure.sh";
   configureFlags = ["--prefix=${placeholder "out"}"];
   postInstall = ''
-    mv -fv $out${pyth1}/* $out
-    mv -fv $out$out/* $out
-    rm -vrf $out/nix
+    cp -r build${pyth1}/* $out
+    cp -r build$out/* $out
     mv $out/bin/umu-run $out/bin/umu
   '';
 }


### PR DESCRIPTION
With the `installer` stage respecting PREFIX, the structure of DESTDIR is different.

Therefore, installing files with `mv` runs into issues because directories cannot be merged using `mv`.

For simplicity, we can use `cp` instead.

This fixes the regression in the nix flake package (#346) caused by #343.

IDK if #346 also affects other package or not though.

cc @beh-10257 
