### PR TITLE
test: ensure the patch target matches proton

### DIFF
--- a/tests/test_delta.py
+++ b/tests/test_delta.py
@@ -23,10 +23,12 @@ def main():  # noqa: D103
         "User-Agent": "",
     }
     codename = "UMU-Latest"
+    ctx = ssl.create_default_context()
 
+    durl = ""
     with urlopen(  # noqa: S310
         Request(url, headers=headers),  # noqa: S310
-        context=ssl.create_default_context(),
+        context=ctx,
     ) as resp:
         releases = json.loads(resp.read())
         for release in releases["assets"]:
@@ -36,12 +38,38 @@ def main():  # noqa: D103
                 durl = release["browser_download_url"]
                 break
 
+    if not durl:
+        print(f"Could not find release with codename '{codename}', skipping")
+        return 0
+
     with urlopen(durl) as resp:  # noqa: S310
         patch = cbor2.loads(resp.read())
         version = patch.get("contents")[0].get("source")
+        target = patch.get("contents")[0].get("target")
 
-    url = f"https://github.com/Open-Wine-Components/umu-proton/releases/download/{version}/{version}.tar.gz"
-    with urlopen(url) as resp:  # noqa: S310
+    # Verify the latest release matches the patch's target
+    url = "https://api.github.com/repos/Open-Wine-Components/umu-proton/releases/latest"
+    durl = ""
+    is_target = False
+    with urlopen(  # noqa: S310
+        Request(url, headers=headers),  # noqa: S310
+        context=ctx,
+    ) as resp:
+        releases = json.loads(resp.read())
+        for release in releases["assets"]:
+            if release["name"].startswith(target) and release["name"].endswith(
+                ".tar.gz"
+            ):
+                is_target = True
+                break
+
+    # Case when the latest release doesn't match the patch target
+    if not is_target:
+        print(f"Latest release is not expected patch target '{target}', skipping")
+        return 0
+
+    durl = f"https://github.com/Open-Wine-Components/umu-proton/releases/download/{version}/{version}.tar.gz"
+    with urlopen(durl) as resp:  # noqa: S310
         buffer = bytearray(64 * 1024)
         view = memoryview(buffer)
         with tempfile.NamedTemporaryFile(mode="ab+", buffering=0) as file:
@@ -60,8 +88,10 @@ def main():  # noqa: D103
         shutil.move(cache.joinpath(version), compat)
         compat.joinpath(version).rename(compat.joinpath("UMU-Latest"))
 
-    exe = shutil.which("umu-run", path="/usr/local/bin")
+    path = "/usr/local/bin"
+    exe = shutil.which("umu-run", path=path)
     if exe is None:
+        print(f"Could not find umu-run in '{path}', exiting")
         return 1
 
     return subprocess.run(

--- a/tests/test_delta.py
+++ b/tests/test_delta.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import json
+import os
 import shutil
 import ssl
 import subprocess
@@ -96,7 +97,12 @@ def main():  # noqa: D103
 
     return subprocess.run(
         (exe, "wineboot", "-u"),
-        env={"PROTONPATH": "UMU-Latest", "GAMEID": "umu-0", "UMU_LOG": "1"},
+        env={
+            "PROTONPATH": "UMU-Latest",
+            "GAMEID": "umu-0",
+            "UMU_LOG": "1",
+            "PATH": os.environ["PATH"],
+        },
         check=False,
     ).returncode
 


### PR DESCRIPTION
The latest patch files are only applicable to specific targets, and those targets are expected to be the latest GitHub releases. However,  in practice the targets may not always be the latest version. We need to ensure that the target is the latest release for this test to be useful. In the case that it's not, skip the test all together.