### PR TITLE
packaging/nix/flake.lock: Update

### DIFF
--- a/packaging/nix/flake.lock
+++ b/packaging/nix/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1738136902,
-        "narHash": "sha256-pUvLijVGARw4u793APze3j6mU1Zwdtz7hGkGGkD87qw=",
+        "lastModified": 1740547748,
+        "narHash": "sha256-Ly2fBL1LscV+KyCqPRufUBuiw+zmWrlJzpWOWbahplg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9a5db3142ce450045840cc8d832b13b8a2018e0c",
+        "rev": "3a05eebede89661660945da1f151959900903b6a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/9a5db3142ce450045840cc8d832b13b8a2018e0c?narHash=sha256-pUvLijVGARw4u793APze3j6mU1Zwdtz7hGkGGkD87qw%3D' (2025-01-29)
  → 'github:NixOS/nixpkgs/3a05eebede89661660945da1f151959900903b6a?narHash=sha256-Ly2fBL1LscV%2BKyCqPRufUBuiw%2BzmWrlJzpWOWbahplg%3D' (2025-02-26)
```

Since #399 is blocking the flake updates CI from opening PRs, here's a manual update PR.

Produced using:
```sh
nix flake update --commit-lock-file --flake ./packaging/nix
```

I've also tested this builds ok with #402 cherry-picked.