### PR TITLE
Update zipapp workflow

### DIFF
--- a/.github/workflows/build-umu-zipapp.yml
+++ b/.github/workflows/build-umu-zipapp.yml
@@ -36,10 +36,10 @@ jobs:
     - name: Create symlink for launchers
       # To preserve file mode bits and link file, use a tar archive.
       # See https://github.com/actions/upload-artifact?tab=readme-ov-file#permission-loss
-      run: cd results && ln -s umu-run umu_run.py && mkdir umu && mv umu-run umu/ && mv umu_run.py umu/ && tar cvf umu-launcher-${{ inputs.version }}-zipapp.tar.gz umu/
+      run: cd results && ln -s umu-run umu_run.py && mkdir umu && mv umu-run umu/ && mv umu_run.py umu/ && tar cvf umu-launcher-${{ inputs.version }}-zipapp.tar umu/
 
     - name: Upload artifact
       uses: actions/upload-artifact@v4
       with:
-        name: umu-launcher-${{ inputs.version }}-zipapp.tar.gz
-        path: results/umu-launcher-${{ inputs.version }}-zipapp.tar.gz
+        name: umu-launcher-${{ inputs.version }}-zipapp.tar
+        path: results/umu-launcher-${{ inputs.version }}-zipapp.tar

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,5 +78,5 @@ jobs:
     uses: ./.github/workflows/build-umu-publish-release.yml
     with:
       version: ${{ github.ref_name }}
-      file1: umu-launcher-${{ github.ref_name }}-zipapp.tar.gz
-      name1: umu-launcher-${{ github.ref_name }}-zipapp.tar.gz
+      file1: umu-launcher-${{ github.ref_name }}-zipapp.tar
+      name1: umu-launcher-${{ github.ref_name }}-zipapp.tar

--- a/configure.sh
+++ b/configure.sh
@@ -192,7 +192,7 @@ usage() {
   "$1" "                      [/usr]"
   "$1" "    --user-install    Install under user-only location. Incompatible with --prefix"
   "$1" "                      [$HOME/.local]"
-  "$1" "    --use-system-pystd"
+  "$1" "    --use-system-pyzstd"
   "$1" "                      Do not use vendored pyzstd"
   "$1" "    --use-system-urllib"
   "$1" "                      Do not use vendored urllib"


### PR DESCRIPTION
The archive was not compressed before, so to avoid further issues, just remove the suffix instead of compressing it.
