### PR TITLE
umu_run: do not force the runtime for winetricks if `UMU_NO_RUNTIME` is set

### DIFF
--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -324,11 +324,10 @@ def build_command(
     if env.get("EXE", "").endswith("winetricks") and opts:
         # The position of arguments matter for winetricks
         # Usage: ./winetricks [options] [command|verb|path-to-verb] ...
+        runtime_cmd: list[str|Path] = [entry_point, "--verb", env["PROTON_VERB"], "--"] if env.get(
+            "UMU_NO_RUNTIME") != "1" else []
         return (
-            entry_point,
-            "--verb",
-            env["PROTON_VERB"],
-            "--",
+            *runtime_cmd,
             proton,
             env["PROTON_VERB"],
             env["EXE"],


### PR DESCRIPTION
Since #293 is still under discussion, I am re-opening this as an interim solution to using `winetricks` with `proton-cachyos`

As it is now, trying to run `winetricks` enforces the use of the runtime even if `UMU_NO_RUNTIME` is set. This causes `proton-cachyos` to not run in its expected environment.

PR #293 is meant to address this in a seamless manner without exposing development features, but until then `UMU_NO_RUNTIME` is the feature itself.
