### PR TITLE
Specify alejandra as the nix formatter

### DIFF
--- a/packaging/nix/flake.nix
+++ b/packaging/nix/flake.nix
@@ -46,6 +46,8 @@
       };
     };
 
+    formatter = builtins.mapAttrs (system: pkgs: pkgs.alejandra) nixpkgs.legacyPackages;
+
     packages.x86_64-linux = {
       inherit (pkgs) umu;
       default = self.packages.x86_64-linux.umu;


### PR DESCRIPTION
Can be run using `nix fmt` from the `packaging/nix` directory.

https://github.com/Open-Wine-Components/umu-launcher/pull/345#discussion_r1924145060
