### PR TITLE
Update configure.sh, fix minor issues in Makefile.in

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -120,7 +120,6 @@ $(OBJDIR)/.build-umu-vendored: | $(OBJDIR)
 	@if [ "$(USE_SYSTEM_URLLIB)" != "xtrue" ]; then \
 		cd subprojects/urllib3 && $(PYTHON_INTERPRETER) -m build -wn --outdir=$(OBJDIR); \
 	fi
-	cp -a subprojects/pyzstd/$(OBJDIR)/*.whl subprojects/urllib3/$(OBJDIR)/*.whl $(OBJDIR)
 	touch $(@)
 
 .PHONY: umu-vendored
@@ -130,11 +129,11 @@ umu-vendored-install: umu-vendored
 	$(info :: Installing subprojects )
 	install -d $(DESTDIR)$(PYTHONDIR)/umu/_vendor
 	@if [ "$(USE_SYSTEM_PYZSTD)" != "xtrue" ]; then \
-		$(PYTHON_INTERPRETER) -m installer --destdir=$(DESTDIR)$(PYTHONDIR)/umu/_vendor $(OBJDIR)/pyzstd*.whl; \
+		$(PYTHON_INTERPRETER) -m installer --destdir=$(DESTDIR)$(PYTHONDIR)/umu/_vendor subprojects/pyzstd/$(OBJDIR)/pyzstd*.whl; \
 		find $(DESTDIR)$(PYTHONDIR)/umu/_vendor -type d -name pyzstd | xargs -I {} mv {} $(DESTDIR)$(PYTHONDIR)/umu/_vendor; \
 	fi
 	@if [ "$(USE_SYSTEM_URLLIB)" != "xtrue" ]; then \
-		$(PYTHON_INTERPRETER) -m installer --destdir=$(DESTDIR)$(PYTHONDIR)/umu/_vendor $(OBJDIR)/urllib3*.whl; \
+		$(PYTHON_INTERPRETER) -m installer --destdir=$(DESTDIR)$(PYTHONDIR)/umu/_vendor subprojects/urllib3/$(OBJDIR)/urllib3*.whl; \
 		find $(DESTDIR)$(PYTHONDIR)/umu/_vendor -type d -name urllib3 | xargs -I {} mv {} $(DESTDIR)$(PYTHONDIR)/umu/_vendor; \
 	fi
 	@if [ "$(USE_SYSTEM_PYZSTD)" != "xtrue" ] || [ "$(USE_SYSTEM_URLLIB)" != "xtrue" ]; then \

--- a/Makefile.in
+++ b/Makefile.in
@@ -131,19 +131,16 @@ umu-vendored-install: umu-vendored
 	install -d $(DESTDIR)$(PYTHONDIR)/umu/_vendor
 	@if [ "$(USE_SYSTEM_PYZSTD)" != "xtrue" ]; then \
 		$(PYTHON_INTERPRETER) -m installer --destdir=$(DESTDIR)$(PYTHONDIR)/umu/_vendor $(OBJDIR)/pyzstd*.whl; \
-	fi
-	@if [ "$(USE_SYSTEM_URLLIB)" != "xtrue" ]; then \
-		$(PYTHON_INTERPRETER) -m installer --destdir=$(DESTDIR)$(PYTHONDIR)/umu/_vendor $(OBJDIR)/urllib3*.whl; \
-	fi
-	@if [ "$(USE_SYSTEM_PYZSTD)" != "xtrue" ]; then \
 		find $(DESTDIR)$(PYTHONDIR)/umu/_vendor -type d -name pyzstd | xargs -I {} mv {} $(DESTDIR)$(PYTHONDIR)/umu/_vendor; \
 	fi
 	@if [ "$(USE_SYSTEM_URLLIB)" != "xtrue" ]; then \
+		$(PYTHON_INTERPRETER) -m installer --destdir=$(DESTDIR)$(PYTHONDIR)/umu/_vendor $(OBJDIR)/urllib3*.whl; \
 		find $(DESTDIR)$(PYTHONDIR)/umu/_vendor -type d -name urllib3 | xargs -I {} mv {} $(DESTDIR)$(PYTHONDIR)/umu/_vendor; \
 	fi
 	@if [ "$(USE_SYSTEM_PYZSTD)" != "xtrue" ] || [ "$(USE_SYSTEM_URLLIB)" != "xtrue" ]; then \
 		rm -r $(DESTDIR)$(PYTHONDIR)/umu/_vendor/$(PREFIX); \
 	fi
+
 $(OBJDIR):
 	@mkdir -p $(@)
 

--- a/Makefile.in
+++ b/Makefile.in
@@ -21,8 +21,8 @@ FLATPAK ?= xfalse
 
 # For vendors that prefer to use native pyzstd and urllib3.
 # Ex. Arch and Fedora have pyzstd but ubuntu and debian don't
-USE_NATIVE_PYZSTD ?= xfalse
-USE_NATIVE_URLLIB ?= xfalse
+USE_SYSTEM_PYZSTD ?= xfalse
+USE_SYSTEM_URLLIB ?= xfalse
 
 INSTALLER_ARGS := -m installer $(OBJDIR)/umu_launcher*.whl
 ifdef DESTDIR
@@ -113,11 +113,11 @@ umu-launcher-install: umu-launcher-dist-install umu-launcher-bin-install
 
 $(OBJDIR)/.build-umu-vendored: | $(OBJDIR)
 	$(info :: Building vendored dependencies )
-	@if [ "$${USE_NATIVE_PYZSTD}" != "xtrue" ]; then \
+	@if [ "$(USE_SYSTEM_PYZSTD)" != "xtrue" ]; then \
 		sed -i 's/setuptools>=64,<74/setuptools/' subprojects/pyzstd/pyproject.toml; \
 		cd subprojects/pyzstd && $(PYTHON_INTERPRETER) -m build -wn --outdir=$(OBJDIR); \
 	fi
-	@if [ "$${USE_NATIVE_URLLIB}" != "xtrue" ]; then \
+	@if [ "$(USE_SYSTEM_URLLIB)" != "xtrue" ]; then \
 		cd subprojects/urllib3 && $(PYTHON_INTERPRETER) -m build -wn --outdir=$(OBJDIR); \
 	fi
 	cp -a subprojects/pyzstd/$(OBJDIR)/*.whl subprojects/urllib3/$(OBJDIR)/*.whl $(OBJDIR)
@@ -129,19 +129,19 @@ umu-vendored: $(OBJDIR)/.build-umu-vendored
 umu-vendored-install: umu-vendored
 	$(info :: Installing subprojects )
 	install -d $(DESTDIR)$(PYTHONDIR)/umu/_vendor
-	@if [ "$${USE_NATIVE_PYZSTD}" != "xtrue" ]; then \
+	@if [ "$(USE_SYSTEM_PYZSTD)" != "xtrue" ]; then \
 		$(PYTHON_INTERPRETER) -m installer --destdir=$(DESTDIR)$(PYTHONDIR)/umu/_vendor $(OBJDIR)/pyzstd*.whl; \
 	fi
-	@if [ "$${USE_NATIVE_URLLIB}" != "xtrue" ]; then \
+	@if [ "$(USE_SYSTEM_URLLIB)" != "xtrue" ]; then \
 		$(PYTHON_INTERPRETER) -m installer --destdir=$(DESTDIR)$(PYTHONDIR)/umu/_vendor $(OBJDIR)/urllib3*.whl; \
 	fi
-	@if [ "$${USE_NATIVE_PYZSTD}" != "xtrue" ]; then \
+	@if [ "$(USE_SYSTEM_PYZSTD)" != "xtrue" ]; then \
 		find $(DESTDIR)$(PYTHONDIR)/umu/_vendor -type d -name pyzstd | xargs -I {} mv {} $(DESTDIR)$(PYTHONDIR)/umu/_vendor; \
 	fi
-	@if [ "$${USE_NATIVE_URLLIB}" != "xtrue" ]; then \
+	@if [ "$(USE_SYSTEM_URLLIB)" != "xtrue" ]; then \
 		find $(DESTDIR)$(PYTHONDIR)/umu/_vendor -type d -name urllib3 | xargs -I {} mv {} $(DESTDIR)$(PYTHONDIR)/umu/_vendor; \
 	fi
-	@if [ "$${USE_NATIVE_PYZSTD}" != "xtrue" ] || [ "$${USE_NATIVE_URLLIB}" != "xtrue" ]; then \
+	@if [ "$(USE_SYSTEM_PYZSTD)" != "xtrue" ] || [ "$(USE_SYSTEM_URLLIB)" != "xtrue" ]; then \
 		rm -r $(DESTDIR)$(PYTHONDIR)/umu/_vendor/$(PREFIX); \
 	fi
 $(OBJDIR):

--- a/configure.sh
+++ b/configure.sh
@@ -69,6 +69,13 @@ function configure() {
       echo "INSTALLDIR      := umu-launcher"
     fi
 
+    if [[ -n "$arg_use_system_pyzstd" ]]; then
+      echo "USE_NATIVE_PYZSTD := xtrue"
+    fi
+    if [[ -n "$arg_use_system_urllib" ]]; then
+      echo "USE_NATIVE_URLLIB := xtrue"
+    fi
+
     # Prefix was specified, baking it into the Makefile
     if [[ -n $arg_prefix ]]; then
       echo "PREFIX          := $(escape_for_make "$arg_prefix")"
@@ -89,6 +96,8 @@ function configure() {
 arg_prefix=""
 arg_user_install=""
 arg_help=""
+arg_use_system_pyzstd=""
+arg_use_system_urllib=""
 function parse_args() {
   local arg;
   local val;
@@ -134,6 +143,10 @@ function parse_args() {
         die "--user-install cannot be used with --prefix"
       fi
       arg_user_install="1"
+    elif [[ $arg = --use-system-pyzstd ]]; then
+      arg_use_system_pyzstd="1"
+    elif [[ $arg = --use-system-urllib ]]; then
+      arg_use_system_urllib="1"
     else
       err "Unrecognized option $arg"
       return 1
@@ -179,6 +192,10 @@ usage() {
   "$1" "                      [/usr]"
   "$1" "    --user-install    Install under user-only location. Incompatible with --prefix"
   "$1" "                      [$HOME/.local]"
+  "$1" "    --use-system-pystd"
+  "$1" "                      Do not use vendored pyzstd"
+  "$1" "    --use-system-urllib"
+  "$1" "                      Do not use vendored urllib"
   "$1" ""
   exit 1;
 }

--- a/configure.sh
+++ b/configure.sh
@@ -70,10 +70,10 @@ function configure() {
     fi
 
     if [[ -n "$arg_use_system_pyzstd" ]]; then
-      echo "USE_NATIVE_PYZSTD := xtrue"
+      echo "USE_SYSTEM_PYZSTD := xtrue"
     fi
     if [[ -n "$arg_use_system_urllib" ]]; then
-      echo "USE_NATIVE_URLLIB := xtrue"
+      echo "USE_SYSTEM_URLLIB := xtrue"
     fi
 
     # Prefix was specified, baking it into the Makefile

--- a/packaging/deb/0001-deb-fix-build-by-using-rustup.patch
+++ b/packaging/deb/0001-deb-fix-build-by-using-rustup.patch
@@ -1,4 +1,4 @@
-From 52d4c7b073433986b64a417e88d6e5454e3759bc Mon Sep 17 00:00:00 2001
+From 848d894b9713ae145d00696e7a328c8346dfc3a9 Mon Sep 17 00:00:00 2001
 From: R1kaB3rN <100738684+R1kaB3rN@users.noreply.github.com>
 Date: Wed, 12 Feb 2025 13:13:35 -0800
 Subject: [PATCH] deb: fix build by using rustup
@@ -9,7 +9,7 @@ Subject: [PATCH] deb: fix build by using rustup
  2 files changed, 14 insertions(+), 3 deletions(-)
 
 diff --git a/Makefile.in b/Makefile.in
-index 188b5212..8a0bac88 100644
+index da2431d..5e4fa5e 100644
 --- a/Makefile.in
 +++ b/Makefile.in
 @@ -2,6 +2,7 @@ PROJECT := umu-launcher
@@ -28,20 +28,26 @@ index 188b5212..8a0bac88 100644
 +
  $(OBJDIR)/.build-umu-vendored: | $(OBJDIR)
  	$(info :: Building vendored dependencies )
- 	@if [ "$${USE_NATIVE_PYZSTD}" != "xtrue" ]; then \
-@@ -118,9 +121,9 @@ $(OBJDIR)/.build-umu-vendored: | $(OBJDIR)
+ 	@if [ "$(USE_SYSTEM_PYZSTD)" != "xtrue" ]; then \
+@@ -118,7 +121,7 @@ $(OBJDIR)/.build-umu-vendored: | $(OBJDIR)
  		cd subprojects/pyzstd && $(PYTHON_INTERPRETER) -m build -wn --outdir=$(OBJDIR); \
  	fi
- 	@if [ "$${USE_NATIVE_URLLIB}" != "xtrue" ]; then \
+ 	@if [ "$(USE_SYSTEM_URLLIB)" != "xtrue" ]; then \
 -		cd subprojects/urllib3 && $(PYTHON_INTERPRETER) -m build -wn --outdir=$(OBJDIR); \
 +		curl -LJO --tlsv1.3 $(URLLIB3_URL) --output-dir $(OBJDIR); \
  	fi
--	cp -a subprojects/pyzstd/$(OBJDIR)/*.whl subprojects/urllib3/$(OBJDIR)/*.whl $(OBJDIR)
-+	cp -a subprojects/pyzstd/$(OBJDIR)/*.whl $(OBJDIR)
  	touch $(@)
  
- .PHONY: umu-vendored
-@@ -198,10 +201,17 @@ zipapp-install: zipapp
+@@ -133,7 +136,7 @@ umu-vendored-install: umu-vendored
+ 		find $(DESTDIR)$(PYTHONDIR)/umu/_vendor -type d -name pyzstd | xargs -I {} mv {} $(DESTDIR)$(PYTHONDIR)/umu/_vendor; \
+ 	fi
+ 	@if [ "$(USE_SYSTEM_URLLIB)" != "xtrue" ]; then \
+-		$(PYTHON_INTERPRETER) -m installer --destdir=$(DESTDIR)$(PYTHONDIR)/umu/_vendor subprojects/urllib3/$(OBJDIR)/urllib3*.whl; \
++		$(PYTHON_INTERPRETER) -m installer --destdir=$(DESTDIR)$(PYTHONDIR)/umu/_vendor $(OBJDIR)/urllib3*.whl; \
+ 		find $(DESTDIR)$(PYTHONDIR)/umu/_vendor -type d -name urllib3 | xargs -I {} mv {} $(DESTDIR)$(PYTHONDIR)/umu/_vendor; \
+ 	fi
+ 	@if [ "$(USE_SYSTEM_PYZSTD)" != "xtrue" ] || [ "$(USE_SYSTEM_URLLIB)" != "xtrue" ]; then \
+@@ -197,10 +200,17 @@ zipapp-install: zipapp
  	@echo "Standalone application 'umu-run' created at '$(DESTDIR)$(PREFIX)/bin'"
  
  PYTHON_PLATFORM_TAG = $(shell $(PYTHON_INTERPRETER) -c 'import sysconfig; print(sysconfig.get_config_var("EXT_SUFFIX"))')
@@ -61,7 +67,7 @@ index 188b5212..8a0bac88 100644
  
  .PHONY: umu-delta
 diff --git a/packaging/deb/debian/control b/packaging/deb/debian/control
-index f8e47298..fef5e082 100644
+index f8e4729..fef5e08 100644
 --- a/packaging/deb/debian/control
 +++ b/packaging/deb/debian/control
 @@ -18,6 +18,7 @@ Build-Depends:


### PR DESCRIPTION
- **configure.sh: Add command line option to configure script**
    Add `--use-system-pyzstd` and `--use-system-urllib` options in the configure script to replace the environment variables
- **Makefile.in: replace `_NATIVE_` with `_SYSTEM_`**
- **Makefile.in: group install steps for vendored dependencies**
- **Makefile.in: use subproject build paths instead of copying vendored wheels**
    Copying the built wheels to the base OBJDIR would fail if system dependecies where used. To fix, remove the `cp` command
    and use paths to the built wheels in their subproject folders

#bringbackmeson :D