### PR TITLE
umu_log: do not use colors if stderr is not an interactive terminal

### DIFF
--- a/umu/umu_log.py
+++ b/umu/umu_log.py
@@ -1,3 +1,4 @@
+import os
 import sys
 from logging import (
     Formatter,
@@ -60,7 +61,8 @@ class CustomFormatter(Formatter):  # noqa: D101
                 color = Color.WARNING
             case _:
                 color = Color.BOLD
-        record.levelname = f"{color}{Color.BOLD}{record.levelname}{Color.RESET}"
+        if os.isatty(sys.stderr.fileno()):
+            record.levelname = f"{color}{Color.BOLD}{record.levelname}{Color.RESET}"
         return super().format(record)
 
 

--- a/umu/umu_log.py
+++ b/umu/umu_log.py
@@ -43,6 +43,8 @@ class CustomLogger(Logger):  # noqa: D101
 
 class CustomFormatter(Formatter):  # noqa: D101
     def format(self, record: LogRecord) -> str:  # noqa: D102
+        if not os.isatty(sys.stderr.fileno()):
+            return super().format(record)
         color: str
         match record.levelname:
             case "INFO":
@@ -61,8 +63,7 @@ class CustomFormatter(Formatter):  # noqa: D101
                 color = Color.WARNING
             case _:
                 color = Color.BOLD
-        if os.isatty(sys.stderr.fileno()):
-            record.levelname = f"{color}{Color.BOLD}{record.levelname}{Color.RESET}"
+        record.levelname = f"{color}{Color.BOLD}{record.levelname}{Color.RESET}"
         return super().format(record)
 
 


### PR DESCRIPTION
Disables using color codes in the log when the log is being directed to a non-interactive shell, such as when logging to a file.