### PR TITLE
refactor: update runtime directory structure

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -51,6 +51,11 @@ jobs:
           source .venv/bin/activate
           sh tests/test_install.sh
           rm -rf "$HOME/.local/share/umu" "$HOME/Games/umu" "$HOME/.local/share/Steam/compatibilitytools.d"
+      - name: Test obsolete steamrt install
+        run: |
+          source .venv/bin/activate
+          sh tests/test_install_obsolete.sh
+          rm -rf "$HOME/.local/share/umu" "$HOME/Games/umu" "$HOME/.local/share/Steam/compatibilitytools.d"
       - name: Test steamrt update
         run: |
           source .venv/bin/activate

--- a/tests/test_config.sh
+++ b/tests/test_config.sh
@@ -19,5 +19,5 @@ store = 'gog'
 " >> "$tmp"
 
 
-UMU_LOG=debug GAMEID=umu-1141086411 STORE=gog "$PWD/.venv/bin/python" "$HOME/.local/bin/umu-run" --config "$tmp" 2> /tmp/umu-log.txt && grep -E "INFO: Non-steam game Silent Hill 4: The Room \(umu-1141086411\)" /tmp/umu-log.txt
+RUNTIMEPATH=steamrt3 UMU_LOG=debug GAMEID=umu-1141086411 STORE=gog "$PWD/.venv/bin/python" "$HOME/.local/bin/umu-run" --config "$tmp" 2> /tmp/umu-log.txt && grep -E "INFO: Non-steam game Silent Hill 4: The Room \(umu-1141086411\)" /tmp/umu-log.txt
 # Run the 'game' using UMU-Proton9.0-3.2 and ensure the protonfixes module finds its fix in umu-database.csv

--- a/tests/test_install_obsolete.sh
+++ b/tests/test_install_obsolete.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env sh
+
+tmp=$(mktemp)
+mkdir -p "$HOME/.local/share/Steam/compatibilitytools.d"
+curl -LJO "https://github.com/GloriousEggroll/proton-ge-custom/releases/download/GE-Proton7-55/GE-Proton7-55.tar.gz"
+tar xaf GE-Proton7-55.tar.gz
+mv GE-Proton7-55 "$HOME/.local/share/Steam/compatibilitytools.d"
+
+UMU_LOG=debug PROTONPATH=GE-Proton7-55 "$HOME/.local/bin/umu-run" wineboot -u

--- a/tests/test_install_obsolete.sh
+++ b/tests/test_install_obsolete.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env sh
 
-tmp=$(mktemp)
 mkdir -p "$HOME/.local/share/Steam/compatibilitytools.d"
 curl -LJO "https://github.com/GloriousEggroll/proton-ge-custom/releases/download/GE-Proton7-55/GE-Proton7-55.tar.gz"
 tar xaf GE-Proton7-55.tar.gz

--- a/tests/test_offline.sh
+++ b/tests/test_offline.sh
@@ -13,20 +13,20 @@ url=$(curl -L "https://api.github.com/repos/Open-Wine-Components/umu-proton/rele
 # Download Proton
 curl -LJO "$url"
 
-mkdir -p "$HOME"/.local/share/Steam/compatibilitytools.d "$HOME"/.local/share/umu "$HOME"/Games/umu
+mkdir -p "$HOME"/.local/share/Steam/compatibilitytools.d "$HOME"/.local/share/umu/steamrt3 "$HOME"/Games/umu
 
 # Extract the archives
 tar xaf "$name" -C "$HOME"/.local/share/Steam/compatibilitytools.d
 tar xaf SteamLinuxRuntime_sniper.tar.xz
 
-cp -a SteamLinuxRuntime_sniper/* "$HOME"/.local/share/umu
-mv "$HOME"/.local/share/umu/_v2-entry-point "$HOME"/.local/share/umu/umu
+cp -a SteamLinuxRuntime_sniper/* "$HOME"/.local/share/umu/steamrt3
+mv "$HOME"/.local/share/umu/steamrt3/_v2-entry-point "$HOME"/.local/share/umu/steamrt3/umu
 
 # Run offline using bwrap
 # TODO: Figure out why the command exits with a 127 when offline. The point
 # is that we're able to enter the container and we do not crash. For now,
 # just query a string that shows that session was offline
-UMU_LOG=debug GAMEID=umu-0 bwrap --unshare-net --bind / / --dev /dev --bind "$HOME" "$HOME" -- "$HOME/.local/bin/umu-run" wineboot -u 2> "$tmp"
+RUNTIMEPATH=steamrt3 UMU_LOG=debug GAMEID=umu-0 bwrap --unshare-net --bind / / --dev /dev --bind "$HOME" "$HOME" -- "$HOME/.local/bin/umu-run" wineboot -u 2> "$tmp"
 
 # Check if we exited. If we logged this statement then there were no errors
 # before entering the container

--- a/tests/test_resume.sh
+++ b/tests/test_resume.sh
@@ -9,5 +9,5 @@ mkdir -p "$HOME"/.cache/umu
 # Move to our cache so it can be picked up then resumed.
 # Note: Must include the *.parts extension
 mv SteamLinuxRuntime_sniper.tar.xz "$HOME"/.cache/umu/SteamLinuxRuntime_sniper.tar.xz."$id".parts
-UMU_LOG=debug GAMEID=umu-0 "$HOME/.local/bin/umu-run" wineboot -u 2> "$tmp"
+RUNTIMEPATH=steamrt3 UMU_LOG=debug GAMEID=umu-0 "$HOME/.local/bin/umu-run" wineboot -u 2> "$tmp"
 grep "resuming" "$tmp" && grep "exited with wait status" "$tmp"

--- a/tests/test_update.sh
+++ b/tests/test_update.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env sh
 
-mkdir -p "$HOME/.local/share/umu"
+mkdir -p "$HOME/.local/share/umu/steamrt3"
 
 curl -LJO "https://repo.steampowered.com/steamrt3/images/0.20240916.101795/SteamLinuxRuntime_sniper.tar.xz"
 tar xaf SteamLinuxRuntime_sniper.tar.xz
-mv SteamLinuxRuntime_sniper/* "$HOME/.local/share/umu"
-mv "$HOME/.local/share/umu/_v2-entry-point" "$HOME/.local/share/umu/umu"
-echo "$@" > "$HOME/.local/share/umu/umu-shim" && chmod 700 "$HOME/.local/share/umu/umu-shim"
+mv SteamLinuxRuntime_sniper/* "$HOME/.local/share/umu/steamrt3"
+mv "$HOME/.local/share/umu/steamrt3/_v2-entry-point" "$HOME/.local/share/umu/steamrt3/umu"
+echo "$@" > "$HOME/.local/share/umu/steamrt3/umu-shim" && chmod 700 "$HOME/.local/share/umu/steamrt3/umu-shim"
 
 # Perform a preflight step, where we ensure everything is in order and create '$HOME/.local/share/umu/var'
 # Afterwards, run a 2nd time to perform the runtime update and ensure '$HOME/.local/share/umu/var' is removed
-UMU_LOG=debug GAMEID=umu-0 UMU_RUNTIME_UPDATE=0 "$HOME/.local/bin/umu-run" wineboot -u && UMU_LOG=debug GAMEID=umu-0 "$HOME/.local/bin/umu-run" wineboot -u
+UMU_LOG=debug GAMEID=umu-0 UMU_RUNTIME_UPDATE=0 "$HOME/.local/bin/umu-run" wineboot -u && RUNTIMEPATH=steamrt3 UMU_LOG=debug GAMEID=umu-0 "$HOME/.local/bin/umu-run" wineboot -u

--- a/umu/__init__.py
+++ b/umu/__init__.py
@@ -1,3 +1,6 @@
 __version__ = "1.2.5"  # noqa: D104
-__runtime_versions__ = (("sniper", "steamrt3"), ("soldier", "steamrt2"))
+__runtime_versions__ = (
+    ("sniper", "steamrt3", "1628350"),
+    ("soldier", "steamrt2", "1391110"),
+)
 __runtime_version__ = __runtime_versions__[0]

--- a/umu/umu_consts.py
+++ b/umu/umu_consts.py
@@ -36,6 +36,14 @@ class GamescopeAtom(Enum):
     BaselayerAppId = "GAMESCOPECTRL_BASELAYER_APPID"
 
 
+class FileLock(Enum):
+    """Files placed with an exclusive lock via flock(2)."""
+
+    Runtime = "umu.lock"  # UMU_RUNTIME lock
+    Compat = "compatibilitytools.d.lock"  # PROTONPATH lock
+    Prefix = "pfx.lock"  # WINEPREFIX lock
+
+
 STEAM_COMPAT: Path = Path.home().joinpath(
     ".local", "share", "Steam", "compatibilitytools.d"
 )

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -260,9 +260,7 @@ def set_env(
     env["UMU_NO_RUNTIME"] = os.environ.get("UMU_NO_RUNTIME") or ""
     env["UMU_RUNTIME_UPDATE"] = os.environ.get("UMU_RUNTIME_UPDATE") or ""
     env["UMU_NO_PROTON"] = os.environ.get("UMU_NO_PROTON") or ""
-    env["RUNTIMEPATH"] = (
-        "" if os.environ.get("UMU_NO_RUNTIME") else os.environ.get("RUNTIMEPATH", "")
-    )
+    env["RUNTIMEPATH"] = f"{UMU_LOCAL}/{os.environ['RUNTIMEPATH']}"
 
     return env
 

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -894,7 +894,7 @@ def umu_run(args: Namespace | tuple[str, list[str]]) -> int:
             opts = args[1]  # Reference the executable options
             check_env(env, session_pools)
 
-        UMU_LOCAL.mkdir(parents=True, exist_ok=True)
+        UMU_LOCAL.joinpath(version[1]).mkdir(parents=True, exist_ok=True)
 
         # Prepare the prefix
         with unix_flock(f"{UMU_LOCAL}/{FileLock.Prefix.value}"):

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -258,12 +258,9 @@ def set_env(
     env["UMU_NO_RUNTIME"] = os.environ.get("UMU_NO_RUNTIME") or ""
     env["UMU_RUNTIME_UPDATE"] = os.environ.get("UMU_RUNTIME_UPDATE") or ""
     env["UMU_NO_PROTON"] = os.environ.get("UMU_NO_PROTON") or ""
-    if not env.get("UMU_NO_RUNTIME") and os.environ.get("RUNTIMEPATH"):
-        env["RUNTIMEPATH"] = str(
-            UMU_LOCAL.joinpath(os.environ["RUNTIMEPATH"]).resolve(strict=True)
-        )
-    else:
-        env["RUNTIMEPATH"] = ""
+    env["RUNTIMEPATH"] = (
+        "" if os.environ.get("UMU_NO_RUNTIME") else os.environ.get("RUNTIMEPATH", "")
+    )
 
     return env
 

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -42,6 +42,7 @@ from umu.umu_consts import (
     STEAM_COMPAT,
     STEAM_WINDOW_ID,
     UMU_LOCAL,
+    FileLock,
     GamescopeAtom,
 )
 from umu.umu_log import log
@@ -814,7 +815,7 @@ def umu_run(args: Namespace | tuple[str, list[str]]) -> int:
         UMU_LOCAL.mkdir(parents=True, exist_ok=True)
 
         # Prepare the prefix
-        with unix_flock(f"{UMU_LOCAL}/pfx.lock"):
+        with unix_flock(f"{UMU_LOCAL}/{FileLock.Prefix.value}"):
             setup_pfx(env["WINEPREFIX"])
 
         # Configure the environment

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -702,9 +702,7 @@ def run_command(command: tuple[Path | str, ...]) -> int:
     return ret
 
 
-def resolve_umu_version(
-    runtime: RuntimeVersion, runtimes: tuple[RuntimeVersion, ...]
-) -> RuntimeVersion | None:
+def resolve_umu_version(runtimes: tuple[RuntimeVersion, ...]) -> RuntimeVersion | None:
     """Resolve the required runtime of a compatibility tool."""
     version: tuple[str, str, str] | None = None
 
@@ -716,18 +714,18 @@ def resolve_umu_version(
         )
 
     if not os.environ.get("PROTONPATH"):
-        log.debug("PROTONPATH unset, defaulting to '%s'", runtime[1])
-        return runtime
+        log.debug("PROTONPATH unset, defaulting to '%s'", runtimes[0][1])
+        return runtimes[0]
 
     # Default to latest runtime for codenames
     if os.environ.get("PROTONPATH") in {"GE-Proton", "GE-Latest", "UMU-Latest"}:
-        log.debug("PROTONPATH is codename, defaulting to '%s'", runtime[1])
-        return runtime
+        log.debug("PROTONPATH is codename, defaulting to '%s'", runtimes[0][1])
+        return runtimes[0]
 
     # Default to latest runtime for native Linux executables
     if os.environ.get("UMU_NO_PROTON"):
-        log.debug("UMU_NO_PROTON set, defaulting to '%s'", runtime[1])
-        return runtime
+        log.debug("UMU_NO_PROTON set, defaulting to '%s'", runtimes[0][1])
+        return runtimes[0]
 
     # Solve the required runtime for PROTONPATH
     log.debug("PROTONPATH set, resolving its required runtime")
@@ -857,7 +855,7 @@ def umu_run(args: Namespace | tuple[str, list[str]]) -> int:
         raise RuntimeError(err)
 
     # Resolve the runtime version for PROTONPATH
-    version = resolve_umu_version(__runtime_version__, __runtime_versions__)
+    version = resolve_umu_version(__runtime_versions__)
     if not version:
         err: str = (
             f"Failed to match '{os.environ.get('PROTONPATH')}' with a container runtime"

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -239,7 +239,9 @@ def set_env(
     env["PROTONPATH"] = str(protonpath)
     env["STEAM_COMPAT_DATA_PATH"] = env["WINEPREFIX"]
     env["STEAM_COMPAT_SHADER_PATH"] = f"{env['STEAM_COMPAT_DATA_PATH']}/shadercache"
-    env["STEAM_COMPAT_TOOL_PATHS"] = f"{env['PROTONPATH']}:{UMU_LOCAL}"
+    env["STEAM_COMPAT_TOOL_PATHS"] = (
+        f"{env['PROTONPATH']}:{UMU_LOCAL}/{os.environ['RUNTIMEPATH']}"
+    )
     env["STEAM_COMPAT_MOUNTS"] = env["STEAM_COMPAT_TOOL_PATHS"]
 
     # Zenity

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -258,9 +258,12 @@ def set_env(
     env["UMU_NO_RUNTIME"] = os.environ.get("UMU_NO_RUNTIME") or ""
     env["UMU_RUNTIME_UPDATE"] = os.environ.get("UMU_RUNTIME_UPDATE") or ""
     env["UMU_NO_PROTON"] = os.environ.get("UMU_NO_PROTON") or ""
-    env["RUNTIMEPATH"] = (
-        "" if os.environ.get("UMU_NO_RUNTIME") else os.environ.get("RUNTIMEPATH", "")
-    )
+    if not env.get("UMU_NO_RUNTIME") and os.environ.get("RUNTIMEPATH"):
+        env["RUNTIMEPATH"] = str(
+            UMU_LOCAL.joinpath(os.environ["RUNTIMEPATH"]).resolve(strict=True)
+        )
+    else:
+        env["RUNTIMEPATH"] = ""
 
     return env
 

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -37,7 +37,7 @@ from Xlib.protocol.request import GetProperty
 from Xlib.protocol.rq import Event
 from Xlib.xobject.drawable import Window
 
-from umu import __runtime_version__, __runtime_versions__, __version__
+from umu import __runtime_versions__, __version__
 from umu.umu_consts import (
     PR_SET_CHILD_SUBREAPER,
     PROTON_VERBS,

--- a/umu/umu_runtime.py
+++ b/umu/umu_runtime.py
@@ -543,7 +543,7 @@ def _update_umu_platform(
     latest: bytes = sha256(resp.data).digest()
     current: bytes = sha256(local.joinpath("VERSIONS.txt").read_bytes()).digest()
     versions: Path = local.joinpath("VERSIONS.txt")
-    lock: str = f"{UMU_LOCAL}/{FileLock.Runtime.value}"
+    lock: str = f"{local.parent}/{FileLock.Runtime.value}"
 
     # Compare our version file to upstream's, updating if different
     if latest != current:

--- a/umu/umu_runtime.py
+++ b/umu/umu_runtime.py
@@ -472,7 +472,7 @@ def _restore_umu(
     session_pools: SessionPools,
     callback_fn: Callable[[], bool],
 ) -> None:
-    lock: str = f"{UMU_LOCAL}/{FileLock.Runtime.value}"
+    lock: str = f"{local.parent}/{FileLock.Runtime.value}"
     with unix_flock(lock):
         log.debug("Acquired file lock '%s'...", lock)
         if callback_fn():

--- a/umu/umu_runtime.py
+++ b/umu/umu_runtime.py
@@ -20,7 +20,7 @@ from urllib3.exceptions import TimeoutError as TimeoutErrorUrllib3
 from urllib3.poolmanager import PoolManager
 from urllib3.response import BaseHTTPResponse
 
-from umu.umu_consts import UMU_CACHE, UMU_LOCAL, FileLock, HTTPMethod
+from umu.umu_consts import UMU_CACHE, FileLock, HTTPMethod
 from umu.umu_log import log
 from umu.umu_util import (
     extract_tarfile,

--- a/umu/umu_runtime.py
+++ b/umu/umu_runtime.py
@@ -36,7 +36,7 @@ RuntimeVersion = tuple[str, str, str]
 SessionPools = tuple[ThreadPoolExecutor, PoolManager]
 
 
-def create_shim(file_path: Path | None = None):
+def create_shim(file_path: Path):
     """Create a shell script shim at the specified file path.
 
     This script sets the DISPLAY environment variable if certain conditions
@@ -44,13 +44,8 @@ def create_shim(file_path: Path | None = None):
 
     Args:
         file_path (Path, optional): The path where the shim script will be created.
-            Defaults to UMU_LOCAL.joinpath("umu-shim").
 
     """
-    # Set the default path if none is provided
-    if file_path is None:
-        file_path = UMU_LOCAL.joinpath("umu-shim")
-
     # Define the content of the shell script
     script_content = (
         "#!/bin/sh\n"

--- a/umu/umu_test.py
+++ b/umu/umu_test.py
@@ -725,11 +725,12 @@ class TestGameLauncher(unittest.TestCase):
             TemporaryDirectory() as file,
             patch.object(umu_runtime, "_install_umu"),
         ):
-            mock_local = Path(file)
+            mock_subdir = Path(file).joinpath("steamrt3")
+            mock_subdir.mkdir(parents=True, exist_ok=True)
             mock_runtime_ver = ("sniper", "steamrt3", "1628350")
             mock_session_pools = (MagicMock(), MagicMock())
             result = umu_runtime._restore_umu(
-                mock_local, mock_runtime_ver, mock_session_pools, mock_cb
+                mock_subdir.parent, mock_runtime_ver, mock_session_pools, mock_cb
             )
             self.assertTrue(result is None, f"Expected None, received {result}")
             self.assertTrue(
@@ -743,11 +744,12 @@ class TestGameLauncher(unittest.TestCase):
         result = MagicMock()
 
         with TemporaryDirectory() as file:
-            mock_local = Path(file)
+            mock_subdir = Path(file).joinpath("steamrt3")
+            mock_subdir.mkdir(parents=True, exist_ok=True)
             mock_runtime_ver = ("sniper", "steamrt3", "1628350")
             mock_session_pools = (MagicMock(), MagicMock())
             result = umu_runtime._restore_umu(
-                mock_local, mock_runtime_ver, mock_session_pools, mock_cb
+                mock_subdir.parent, mock_runtime_ver, mock_session_pools, mock_cb
             )
             self.assertTrue(result is None, f"Expected None, received {result}")
             self.assertTrue(

--- a/umu/umu_test.py
+++ b/umu/umu_test.py
@@ -726,7 +726,7 @@ class TestGameLauncher(unittest.TestCase):
             patch.object(umu_runtime, "_install_umu"),
         ):
             mock_local = Path(file)
-            mock_runtime_ver = ("sniper", "steamrt3")
+            mock_runtime_ver = ("sniper", "steamrt3", "1628350")
             mock_session_pools = (MagicMock(), MagicMock())
             result = umu_runtime._restore_umu(
                 mock_local, mock_runtime_ver, mock_session_pools, mock_cb
@@ -744,7 +744,7 @@ class TestGameLauncher(unittest.TestCase):
 
         with TemporaryDirectory() as file:
             mock_local = Path(file)
-            mock_runtime_ver = ("sniper", "steamrt3")
+            mock_runtime_ver = ("sniper", "steamrt3", "1628350")
             mock_session_pools = (MagicMock(), MagicMock())
             result = umu_runtime._restore_umu(
                 mock_local, mock_runtime_ver, mock_session_pools, mock_cb
@@ -764,7 +764,7 @@ class TestGameLauncher(unittest.TestCase):
             # Populate our fake $XDG_DATA_HOME/umu
             Path(file2, "umu").touch()
             # Mock the runtime ver
-            mock_runtime_ver = ("sniper", "steamrt3")
+            mock_runtime_ver = ("sniper", "steamrt3", "1628350")
             # Mock our thread and conn pool
             mock_session_pools = (MagicMock(), MagicMock())
             with patch.object(umu_runtime, "_update_umu"):
@@ -786,7 +786,7 @@ class TestGameLauncher(unittest.TestCase):
             # Populate our fake $XDG_DATA_HOME/umu
             Path(file2, "umu").touch()
             # Mock the runtime ver
-            mock_runtime_ver = ("sniper", "steamrt3")
+            mock_runtime_ver = ("sniper", "steamrt3", "1628350")
             # Mock our thread and conn pool
             mock_session_pools = (MagicMock(), MagicMock())
             with patch.object(umu_runtime, "_restore_umu"):
@@ -805,7 +805,7 @@ class TestGameLauncher(unittest.TestCase):
         # Mock a new install
         with TemporaryDirectory() as file1, TemporaryDirectory() as file2:
             # Mock the runtime ver
-            mock_runtime_ver = ("sniper", "steamrt3")
+            mock_runtime_ver = ("sniper", "steamrt3", "1628350")
             # Mock our thread and conn pool
             mock_session_pools = (MagicMock(), MagicMock())
             with patch.object(umu_runtime, "_restore_umu"):
@@ -850,7 +850,7 @@ class TestGameLauncher(unittest.TestCase):
         mock_tp = MagicMock()
 
         # Mock runtime ver
-        mock_runtime_ver = ("sniper", "steamrt3")
+        mock_runtime_ver = ("sniper", "steamrt3", "1628350")
 
         with TemporaryDirectory() as file:
             mock_runtime_base = Path(file)
@@ -879,7 +879,7 @@ class TestGameLauncher(unittest.TestCase):
         mock_tp = MagicMock()
 
         # Mock runtime ver
-        mock_runtime_ver = ("sniper", "steamrt3")
+        mock_runtime_ver = ("sniper", "steamrt3", "1628350")
 
         with TemporaryDirectory() as file:
             mock_runtime_base = Path(file)
@@ -920,7 +920,7 @@ class TestGameLauncher(unittest.TestCase):
         mock_tp = MagicMock()
 
         # Mock runtime ver
-        mock_runtime_ver = ("sniper", "steamrt3")
+        mock_runtime_ver = ("sniper", "steamrt3", "1628350")
 
         with TemporaryDirectory() as file:
             mock_runtime_base = Path(file)
@@ -965,7 +965,7 @@ class TestGameLauncher(unittest.TestCase):
         mock_tp = MagicMock()
 
         # Mock runtime ver
-        mock_runtime_ver = ("sniper", "steamrt3")
+        mock_runtime_ver = ("sniper", "steamrt3", "1628350")
 
         with TemporaryDirectory() as file:
             mock_runtime_base = Path(file)

--- a/umu/umu_test.py
+++ b/umu/umu_test.py
@@ -70,6 +70,7 @@ class TestGameLauncher(unittest.TestCase):
             "STEAM_FOSSILIZE_DUMP_PATH": "",
             "DXVK_STATE_CACHE_PATH": "",
             "UMU_NO_PROTON": "",
+            "RUNTIMEPATH": "",
         }
         self.user = getpwuid(os.getuid()).pw_name
         self.test_opts = "-foo -bar"
@@ -2569,7 +2570,9 @@ class TestGameLauncher(unittest.TestCase):
                 self.env["STEAM_COMPAT_TOOL_PATHS"],
                 self.env["PROTONPATH"]
                 + ":"
-                + Path.home().joinpath(".local", "share", "umu").as_posix(),
+                + Path.home()
+                .joinpath(".local", "share", "umu", self.test_runtime_version[1])
+                .as_posix(),
                 "Expected STEAM_COMPAT_TOOL_PATHS to be set",
             )
             self.assertEqual(
@@ -2683,7 +2686,9 @@ class TestGameLauncher(unittest.TestCase):
                 self.env["STEAM_COMPAT_TOOL_PATHS"],
                 self.env["PROTONPATH"]
                 + ":"
-                + Path.home().joinpath(".local", "share", "umu").as_posix(),
+                + Path.home()
+                .joinpath(".local", "share", "umu", self.test_runtime_version[1])
+                .as_posix(),
                 "Expected STEAM_COMPAT_TOOL_PATHS to be set",
             )
             self.assertEqual(
@@ -2802,7 +2807,9 @@ class TestGameLauncher(unittest.TestCase):
                 self.env["STEAM_COMPAT_TOOL_PATHS"],
                 self.env["PROTONPATH"]
                 + ":"
-                + Path.home().joinpath(".local", "share", "umu").as_posix(),
+                + Path.home()
+                .joinpath(".local", "share", "umu", self.test_runtime_version[1])
+                .as_posix(),
                 "Expected STEAM_COMPAT_TOOL_PATHS to be set",
             )
             self.assertEqual(
@@ -2934,7 +2941,9 @@ class TestGameLauncher(unittest.TestCase):
                 self.env["STEAM_COMPAT_TOOL_PATHS"],
                 self.env["PROTONPATH"]
                 + ":"
-                + Path.home().joinpath(".local", "share", "umu").as_posix(),
+                + Path.home()
+                .joinpath(".local", "share", "umu", self.test_runtime_version[1])
+                .as_posix(),
                 "Expected STEAM_COMPAT_TOOL_PATHS to be set",
             )
             self.assertEqual(

--- a/umu/umu_test.py
+++ b/umu/umu_test.py
@@ -1867,6 +1867,7 @@ class TestGameLauncher(unittest.TestCase):
             os.environ["PROTONPATH"] = self.test_file
             os.environ["GAMEID"] = self.test_file
             os.environ["STORE"] = self.test_file
+            os.environ["RUNTIMEPATH"] = self.test_runtime_version[1]
             # Args
             args = __main__.parse_args()
             # Config
@@ -1930,6 +1931,7 @@ class TestGameLauncher(unittest.TestCase):
             os.environ["PROTONPATH"] = self.test_file
             os.environ["GAMEID"] = self.test_file
             os.environ["STORE"] = self.test_file
+            os.environ["RUNTIMEPATH"] = self.test_runtime_version[1]
             # Args
             args = __main__.parse_args()
             # Config
@@ -2026,6 +2028,7 @@ class TestGameLauncher(unittest.TestCase):
             os.environ["PROTONPATH"] = self.test_file
             os.environ["GAMEID"] = self.test_file
             os.environ["STORE"] = self.test_file
+            os.environ["RUNTIMEPATH"] = self.test_runtime_version[1]
             # Args
             args = __main__.parse_args()
             # Config
@@ -2101,6 +2104,7 @@ class TestGameLauncher(unittest.TestCase):
             os.environ["GAMEID"] = self.test_file
             os.environ["STORE"] = self.test_file
             os.environ["UMU_NO_PROTON"] = "1"
+            os.environ["RUNTIMEPATH"] = self.test_runtime_version[1]
             # Args
             result_args = __main__.parse_args()
             # Config
@@ -2188,6 +2192,7 @@ class TestGameLauncher(unittest.TestCase):
             os.environ["GAMEID"] = self.test_file
             os.environ["STORE"] = self.test_file
             os.environ["UMU_NO_RUNTIME"] = "1"
+            os.environ["RUNTIMEPATH"] = self.test_runtime_version[1]
             # Args
             result_args = __main__.parse_args()
             # Config
@@ -2266,6 +2271,7 @@ class TestGameLauncher(unittest.TestCase):
             os.environ["GAMEID"] = self.test_file
             os.environ["STORE"] = self.test_file
             os.environ["UMU_NO_RUNTIME"] = "pressure-vessel"
+            os.environ["RUNTIMEPATH"] = self.test_runtime_version[1]
             # Args
             result_args = __main__.parse_args()
             # Config
@@ -2313,6 +2319,7 @@ class TestGameLauncher(unittest.TestCase):
             os.environ["PROTONPATH"] = self.test_file
             os.environ["GAMEID"] = self.test_file
             os.environ["STORE"] = self.test_file
+            os.environ["RUNTIMEPATH"] = self.test_runtime_version[1]
             # Args
             result_args = __main__.parse_args()
             # Config
@@ -2405,6 +2412,7 @@ class TestGameLauncher(unittest.TestCase):
             os.environ["GAMEID"] = test_str
             os.environ["STORE"] = test_str
             os.environ["PROTON_VERB"] = self.test_verb
+            os.environ["RUNTIMEPATH"] = self.test_runtime_version[1]
             # Args
             result = __main__.parse_args()
             # Check
@@ -2485,6 +2493,7 @@ class TestGameLauncher(unittest.TestCase):
             os.environ["GAMEID"] = umu_id
             os.environ["STORE"] = test_str
             os.environ["PROTON_VERB"] = self.test_verb
+            os.environ["RUNTIMEPATH"] = self.test_runtime_version[1]
             # Args
             result = __main__.parse_args()
             # Check
@@ -2590,6 +2599,7 @@ class TestGameLauncher(unittest.TestCase):
             os.environ["GAMEID"] = test_str
             os.environ["STORE"] = test_str
             os.environ["PROTON_VERB"] = self.test_verb
+            os.environ["RUNTIMEPATH"] = self.test_runtime_version[1]
             # Args
             result = __main__.parse_args()
             # Check
@@ -2703,6 +2713,7 @@ class TestGameLauncher(unittest.TestCase):
             os.environ["STORE"] = test_str
             os.environ["PROTON_VERB"] = self.test_verb
             os.environ["UMU_RUNTIME_UPDATE"] = "0"
+            os.environ["RUNTIMEPATH"] = self.test_runtime_version[1]
             # Args
             result = __main__.parse_args()
             # Check
@@ -2830,6 +2841,7 @@ class TestGameLauncher(unittest.TestCase):
             os.environ["PROTONPATH"] = test_dir.as_posix()
             os.environ["GAMEID"] = test_str
             os.environ["PROTON_VERB"] = proton_verb
+            os.environ["RUNTIMEPATH"] = self.test_runtime_version[1]
             # Args
             result = __main__.parse_args()
             # Check

--- a/umu/umu_test.py
+++ b/umu/umu_test.py
@@ -97,10 +97,13 @@ class TestGameLauncher(unittest.TestCase):
         # /usr/share/umu
         self.test_user_share = Path("./tmp.BXk2NnvW2m")
         # ~/.local/share/Steam/compatibilitytools.d
-        self.test_local_share = Path("./tmp.aDl73CbQCP")
+        self.test_runtime_version = ("sniper", "steamrt3", "1628350")
+        self.test_local_share_parent = Path("./tmp.aDl73CbQCP")
+        self.test_local_share = self.test_local_share_parent.joinpath(
+            self.test_runtime_version[1]
+        )
         # Wine prefix
         self.test_winepfx = Path("./tmp.AlfLPDhDvA")
-        self.test_runtime_version = ("sniper", "steamrt3", "1628350")
         # Thread pool and connection pool instances
         self.test_session_pools = (MagicMock(), MagicMock())
 
@@ -109,7 +112,7 @@ class TestGameLauncher(unittest.TestCase):
 
         self.test_winepfx.mkdir(exist_ok=True)
         self.test_user_share.mkdir(exist_ok=True)
-        self.test_local_share.mkdir(exist_ok=True)
+        self.test_local_share.mkdir(parents=True, exist_ok=True)
         self.test_cache.mkdir(exist_ok=True)
         self.test_compat.mkdir(exist_ok=True)
         self.test_proton_dir.mkdir(exist_ok=True)
@@ -180,6 +183,9 @@ class TestGameLauncher(unittest.TestCase):
 
         if self.test_local_share.exists():
             rmtree(self.test_local_share.as_posix())
+
+        if self.test_local_share_parent.exists():
+            rmtree(self.test_local_share_parent)
 
         if self.test_winepfx.exists():
             rmtree(self.test_winepfx.as_posix())
@@ -731,7 +737,7 @@ class TestGameLauncher(unittest.TestCase):
             mock_runtime_ver = ("sniper", "steamrt3", "1628350")
             mock_session_pools = (MagicMock(), MagicMock())
             result = umu_runtime._restore_umu(
-                mock_subdir.parent, mock_runtime_ver, mock_session_pools, mock_cb
+                mock_subdir, mock_runtime_ver, mock_session_pools, mock_cb
             )
             self.assertTrue(result is None, f"Expected None, received {result}")
             self.assertTrue(
@@ -750,7 +756,7 @@ class TestGameLauncher(unittest.TestCase):
             mock_runtime_ver = ("sniper", "steamrt3", "1628350")
             mock_session_pools = (MagicMock(), MagicMock())
             result = umu_runtime._restore_umu(
-                mock_subdir.parent, mock_runtime_ver, mock_session_pools, mock_cb
+                mock_subdir, mock_runtime_ver, mock_session_pools, mock_cb
             )
             self.assertTrue(result is None, f"Expected None, received {result}")
             self.assertTrue(
@@ -765,7 +771,9 @@ class TestGameLauncher(unittest.TestCase):
         # Mock a new install
         with TemporaryDirectory() as file1, TemporaryDirectory() as file2:
             # Populate our fake $XDG_DATA_HOME/umu
-            Path(file2, "umu").touch()
+            mock_subdir = Path(file2, self.test_runtime_version[1])
+            mock_subdir.mkdir()
+            mock_subdir.joinpath("umu").touch()
             # Mock the runtime ver
             mock_runtime_ver = ("sniper", "steamrt3", "1628350")
             # Mock our thread and conn pool
@@ -773,7 +781,7 @@ class TestGameLauncher(unittest.TestCase):
             with patch.object(umu_runtime, "_update_umu"):
                 result = umu_runtime.setup_umu(
                     Path(file1),
-                    Path(file2),
+                    mock_subdir,
                     mock_runtime_ver,
                     mock_session_pools,
                 )
@@ -787,7 +795,9 @@ class TestGameLauncher(unittest.TestCase):
         # Mock a new install
         with TemporaryDirectory() as file1, TemporaryDirectory() as file2:
             # Populate our fake $XDG_DATA_HOME/umu
-            Path(file2, "umu").touch()
+            mock_subdir = Path(file2, self.test_runtime_version[1])
+            mock_subdir.mkdir()
+            mock_subdir.joinpath("umu").touch()
             # Mock the runtime ver
             mock_runtime_ver = ("sniper", "steamrt3", "1628350")
             # Mock our thread and conn pool
@@ -795,7 +805,7 @@ class TestGameLauncher(unittest.TestCase):
             with patch.object(umu_runtime, "_restore_umu"):
                 result = umu_runtime.setup_umu(
                     Path(file1),
-                    Path(file2),
+                    mock_subdir,
                     mock_runtime_ver,
                     mock_session_pools,
                 )
@@ -807,6 +817,9 @@ class TestGameLauncher(unittest.TestCase):
 
         # Mock a new install
         with TemporaryDirectory() as file1, TemporaryDirectory() as file2:
+            mock_subdir = Path(file2, self.test_runtime_version[1])
+            mock_subdir.mkdir()
+            mock_subdir.joinpath("umu").touch()
             # Mock the runtime ver
             mock_runtime_ver = ("sniper", "steamrt3", "1628350")
             # Mock our thread and conn pool
@@ -814,7 +827,7 @@ class TestGameLauncher(unittest.TestCase):
             with patch.object(umu_runtime, "_restore_umu"):
                 result = umu_runtime.setup_umu(
                     Path(file1),
-                    Path(file2),
+                    mock_subdir,
                     mock_runtime_ver,
                     mock_session_pools,
                 )

--- a/umu/umu_test.py
+++ b/umu/umu_test.py
@@ -99,7 +99,7 @@ class TestGameLauncher(unittest.TestCase):
         self.test_local_share = Path("./tmp.aDl73CbQCP")
         # Wine prefix
         self.test_winepfx = Path("./tmp.AlfLPDhDvA")
-        self.test_runtime_version = ("sniper", "steamrt3")
+        self.test_runtime_version = ("sniper", "steamrt3", "1628350")
         # Thread pool and connection pool instances
         self.test_session_pools = (MagicMock(), MagicMock())
 

--- a/umu/umu_test.py
+++ b/umu/umu_test.py
@@ -1149,26 +1149,6 @@ class TestGameLauncher(unittest.TestCase):
                 os.access(shim, os.X_OK), f"Expected '{shim}' to be executable"
             )
 
-    def test_create_shim_none(self):
-        """Test create_shim when not passed a Path."""
-        shim = None
-
-        # When not passed a Path, the function should default to creating $HOME/.local/share/umu/umu-shim
-        with (
-            TemporaryDirectory() as tmp,
-            patch.object(Path, "joinpath", return_value=Path(tmp, "umu-shim")),
-        ):
-            umu_runtime.create_shim()
-            self.assertTrue(
-                Path(tmp, "umu-shim").is_file(),
-                f"Expected '{shim}' to be a file",
-            )
-            # Ensure there's data
-            self.assertTrue(
-                Path(tmp, "umu-shim").stat().st_size > 0,
-                f"Expected '{shim}' to have data",
-            )
-
     def test_create_shim(self):
         """Test create_shim."""
         shim = None

--- a/umu/umu_test_plugins.py
+++ b/umu/umu_test_plugins.py
@@ -65,7 +65,7 @@ class TestGameLauncherPlugins(unittest.TestCase):
         self.test_user_share = Path("./tmp.jl3W4MtO57")
         # ~/.local/share/Steam/compatibilitytools.d
         self.test_local_share = Path("./tmp.WUaQAk7hQJ")
-        self.test_runtime_version = ("sniper", "steamrt3")
+        self.test_runtime_version = ("sniper", "steamrt3", "1628350")
 
         self.test_user_share.mkdir(exist_ok=True)
         self.test_local_share.mkdir(exist_ok=True)

--- a/umu/umu_test_plugins.py
+++ b/umu/umu_test_plugins.py
@@ -181,6 +181,7 @@ class TestGameLauncherPlugins(unittest.TestCase):
             "parse_args",
             return_value=argparse.Namespace(config=toml_path),
         ):
+            os.environ["RUNTIMEPATH"] = self.test_runtime_version[1]
             # Args
             result = __main__.parse_args()
             # Config
@@ -256,6 +257,7 @@ class TestGameLauncherPlugins(unittest.TestCase):
             "parse_args",
             return_value=argparse.Namespace(config=toml_path),
         ):
+            os.environ["RUNTIMEPATH"] = self.test_runtime_version[1]
             # Args
             result = __main__.parse_args()
             # Config
@@ -337,6 +339,7 @@ class TestGameLauncherPlugins(unittest.TestCase):
             "parse_args",
             return_value=argparse.Namespace(config=toml_path),
         ):
+            os.environ["RUNTIMEPATH"] = self.test_runtime_version[1]
             # Args
             result = __main__.parse_args()
             # Config


### PR DESCRIPTION
- Updates the file structure of `$HOME/.local/share/umu` to store container runtimes in subdirectories organized by codename. This obsoletes the files `mtree.txt.gz`, `pressure-vessel`, `README.md`, `run`, `run-in-sniper`, `sniper_platform_*`, `steampipe`, `toolmanifest.vdf`, `umu`, `umu-shim`, `var`, and `VERSIONS.txt` in the top-level of `$HOME/.local/share/umu`. This change is necessary in preparation for a potential change in the Steam Linux Runtime base platform, and to support switching to different runtimes. Manual intervention will be **required** by the user to remove the files.
- Adds support for explicitly changing to a specific container runtime.
- Adds support for automatically assigning the correct container runtime for PROTONPATH.
- Adds support for using obsolete Protons down to v5.13. Helpful for clients (e.g., Heroic Games Launcher) which allow its users to use obsolete Protons for their games.
