### PR TITLE
build(nix): minor fixes

### DIFF
--- a/packaging/nix/unwrapped.nix
+++ b/packaging/nix/unwrapped.nix
@@ -25,6 +25,12 @@ umu-launcher-unwrapped.overridePythonAttrs (prev: {
   #   https://github.com/Open-Wine-Components/umu-launcher/pull/343
   patches = [];
 
+  nativeCheckInputs =
+    (prev.nativeCheckInputs or [])
+    ++ [
+      python3Packages.pytestCheckHook
+    ];
+
   nativeBuildInputs =
     (prev.nativeBuildInputs or [])
     ++ [
@@ -52,4 +58,22 @@ umu-launcher-unwrapped.overridePythonAttrs (prev: {
       "--use-system-pyzstd"
       "--use-system-urllib"
     ];
+
+  disabledTests = [
+    # Broken? Asserts that $STEAM_RUNTIME_LIBRARY_PATH is non-empty
+    # Fails with AssertionError: '' is not true : Expected two elements in STEAM_RUNTIME_LIBRARY_PATHS
+    "test_game_drive_empty"
+    "test_game_drive_libpath_empty"
+
+    # Broken? Tests parse_args with no options (./umu_run.py)
+    # Fails with AssertionError: SystemExit not raised
+    "test_parse_args_noopts"
+  ];
+
+  preCheck = ''
+    ${prev.preCheck or ""}
+
+    # Some tests require a writable HOME
+    export HOME=$(mktemp -d)
+  '';
 })


### PR DESCRIPTION
Based on @R1kaB3rN's feedback in https://github.com/NixOS/nixpkgs/pull/381975

Pushed up separately to #374, so that we can keep that one small & atomic.

- Use configure flags to disable building vendored dependencies
- Ensure pystd is always installed - it isn't optional
- Switch from `propagatedBuildInputs` to `pythonPath`
- Move cargo lock to before dependencies
- Added check phase

cc @beh-10257 @LovingMelody @R1kaB3rN
