### PR TITLE
ci: add nix flake workflows

### DIFF
--- a/.github/workflows/build-umu-nix-flake.yml
+++ b/.github/workflows/build-umu-nix-flake.yml
@@ -1,0 +1,30 @@
+name: UMU Nix Flake Build
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    # TODO: setup binary cache
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Install nix
+        uses: cachix/install-nix-action@v30
+        with:
+          github_access_token: ${{ github.token }}
+      - name: Check flake inputs
+        uses: DeterminateSystems/flake-checker-action@v9
+        with:
+          flake-lock-path: packaging/nix/flake.lock
+      - name: Check flake outputs
+        run: nix flake check ./packaging/nix
+      - name: Build
+        run: nix build ./packaging/nix
+

--- a/.github/workflows/update-umu-nix-flake.yml
+++ b/.github/workflows/update-umu-nix-flake.yml
@@ -1,0 +1,53 @@
+name: UMU Update flake.lock
+on:
+  workflow_dispatch:
+  schedule:
+    # Every Saturday at noon
+    - cron: '0 12 * * sat'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  flake_lock:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Install nix
+        uses: cachix/install-nix-action@v30
+        with:
+          github_access_token: ${{ github.token }}
+      - name: Update flake lockfile
+        id: update
+        uses: DeterminateSystems/update-flake-lock@main
+        with:
+          # NOTE: PR pushes by @github-actions don't trigger CI.
+          # One workaround is to provide a Personal Access Token,
+          # but then the PAT-owner is marked as the PR author.
+          # TODO: Consider providing a PAT. Maybe of a "bot account"?
+          path-to-flake-dir: packaging/nix
+          branch: update_flake/${{ github.ref_name }}
+          pr-labels: |
+            dependencies
+            github_actions
+          pr-reviewers: |
+            beh-10257
+            MattSturgeon
+            LovingMelody
+      - name: Print summary
+        env:
+          num: ${{ steps.update.outputs.pull-request-number }}
+          url: ${{ steps.update.outputs.pull-request-url }}
+          operation: ${{ steps.update.outputs.pull-request-operation }}
+        run: |
+          echo "Pull request #$num was $operation."
+          echo "$url"
+          (
+            echo "Pull request"
+            echo
+            echo "[#$num]($url) was $operation."
+            echo
+          ) >> $GITHUB_STEP_SUMMARY
+


### PR DESCRIPTION
### Build nix flake on push

Added a workflow that checks the flake and builds the nix package on push.

It may be nice to add a public binary cache, as this could be used as a substituter both by CI and end-users. See below.

### Update flake.lock weekly

Added a workflow that schedules a nix flake.lock update every Saturday at noon. This will open a PR with the bumped lockfile.

As-is, CI will not run against the created update PRs, because pushes by "bots" do not trigger CI. There are workarounds available, but they are kinda ugly.

The cleanest solution may be to create a "machine user" account and pass its Personal Access Token to the update-flake-lock action.

See [Running GitHub Actions CI](https://github.com/DeterminateSystems/update-flake-lock?tab=readme-ov-file#running-github-actions-ci) and this quote from [GitHub's docs](https://docs.github.com/en/get-started/learning-about-github/types-of-github-accounts#user-accounts) regarding "machine users":

> User accounts are intended for humans, but you can create accounts to automate activity on GitHub. This type of account is called a machine user. For example, you can create a machine user account to automate continuous integration (CI) workflows.

### Binary Cache

With your other build workflows, you often upload the binary artifacts to github actions. For nix, this doesn't really make sense. However it _does_ make sense to upload binaries to a "substitutor" like cachix or flakehub cache.

Such substitutors can be used by both CI, devs, and end-users to reduce re-builds and instead download pre-built binaries.

I haven't included anything related to this in _this_ PR, but if you setup the appropriate accounts & secrets I can do so either here or in a follow-up.

I would probably recommend cachix over flakehub cache. Both require some setup by end-users, but flakehub cache requires end-users install a `determinate` package and be authenticated with flakehub in order to benefit from caching.

To setup cachix, first [create an account](https://www.cachix.org/signup). This can be a free account; the free plan grants 5GB of public cache storage, which should be plenty for umu.

Next, as per the [Getting Started docs](https://docs.cachix.org/getting-started), you'll need to [create a cache](https://app.cachix.org/cache). This cache should be named something like `open-wine-components` or `umu-launcher`, depending on whether you'd use this cache or another for other OWC repos.

Also as per the [Getting Started docs](https://docs.cachix.org/getting-started), create an auth token for the new cache. Per-cache tokens allow access to only a specific binary cache, rather than all caches in your account. On [dashboard](https://app.cachix.org/) you can click on your cache's **Settings** and generate a new access token. You should give this token a description like `"Github CI token"`, permissions `read+write`, expires `never`.

If you named the cache `umu-launcher`, then your cache's auth settings are here: https://app.cachix.org/cache/umu-launcher/settings/authtokens

Once generated, save the token to [GitHub secrets](https://docs.github.com/en/actions/security-for-github-actions/security-guides/using-secrets-in-github-actions). Name it something like `UMU_CACHIX_TOKEN`

Use to org secrets if you may end up using the same cache+token in other OWC repos.  Org secrets can be added [here](https://github.com/organizations/Open-Wine-Components/settings/secrets/actions/new).\
Or use repo secrets if you'd probably create separate caches for other repos in the org. Repo secrets can be added [here](https://github.com/Open-Wine-Components/umu-launcher/settings/secrets/actions/new).

Once this is all set-up, we'd be able to use the [cachix action](https://github.com/cachix/cachix-action) in the workflow:

```yml
- name: Setup cachix
  uses: cachix/cachix-action@v15
  with:
    # name of the cache
    name: umu-launcher
    # per-cache auth token
    authToken: ${{ secrets.UMU_CACHIX_TOKEN }}
```

We may also want to add instructions to the README, for this we'd need to know the cache's name and its "public key":

```md
> [!TIP]
> You can use our binary cache to reduce rebuilds:
>
> ```nix
> nix.settings = {
>   extra-substituters = [
>     "https://umu-launcher.cachix.org"
>   ];
>   extra-trusted-public-keys = [
>     "umu-launcher.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
>   ];
> };
> ```
```

---

As ever with github workflows, this is hard to test. So I may have missed some obvious errors.

If I get chance to test these workflows out on a fork (or something), I'll update the PR to clarify that I've done so.

EDIT: Seems the check&build workflow was triggered and ran fine against this PR. The update workflow can only really be tested on a fork or once merged.

- https://github.com/Open-Wine-Components/umu-launcher/actions/runs/13094954905/job/36536147332?pr=360

---

cc @beh-10257 @LovingMelody @R1kaB3rN 