### PR TITLE
Support overriding 1.2.0+ nix package

### DIFF
--- a/packaging/nix/old-unwrapped.nix
+++ b/packaging/nix/old-unwrapped.nix
@@ -1,0 +1,60 @@
+{
+  # Dependencies
+  lib,
+  cargo,
+  python3Packages,
+  rustPlatform,
+  umu-launcher-unwrapped,
+  # Public API
+  withTruststore ? true,
+  withDeltaUpdates ? true,
+}:
+umu-launcher-unwrapped.overridePythonAttrs (prev: {
+  # The nixpkgs patches (in `prev.patches`) are not needed anymore
+  # - no-umu-version-json.patch was resolved in:
+  #   https://github.com/Open-Wine-Components/umu-launcher/pull/289
+  # - The other is backporting:
+  #   https://github.com/Open-Wine-Components/umu-launcher/pull/343
+  patches = [];
+
+  nativeCheckInputs =
+    (prev.nativeCheckInputs or [])
+    ++ [
+      python3Packages.pytestCheckHook
+    ];
+
+  nativeBuildInputs =
+    (prev.nativeBuildInputs or [])
+    ++ [
+      rustPlatform.cargoSetupHook
+      cargo
+    ];
+
+  pythonPath = with python3Packages;
+    (prev.pythonPath or [])
+    ++ [
+      urllib3
+      (callPackage ./pyzstd.nix {})
+    ]
+    ++ lib.optionals withTruststore [
+      truststore
+    ]
+    ++ lib.optionals withDeltaUpdates [
+      cbor2
+      xxhash
+    ];
+
+  configureFlags =
+    (prev.configureFlags or [])
+    ++ [
+      "--use-system-pyzstd"
+      "--use-system-urllib"
+    ];
+
+  preCheck = ''
+    ${prev.preCheck or ""}
+
+    # Some tests require a writable HOME
+    export HOME=$(mktemp -d)
+  '';
+})


### PR DESCRIPTION
Prepare for the upcoming version bump in nixpkgs, by making the unnecessary or conflicting overrides conditional on the version of the package being overridden.

This is compatible with nixpkgs inputs both with and without https://github.com/NixOS/nixpkgs/pull/381975, because we can check the base-package's version and choose an override impl based on that.

If the base package is older than 1.2.0, we use the old/current impl. If the package is 1.2.0 or newer, we can drop those overrides and only use the newer simpler impl.

I've split the old & new impl into separate files to simplify the diff and make the eventual removal easier.

### Testing

To test the "old" impl, you can simply clone this PR and run `nix build`.

To test the "new" impl, against https://github.com/NixOS/nixpkgs/pull/381975, you can override the `nixpkgs` input and then build:

```sh
nix flake lock --override-input nixpkgs 'github:nixos/nixpkgs?ref=pull/381975/merge'

nix build
```

> [!TIP]
> Use `ref=pull/<number>/merge` to test a PR merged with the latest nixpkgs master
> or use `ref=pull/<number>/head` to test the PR itself.

cc @beh-10257 @LovingMelody @diniamo @R1kaB3rN

Nixpkgs PR https://github.com/NixOS/nixpkgs/pull/381975