### PR TITLE
Reapply "umu_run: handle Protons without an explicit runtime requirement"

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,13 @@ Borderlands 3 from EGS store.
 3. In our umu unified database, we create a 'title' column, 'store' column, 'codename' column, 'umu-ID' column. We add a line for Borderlands 3 and fill in the details for each column.
 4. Now the launcher can search 'Catnip' and 'egs' as the codename and store in the database and correlate it with Borderlands 3 and umu-12345. It can then feed umu-12345 to the `umu-run` script.
 
+## Reporting issues
+
+When reporting issues for games that fail to run, be sure to attach a log with your issue report. To acquire a log from umu, add `UMU_LOG=1` to your environment variables for verbose logging. Furthermore, you can use `PROTON_LOG=1` for proton to create a verbose log in your `$HOME` directory. The log will be named `steam-<appid>.log`, where `<appid>` will be `default` if you haven't set a `GAMEID` or a number, depending on what you have set for `GAMEID`.
+
+Do **NOT** report issues when using `UMU_NO_RUNTIME=1`, this option is provided for convenience for compatibility tools that do not set their runtime requirements, such as Proton < `5.13`, and they do not work with any of the supported runtimes.
+This mode does not make use of a container runtime, and issues while using it are irrelevant to umu-launcher in general. Thus such issues will be automatically closed.
+
 ## Building
 
 Building umu-launcher currently requires `bash`, `make`, and `scdoc` for distribution, as well as the following Python build tools: [build](https://github.com/pypa/build), [hatchling](https://github.com/pypa/hatch), [installer](https://github.com/pypa/installer), and [pip](https://github.com/pypa/pip).

--- a/docs/umu.1.scd
+++ b/docs/umu.1.scd
@@ -176,6 +176,13 @@ _UMU_NO_PROTON_
 
 	Set _1_ to run the executable natively within the SLR.
 
+_UMU_NO_RUNTIME_
+	Optional. Allows for the configured compatibility tool to run outside of the Steam Linux Runtime.
+	This option is effective only if the compatibility tool doesn't require a runtime through its configuration.
+	On compatibility tools that require a runtime, this option is ignored.
+
+	Set _1_ to silence umu's error that it couldn't resolve a runtime to use, and run using the host's libraries.
+
 # SEE ALSO
 
 _umu_(5), _winetricks_(1)

--- a/tests/test_config.sh
+++ b/tests/test_config.sh
@@ -19,5 +19,6 @@ store = 'gog'
 " >> "$tmp"
 
 
+# This works only for an existing prefix, the prefix `~/Games/umu/umu-0` is created in the previous workflow steps
 RUNTIMEPATH=steamrt3 UMU_LOG=debug GAMEID=umu-1141086411 STORE=gog "$PWD/.venv/bin/python" "$HOME/.local/bin/umu-run" --config "$tmp" 2> /tmp/umu-log.txt && grep -E "INFO: Non-steam game Silent Hill 4: The Room \(umu-1141086411\)" /tmp/umu-log.txt
 # Run the 'game' using UMU-Proton9.0-3.2 and ensure the protonfixes module finds its fix in umu-database.csv

--- a/umu/umu_plugins.py
+++ b/umu/umu_plugins.py
@@ -52,9 +52,9 @@ def set_env_toml(
     _check_env_toml(toml)
 
     # Required environment variables
-    env["WINEPREFIX"] = toml["umu"]["prefix"]
-    env["PROTONPATH"] = toml["umu"]["proton"]
-    env["EXE"] = toml["umu"]["exe"]
+    env["WINEPREFIX"] = str(Path(toml["umu"]["prefix"]).expanduser())
+    env["PROTONPATH"] = str(Path(toml["umu"]["proton"]).expanduser())
+    env["EXE"] = str(Path(toml["umu"]["exe"]).expanduser())
     # Optional
     env["GAMEID"] = toml["umu"].get("game_id", "")
     env["STORE"] = toml["umu"].get("store", "")

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -839,7 +839,9 @@ def umu_run(args: Namespace | tuple[str, list[str]]) -> int:
             f"Failed to match '{os.environ.get('PROTONPATH')}' with a container runtime"
         )
         raise ValueError(err)
-    os.environ["RUNTIMEPATH"] = runtime_version[1]
+    # runtime_name, runtime_variant, runtime_appid
+    _, runtime_variant, _ = runtime_version
+    os.environ["RUNTIMEPATH"] = runtime_variant
 
     # Opt to use the system's native CA bundle rather than certifi's
     with suppress(ModuleNotFoundError):
@@ -864,11 +866,11 @@ def umu_run(args: Namespace | tuple[str, list[str]]) -> int:
         # Setup the launcher and runtime files
         _, do_download = check_env(env)
 
-        if runtime_version[1] != "host":
-            UMU_LOCAL.joinpath(runtime_version[1]).mkdir(parents=True, exist_ok=True)
+        if runtime_variant != "host":
+            UMU_LOCAL.joinpath(runtime_variant).mkdir(parents=True, exist_ok=True)
 
             future: Future = thread_pool.submit(
-                setup_umu, UMU_LOCAL / runtime_version[1], runtime_version, session_pools
+                setup_umu, UMU_LOCAL / runtime_variant, runtime_version, session_pools
             )
 
             download_proton(do_download, env, session_pools)
@@ -910,7 +912,7 @@ def umu_run(args: Namespace | tuple[str, list[str]]) -> int:
         sys.exit(1)
 
     # Build the command
-    command: tuple[Path | str, ...] = build_command(env, UMU_LOCAL, runtime_version[1], opts)
+    command: tuple[Path | str, ...] = build_command(env, UMU_LOCAL, runtime_variant, opts)
     log.debug("%s", command)
 
     # Run the command

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -39,7 +39,7 @@ from umu.umu_consts import (
 from umu.umu_log import log
 from umu.umu_plugins import set_env_toml
 from umu.umu_proton import get_umu_proton
-from umu.umu_runtime import setup_umu
+from umu.umu_runtime import create_shim, setup_umu
 from umu.umu_util import (
     get_libc,
     get_library_paths,
@@ -88,9 +88,7 @@ def setup_pfx(path: str) -> None:
         wineuser.symlink_to("steamuser")
 
 
-def check_env(
-    env: dict[str, str], session_pools: tuple[ThreadPoolExecutor, PoolManager]
-) -> dict[str, str] | dict[str, Any]:
+def check_env(env: dict[str, str]) -> tuple[dict[str, str] | dict[str, Any], bool]:
     """Before executing a game, check for environment variables and set them.
 
     GAMEID is strictly required and the client is responsible for setting this.
@@ -122,9 +120,10 @@ def check_env(
 
     env["WINEPREFIX"] = os.environ.get("WINEPREFIX", "")
 
+    do_download = False
     # Skip Proton if running a native Linux executable
     if os.environ.get("UMU_NO_PROTON") == "1":
-        return env
+        return env, do_download
 
     # Proton Version
     path: Path = STEAM_COMPAT.joinpath(os.environ.get("PROTONPATH", ""))
@@ -133,24 +132,34 @@ def check_env(
 
     # Proton Codename
     if os.environ.get("PROTONPATH") in {"GE-Proton", "GE-Latest", "UMU-Latest"}:
-        get_umu_proton(env, session_pools)
+        do_download = True
 
     if "PROTONPATH" not in os.environ:
         os.environ["PROTONPATH"] = ""
-        get_umu_proton(env, session_pools)
+        do_download = True
 
     env["PROTONPATH"] = os.environ["PROTONPATH"]
 
+    return env, do_download
+
+
+def download_proton(download: bool, env: dict[str, str], session_pools: tuple[ThreadPoolExecutor, PoolManager]) -> None:
+    """Check if umu should download proton and check if PROTONPATH is set.
+
+    I am not gonna lie about it, this only exists to satisfy the tests, because downloading
+    was previously nested in `check_env()`
+    """
+    if download:
+        get_umu_proton(env, session_pools)
+
     # If download fails/doesn't exist in the system, raise an error
-    if not os.environ["PROTONPATH"]:
+    if os.environ.get("UMU_NO_PROTON") != "1" and not os.environ["PROTONPATH"]:
         err: str = (
             "Environment variable not set or is empty: PROTONPATH\n"
             f"Possible reason: GE-Proton or UMU-Proton not found in '{STEAM_COMPAT}'"
             " or network error"
         )
         raise FileNotFoundError(err)
-
-    return env
 
 
 def set_env(
@@ -288,12 +297,17 @@ def enable_steam_game_drive(env: dict[str, str]) -> dict[str, str]:
 def build_command(
     env: dict[str, str],
     local: Path,
-    opts: list[str] = [],
+    version: str,
+    opts: list[str] | None = None,
 ) -> tuple[Path | str, ...]:
     """Build the command to be executed."""
     shim: Path = local.joinpath("umu-shim")
     proton: Path = Path(env["PROTONPATH"], "proton")
-    entry_point: Path = local.joinpath("umu")
+    entry_point: tuple[Path, str, str, str] | tuple[()] = (
+        local.joinpath(version, "umu"), "--verb", env["PROTON_VERB"], "--"
+    ) if version != "host" else ()
+    if opts is None:
+        opts = []
 
     if env.get("UMU_NO_PROTON") != "1" and not proton.is_file():
         err: str = "The following file was not found in PROTONPATH: proton"
@@ -302,7 +316,7 @@ def build_command(
     # Exit if the entry point is missing
     # The _v2-entry-point script and container framework tools are included in
     # the same image, so this can happen if the image failed to download
-    if not entry_point.is_file():
+    if entry_point and not entry_point[0].is_file():
         err: str = (
             f"_v2-entry-point (umu) cannot be found in '{local}'\n"
             "Runtime Platform missing or download incomplete"
@@ -314,10 +328,7 @@ def build_command(
         # The position of arguments matter for winetricks
         # Usage: ./winetricks [options] [command|verb|path-to-verb] ...
         return (
-            entry_point,
-            "--verb",
-            env["PROTON_VERB"],
-            "--",
+            *entry_point,
             proton,
             env["PROTON_VERB"],
             env["EXE"],
@@ -329,7 +340,7 @@ def build_command(
     # Ideally, for reliability, executables should be compiled within
     # the Steam Runtime
     if env.get("UMU_NO_PROTON") == "1":
-        return (entry_point, "--verb", env["PROTON_VERB"], "--", env["EXE"], *opts)
+        return *entry_point, env["EXE"], *opts
 
     # Will run the game outside the Steam Runtime w/ Proton
     if env.get("UMU_NO_RUNTIME") == "1":
@@ -337,10 +348,7 @@ def build_command(
         return proton, env["PROTON_VERB"], env["EXE"], *opts
 
     return (
-        entry_point,
-        "--verb",
-        env["PROTON_VERB"],
-        "--",
+        *entry_point,
         shim,
         proton,
         env["PROTON_VERB"],
@@ -703,6 +711,9 @@ def resolve_umu_version(runtimes: tuple[RuntimeVersion, ...]) -> RuntimeVersion 
     path = Path(os.environ["PROTONPATH"], "toolmanifest.vdf").resolve()
     if path.is_file():
         version = get_umu_version_from_manifest(path, runtimes)
+    else:
+        err: str = f"PROTONPATH '{os.environ['PROTONPATH']}' is not valid, toolmanifest.vdf not found"
+        raise FileNotFoundError(err)
 
     return version
 
@@ -724,7 +735,7 @@ def get_umu_version_from_manifest(
                 break
 
     if not appid:
-        return None
+        return "host", "host", "host"
 
     if appid not in appids:
         return None
@@ -812,6 +823,12 @@ def umu_run(args: Namespace | tuple[str, list[str]]) -> int:
         )
         raise RuntimeError(err)
 
+    if isinstance(args, Namespace):
+        env, opts = set_env_toml(env, args)
+        os.environ.update({k: v for k, v in env.items() if bool(v)})
+    else:
+        opts = args[1]  # Reference the executable options
+
     # Resolve the runtime version for PROTONPATH
     version = resolve_umu_version(__runtime_versions__)
     if not version:
@@ -833,36 +850,25 @@ def umu_run(args: Namespace | tuple[str, list[str]]) -> int:
     # Default to a strict 5 second timeouts throughout
     timeout: Timeout = Timeout(connect=NET_TIMEOUT, read=NET_TIMEOUT)
 
+    # ensure base directory exists
+    UMU_LOCAL.mkdir(parents=True, exist_ok=True)
+
     with (
         ThreadPoolExecutor() as thread_pool,
         PoolManager(timeout=timeout, retries=retries) as http_pool,
     ):
         session_pools: tuple[ThreadPoolExecutor, PoolManager] = (thread_pool, http_pool)
         # Setup the launcher and runtime files
-        future: Future = thread_pool.submit(
-            setup_umu, UMU_LOCAL / version[1], version, session_pools
-        )
+        _, do_download = check_env(env)
 
-        if isinstance(args, Namespace):
-            env, opts = set_env_toml(env, args)
-        else:
-            opts = args[1]  # Reference the executable options
-            check_env(env, session_pools)
+        if version[1] != "host":
+            UMU_LOCAL.joinpath(version[1]).mkdir(parents=True, exist_ok=True)
 
-        UMU_LOCAL.joinpath(version[1]).mkdir(parents=True, exist_ok=True)
+            future: Future = thread_pool.submit(
+                setup_umu, UMU_LOCAL / version[1], version, session_pools
+            )
 
-        # Prepare the prefix
-        with unix_flock(f"{UMU_LOCAL}/{FileLock.Prefix.value}"):
-            setup_pfx(env["WINEPREFIX"])
-
-        # Configure the environment
-        set_env(env, args)
-
-        # Set all environment variables
-        # NOTE: `env` after this block should be read only
-        for key, val in env.items():
-            log.debug("%s=%s", key, val)
-            os.environ[key] = val
+            download_proton(do_download, env, session_pools)
 
         try:
             future.result()
@@ -877,6 +883,23 @@ def umu_run(args: Namespace | tuple[str, list[str]]) -> int:
         except Exception as e:
             log.exception(e)
 
+        # Prepare the prefix
+        with unix_flock(f"{UMU_LOCAL}/{FileLock.Prefix.value}"):
+            setup_pfx(env["WINEPREFIX"])
+
+        # Configure the environment
+        set_env(env, args)
+
+        # Restore shim if missing
+        if not UMU_LOCAL.joinpath("umu-shim").is_file():
+            create_shim(UMU_LOCAL / "umu-shim")
+
+        # Set all environment variables
+        # NOTE: `env` after this block should be read only
+        for key, val in env.items():
+            log.debug("%s=%s", key, val)
+            os.environ[key] = val
+
     # Exit if the winetricks verb is already installed to avoid reapplying it
     if env["EXE"].endswith("winetricks") and is_installed_verb(
         opts, Path(env["WINEPREFIX"])
@@ -884,7 +907,7 @@ def umu_run(args: Namespace | tuple[str, list[str]]) -> int:
         sys.exit(1)
 
     # Build the command
-    command: tuple[Path | str, ...] = build_command(env, UMU_LOCAL / version[1], opts)
+    command: tuple[Path | str, ...] = build_command(env, UMU_LOCAL, version[1], opts)
     log.debug("%s", command)
 
     # Run the command

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -232,14 +232,16 @@ def set_env(
     env["SteamGameId"] = env["SteamAppId"]
     env["UMU_INVOCATION_ID"] = token_hex(16)
 
+    runtime_path = f"{UMU_LOCAL}/{os.environ['RUNTIMEPATH']}" if os.environ['RUNTIMEPATH'] != "host" else ""
+
     # PATHS
     env["WINEPREFIX"] = str(pfx)
     env["PROTONPATH"] = str(protonpath)
     env["STEAM_COMPAT_DATA_PATH"] = env["WINEPREFIX"]
     env["STEAM_COMPAT_SHADER_PATH"] = f"{env['STEAM_COMPAT_DATA_PATH']}/shadercache"
-    env["STEAM_COMPAT_TOOL_PATHS"] = (
-        f"{env['PROTONPATH']}:{UMU_LOCAL}/{os.environ['RUNTIMEPATH']}"
-    )
+    env["STEAM_COMPAT_TOOL_PATHS"] = ":".join(
+        [f"{env['PROTONPATH']}", runtime_path]
+    ) if runtime_path else f"{env['PROTONPATH']}"
     env["STEAM_COMPAT_MOUNTS"] = env["STEAM_COMPAT_TOOL_PATHS"]
 
     # Zenity
@@ -258,7 +260,7 @@ def set_env(
     env["UMU_NO_RUNTIME"] = os.environ.get("UMU_NO_RUNTIME") or ""
     env["UMU_RUNTIME_UPDATE"] = os.environ.get("UMU_RUNTIME_UPDATE") or ""
     env["UMU_NO_PROTON"] = os.environ.get("UMU_NO_PROTON") or ""
-    env["RUNTIMEPATH"] = f"{UMU_LOCAL}/{os.environ['RUNTIMEPATH']}"
+    env["RUNTIMEPATH"] = runtime_path
 
     return env
 
@@ -780,7 +782,7 @@ def umu_run(args: Namespace | tuple[str, list[str]]) -> int:
     }
     opts: list[str] = []
     prereq: bool = False
-    version: RuntimeVersion | None = None
+    runtime_version: RuntimeVersion | None = None
 
     log.info("umu-launcher version %s (%s)", __version__, sys.version)
 
@@ -828,13 +830,13 @@ def umu_run(args: Namespace | tuple[str, list[str]]) -> int:
         opts = args[1]  # Reference the executable options
 
     # Resolve the runtime version for PROTONPATH
-    version = resolve_umu_version(__runtime_versions__)
-    if not version:
+    runtime_version = resolve_umu_version(__runtime_versions__)
+    if not runtime_version:
         err: str = (
             f"Failed to match '{os.environ.get('PROTONPATH')}' with a container runtime"
         )
         raise ValueError(err)
-    os.environ["RUNTIMEPATH"] = version[1]
+    os.environ["RUNTIMEPATH"] = runtime_version[1]
 
     # Opt to use the system's native CA bundle rather than certifi's
     with suppress(ModuleNotFoundError):
@@ -859,11 +861,11 @@ def umu_run(args: Namespace | tuple[str, list[str]]) -> int:
         # Setup the launcher and runtime files
         _, do_download = check_env(env)
 
-        if version[1] != "host":
-            UMU_LOCAL.joinpath(version[1]).mkdir(parents=True, exist_ok=True)
+        if runtime_version[1] != "host":
+            UMU_LOCAL.joinpath(runtime_version[1]).mkdir(parents=True, exist_ok=True)
 
             future: Future = thread_pool.submit(
-                setup_umu, UMU_LOCAL / version[1], version, session_pools
+                setup_umu, UMU_LOCAL / runtime_version[1], runtime_version, session_pools
             )
 
             download_proton(do_download, env, session_pools)
@@ -905,7 +907,7 @@ def umu_run(args: Namespace | tuple[str, list[str]]) -> int:
         sys.exit(1)
 
     # Build the command
-    command: tuple[Path | str, ...] = build_command(env, UMU_LOCAL, version[1], opts)
+    command: tuple[Path | str, ...] = build_command(env, UMU_LOCAL, runtime_version[1], opts)
     log.debug("%s", command)
 
     # Run the command

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -342,11 +342,6 @@ def build_command(
     if env.get("UMU_NO_PROTON") == "1":
         return *entry_point, env["EXE"], *opts
 
-    # Will run the game outside the Steam Runtime w/ Proton
-    if env.get("UMU_NO_RUNTIME") == "1":
-        log.warning("Runtime Platform disabled")
-        return proton, env["PROTON_VERB"], env["EXE"], *opts
-
     return (
         *entry_point,
         shim,
@@ -735,7 +730,10 @@ def get_umu_version_from_manifest(
                 break
 
     if not appid:
-        return "host", "host", "host"
+        if os.environ.get("UMU_NO_RUNTIME", None) == "1":
+            log.warning("Runtime Platform disabled")
+            return "host", "host", "host"
+        return None
 
     if appid not in appids:
         return None

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -143,7 +143,7 @@ def check_env(env: dict[str, str]) -> tuple[dict[str, str] | dict[str, Any], boo
     return env, do_download
 
 
-def download_proton(download: bool, env: dict[str, str], session_pools: tuple[ThreadPoolExecutor, PoolManager]) -> None:
+def download_proton(env: dict[str, str], session_pools: tuple[ThreadPoolExecutor, PoolManager], *, download: bool) -> None:
     """Check if umu should download proton and check if PROTONPATH is set.
 
     I am not gonna lie about it, this only exists to satisfy the tests, because downloading
@@ -732,13 +732,8 @@ def get_umu_version_from_manifest(
                 break
 
     if not appid:
-        if os.environ.get("UMU_NO_RUNTIME", None) == "1":
-            log.warning(
-                "Runtime Platform disabled. This mode is UNSUPPORTED by umu and remains only for convenience. "
-                "Issues created while using this mode will be automatically closed."
-            )
-            return "host", "host", "host"
-        return None
+        os.environ["UMU_RUNTIME_UPDATE"] = "0"
+        return "host", "host", "host"
 
     if appid not in appids:
         return None
@@ -873,7 +868,7 @@ def umu_run(args: Namespace | tuple[str, list[str]]) -> int:
                 setup_umu, UMU_LOCAL / runtime_variant, runtime_version, session_pools
             )
 
-            download_proton(do_download, env, session_pools)
+            download_proton(env, session_pools, download=do_download)
 
         try:
             future.result()

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -733,7 +733,10 @@ def get_umu_version_from_manifest(
 
     if not appid:
         if os.environ.get("UMU_NO_RUNTIME", None) == "1":
-            log.warning("Runtime Platform disabled")
+            log.warning(
+                "Runtime Platform disabled. This mode is UNSUPPORTED by umu and remains only for convenience. "
+                "Issues created while using this mode will be automatically closed."
+            )
             return "host", "host", "host"
         return None
 

--- a/umu/umu_runtime.py
+++ b/umu/umu_runtime.py
@@ -258,8 +258,6 @@ def _install_umu(
     log.debug("Renaming: _v2-entry-point -> umu")
     local.joinpath("_v2-entry-point").rename(local.joinpath("umu"))
 
-    create_shim(local / "umu-shim")
-
     # Validate the runtime after moving the files
     check_runtime(local, runtime_ver)
 
@@ -367,10 +365,6 @@ def _update_umu(
 
     # Update our runtime
     _update_umu_platform(local, runtime, runtime_ver, session_pools, resp)
-
-    # Restore shim if missing
-    if not local.joinpath("umu-shim").is_file():
-        create_shim(local / "umu-shim")
 
     log.info("%s is up to date", variant)
 

--- a/umu/umu_test.py
+++ b/umu/umu_test.py
@@ -1428,7 +1428,7 @@ class TestGameLauncher(unittest.TestCase):
             os.environ["GAMEID"] = self.test_file
             os.environ["PROTONPATH"] = "GE-Proton"
             result_env, result_dl = umu_run.check_env(self.env)
-            umu_run.download_proton(result_dl, result_env, self.test_session_pools)
+            umu_run.download_proton(result_env, self.test_session_pools, download=result_dl)
             self.assertEqual(
                 self.env["PROTONPATH"],
                 self.test_compat.joinpath(
@@ -1456,7 +1456,7 @@ class TestGameLauncher(unittest.TestCase):
             os.environ["GAMEID"] = self.test_file
             os.environ["PROTONPATH"] = "GE-Proton"
             result_env, result_dl = umu_run.check_env(self.env)
-            umu_run.download_proton(result_dl, result_env, mock_session_pools)
+            umu_run.download_proton(result_env, mock_session_pools, download=result_dl)
             self.assertFalse(os.environ.get("PROTONPATH"), "Expected empty string")
 
     def test_latest_interrupt(self):
@@ -1818,7 +1818,7 @@ class TestGameLauncher(unittest.TestCase):
             args = __main__.parse_args()
             # Config
             result_env, result_dl = umu_run.check_env(self.env)
-            umu_run.download_proton(result_dl, result_env, thread_pool)
+            umu_run.download_proton(result_env, thread_pool, download=result_dl)
             # Prefix
             umu_run.setup_pfx(self.env["WINEPREFIX"])
             # Env
@@ -1916,7 +1916,7 @@ class TestGameLauncher(unittest.TestCase):
             args = __main__.parse_args()
             # Config
             result_env, result_dl = umu_run.check_env(self.env)
-            umu_run.download_proton(result_dl, result_env, thread_pool)
+            umu_run.download_proton(result_env, thread_pool, download=result_dl)
             # Prefix
             umu_run.setup_pfx(self.env["WINEPREFIX"])
             # Env
@@ -1993,7 +1993,7 @@ class TestGameLauncher(unittest.TestCase):
             result_args = __main__.parse_args()
             # Config
             result_env, result_dl = umu_run.check_env(self.env)
-            umu_run.download_proton(result_dl, result_env, thread_pool)
+            umu_run.download_proton(result_env, thread_pool, download=result_dl)
             # Prefix
             umu_run.setup_pfx(self.env["WINEPREFIX"])
             # Env
@@ -2096,7 +2096,7 @@ class TestGameLauncher(unittest.TestCase):
             # Config
             _, result_dl = umu_run.check_env(self.env)
             if version[1] != "host":
-                umu_run.download_proton(result_dl, self.env, thread_pool)
+                umu_run.download_proton(self.env, thread_pool, download=result_dl)
             # Prefix
             umu_run.setup_pfx(self.env["WINEPREFIX"])
             # Env
@@ -2196,7 +2196,7 @@ class TestGameLauncher(unittest.TestCase):
             # Config
             _, result_dl = umu_run.check_env(self.env)
             if version[1] != "host":
-                umu_run.download_proton(result_dl, self.env, thread_pool)
+                umu_run.download_proton(self.env, thread_pool, download=result_dl)
             # Prefix
             umu_run.setup_pfx(self.env["WINEPREFIX"])
             # Env
@@ -2276,7 +2276,7 @@ class TestGameLauncher(unittest.TestCase):
             result_args = __main__.parse_args()
             # Config
             result_env, result_dl = umu_run.check_env(self.env)
-            umu_run.download_proton(result_dl, result_env, thread_pool)
+            umu_run.download_proton(result_env, thread_pool, download=result_dl)
             # Prefix
             umu_run.setup_pfx(self.env["WINEPREFIX"])
             # Env
@@ -2325,7 +2325,7 @@ class TestGameLauncher(unittest.TestCase):
             result_args = __main__.parse_args()
             # Config
             result_env, result_dl = umu_run.check_env(self.env)
-            umu_run.download_proton(result_dl, result_env, thread_pool)
+            umu_run.download_proton(result_env, thread_pool, download=result_dl)
             # Prefix
             umu_run.setup_pfx(self.env["WINEPREFIX"])
             # Env
@@ -2418,7 +2418,7 @@ class TestGameLauncher(unittest.TestCase):
             result = __main__.parse_args()
             # Check
             result_env, result_dl = umu_run.check_env(self.env)
-            umu_run.download_proton(result_dl, result_env, thread_pool)
+            umu_run.download_proton(result_env, thread_pool, download=result_dl)
             # Prefix
             umu_run.setup_pfx(self.env["WINEPREFIX"])
 
@@ -2500,7 +2500,7 @@ class TestGameLauncher(unittest.TestCase):
             result = __main__.parse_args()
             # Check
             result_env, result_dl = umu_run.check_env(self.env)
-            umu_run.download_proton(result_dl, result_env, thread_pool)
+            umu_run.download_proton(result_env, thread_pool, download=result_dl)
             # Prefix
             umu_run.setup_pfx(self.env["WINEPREFIX"])
             # Env
@@ -2609,7 +2609,7 @@ class TestGameLauncher(unittest.TestCase):
             result = __main__.parse_args()
             # Check
             result_env, result_dl = umu_run.check_env(self.env)
-            umu_run.download_proton(result_dl, result_env, thread_pool)
+            umu_run.download_proton(result_env, thread_pool, download=result_dl)
             # Prefix
             umu_run.setup_pfx(self.env["WINEPREFIX"])
             # Env
@@ -2726,7 +2726,7 @@ class TestGameLauncher(unittest.TestCase):
             result = __main__.parse_args()
             # Check
             result_env, result_dl = umu_run.check_env(self.env)
-            umu_run.download_proton(result_dl, result_env, thread_pool)
+            umu_run.download_proton(result_env, thread_pool, download=result_dl)
             # Prefix
             umu_run.setup_pfx(self.env["WINEPREFIX"])
             # Env
@@ -2857,7 +2857,7 @@ class TestGameLauncher(unittest.TestCase):
             result = __main__.parse_args()
             # Check
             result_env, result_dl = umu_run.check_env(self.env)
-            umu_run.download_proton(result_dl, result_env, thread_pool)
+            umu_run.download_proton(result_env, thread_pool, download=result_dl)
             # Prefix
             umu_run.setup_pfx(self.env["WINEPREFIX"])
             # Env
@@ -3399,7 +3399,7 @@ class TestGameLauncher(unittest.TestCase):
             os.environ["WINEPREFIX"] = self.test_file
             os.environ["GAMEID"] = self.test_file
             result_env, result_dl = umu_run.check_env(self.env)
-            umu_run.download_proton(result_dl, result_env, thread_pool)
+            umu_run.download_proton(result_env, thread_pool, download=result_dl)
 
     def test_env_wine_empty(self):
         """Test check_env when $WINEPREFIX is empty.
@@ -3416,7 +3416,7 @@ class TestGameLauncher(unittest.TestCase):
             os.environ["WINEPREFIX"] = ""
             os.environ["GAMEID"] = self.test_file
             result_env, result_dl = umu_run.check_env(self.env)
-            umu_run.download_proton(result_dl, result_env, thread_pool)
+            umu_run.download_proton(result_env, thread_pool, download=result_dl)
 
     def test_env_gameid_empty(self):
         """Test check_env when $GAMEID is empty.
@@ -3433,7 +3433,7 @@ class TestGameLauncher(unittest.TestCase):
             os.environ["WINEPREFIX"] = ""
             os.environ["GAMEID"] = ""
             result_env, result_dl = umu_run.check_env(self.env)
-            umu_run.download_proton(result_dl, result_env, thread_pool)
+            umu_run.download_proton(result_env, thread_pool, download=result_dl)
 
     def test_env_wine_dir(self):
         """Test check_env when $WINEPREFIX is not a directory.
@@ -3455,7 +3455,7 @@ class TestGameLauncher(unittest.TestCase):
 
         with ThreadPoolExecutor() as thread_pool:
             result_env, result_dl = umu_run.check_env(self.env)
-            umu_run.download_proton(result_dl, result_env, thread_pool)
+            umu_run.download_proton(result_env, thread_pool, download=result_dl)
 
         # After this, the WINEPREFIX and new dirs should be created
         self.assertTrue(
@@ -3491,7 +3491,7 @@ class TestGameLauncher(unittest.TestCase):
 
         with ThreadPoolExecutor() as thread_pool:
             result_env, result_dl = umu_run.check_env(self.env)
-            umu_run.download_proton(result_dl, result_env, thread_pool)
+            umu_run.download_proton(result_env, thread_pool, download=result_dl)
 
         self.assertTrue(result_env is self.env, "Expected the same reference")
         self.assertEqual(
@@ -3517,7 +3517,7 @@ class TestGameLauncher(unittest.TestCase):
 
         with ThreadPoolExecutor() as thread_pool:
             result_env, result_dl = umu_run.check_env(self.env)
-            umu_run.download_proton(result_dl, result_env, thread_pool)
+            umu_run.download_proton(result_env, thread_pool, download=result_dl)
 
         self.assertTrue(result_env is self.env, "Expected the same reference")
         self.assertEqual(
@@ -3551,7 +3551,7 @@ class TestGameLauncher(unittest.TestCase):
                 os.environ["WINEPREFIX"] = self.test_file
                 os.environ["GAMEID"] = self.test_file
                 result_env, result_dl = umu_run.check_env(self.env)
-                umu_run.download_proton(result_dl, result_env, thread_pool)
+                umu_run.download_proton(result_env, thread_pool, download=result_dl)
                 self.assertTrue(result_env is self.env, "Expected the same reference")
                 self.assertFalse(os.environ["PROTONPATH"])
 

--- a/umu/umu_test.py
+++ b/umu/umu_test.py
@@ -1423,7 +1423,8 @@ class TestGameLauncher(unittest.TestCase):
             os.environ["WINEPREFIX"] = self.test_file
             os.environ["GAMEID"] = self.test_file
             os.environ["PROTONPATH"] = "GE-Proton"
-            umu_run.check_env(self.env, self.test_session_pools)
+            result_env, result_dl = umu_run.check_env(self.env)
+            umu_run.download_proton(result_dl, result_env, self.test_session_pools)
             self.assertEqual(
                 self.env["PROTONPATH"],
                 self.test_compat.joinpath(
@@ -1450,7 +1451,8 @@ class TestGameLauncher(unittest.TestCase):
             os.environ["WINEPREFIX"] = self.test_file
             os.environ["GAMEID"] = self.test_file
             os.environ["PROTONPATH"] = "GE-Proton"
-            umu_run.check_env(self.env, mock_session_pools)
+            result_env, result_dl = umu_run.check_env(self.env)
+            umu_run.download_proton(result_dl, result_env, mock_session_pools)
             self.assertFalse(os.environ.get("PROTONPATH"), "Expected empty string")
 
     def test_latest_interrupt(self):
@@ -1747,7 +1749,7 @@ class TestGameLauncher(unittest.TestCase):
             # Args
             args = __main__.parse_args()
             # Config
-            umu_run.check_env(self.env, self.test_session_pools)
+            result_env, result_dl = umu_run.check_env(self.env)
             # Prefix
             umu_run.setup_pfx(self.env["WINEPREFIX"])
             # Env
@@ -1811,7 +1813,8 @@ class TestGameLauncher(unittest.TestCase):
             # Args
             args = __main__.parse_args()
             # Config
-            umu_run.check_env(self.env, thread_pool)
+            result_env, result_dl = umu_run.check_env(self.env)
+            umu_run.download_proton(result_dl, result_env, thread_pool)
             # Prefix
             umu_run.setup_pfx(self.env["WINEPREFIX"])
             # Env
@@ -1908,7 +1911,8 @@ class TestGameLauncher(unittest.TestCase):
             # Args
             args = __main__.parse_args()
             # Config
-            umu_run.check_env(self.env, thread_pool)
+            result_env, result_dl = umu_run.check_env(self.env)
+            umu_run.download_proton(result_dl, result_env, thread_pool)
             # Prefix
             umu_run.setup_pfx(self.env["WINEPREFIX"])
             # Env
@@ -1984,7 +1988,8 @@ class TestGameLauncher(unittest.TestCase):
             # Args
             result_args = __main__.parse_args()
             # Config
-            umu_run.check_env(self.env, thread_pool)
+            result_env, result_dl = umu_run.check_env(self.env)
+            umu_run.download_proton(result_dl, result_env, thread_pool)
             # Prefix
             umu_run.setup_pfx(self.env["WINEPREFIX"])
             # Env
@@ -2023,7 +2028,7 @@ class TestGameLauncher(unittest.TestCase):
             )
 
         # Build
-        test_command = umu_run.build_command(self.env, self.test_local_share)
+        test_command = umu_run.build_command(self.env, self.test_local_share_parent, self.test_runtime_version[1])
         self.assertIsInstance(
             test_command, tuple, "Expected a tuple from build_command"
         )
@@ -2071,7 +2076,8 @@ class TestGameLauncher(unittest.TestCase):
             # Args
             result_args = __main__.parse_args()
             # Config
-            umu_run.check_env(self.env, thread_pool)
+            result_env, result_dl = umu_run.check_env(self.env)
+            umu_run.download_proton(result_dl, result_env, thread_pool)
             # Prefix
             umu_run.setup_pfx(self.env["WINEPREFIX"])
             # Env
@@ -2110,7 +2116,7 @@ class TestGameLauncher(unittest.TestCase):
         os.environ |= self.env
 
         # Build
-        test_command = umu_run.build_command(self.env, self.test_local_share)
+        test_command = umu_run.build_command(self.env, self.test_local_share_parent, self.test_runtime_version[1])
         self.assertIsInstance(
             test_command, tuple, "Expected a tuple from build_command"
         )
@@ -2149,7 +2155,8 @@ class TestGameLauncher(unittest.TestCase):
             # Args
             result_args = __main__.parse_args()
             # Config
-            umu_run.check_env(self.env, thread_pool)
+            result_env, result_dl = umu_run.check_env(self.env)
+            umu_run.download_proton(result_dl, result_env, thread_pool)
             # Prefix
             umu_run.setup_pfx(self.env["WINEPREFIX"])
             # Env
@@ -2164,7 +2171,7 @@ class TestGameLauncher(unittest.TestCase):
 
         # Since we didn't create the proton file, an exception should be raised
         with self.assertRaises(FileNotFoundError):
-            umu_run.build_command(self.env, self.test_local_share)
+            umu_run.build_command(self.env, self.test_local_share, self.test_runtime_version[1])
 
     def test_build_command(self):
         """Test build command.
@@ -2182,7 +2189,7 @@ class TestGameLauncher(unittest.TestCase):
         Path(self.test_file, "proton").touch()
 
         # Mock the shim file
-        shim_path = Path(self.test_local_share, "umu-shim")
+        shim_path = Path(self.test_local_share_parent, "umu-shim")
         shim_path.touch()
 
         with (
@@ -2197,7 +2204,8 @@ class TestGameLauncher(unittest.TestCase):
             # Args
             result_args = __main__.parse_args()
             # Config
-            umu_run.check_env(self.env, thread_pool)
+            result_env, result_dl = umu_run.check_env(self.env)
+            umu_run.download_proton(result_dl, result_env, thread_pool)
             # Prefix
             umu_run.setup_pfx(self.env["WINEPREFIX"])
             # Env
@@ -2237,7 +2245,7 @@ class TestGameLauncher(unittest.TestCase):
             )
 
         # Build
-        test_command = umu_run.build_command(self.env, self.test_local_share)
+        test_command = umu_run.build_command(self.env, self.test_local_share_parent, self.test_runtime_version[1])
         self.assertIsInstance(
             test_command, tuple, "Expected a tuple from build_command"
         )
@@ -2289,7 +2297,8 @@ class TestGameLauncher(unittest.TestCase):
             # Args
             result = __main__.parse_args()
             # Check
-            umu_run.check_env(self.env, thread_pool)
+            result_env, result_dl = umu_run.check_env(self.env)
+            umu_run.download_proton(result_dl, result_env, thread_pool)
             # Prefix
             umu_run.setup_pfx(self.env["WINEPREFIX"])
 
@@ -2370,7 +2379,8 @@ class TestGameLauncher(unittest.TestCase):
             # Args
             result = __main__.parse_args()
             # Check
-            umu_run.check_env(self.env, thread_pool)
+            result_env, result_dl = umu_run.check_env(self.env)
+            umu_run.download_proton(result_dl, result_env, thread_pool)
             # Prefix
             umu_run.setup_pfx(self.env["WINEPREFIX"])
             # Env
@@ -2478,7 +2488,8 @@ class TestGameLauncher(unittest.TestCase):
             # Args
             result = __main__.parse_args()
             # Check
-            umu_run.check_env(self.env, thread_pool)
+            result_env, result_dl = umu_run.check_env(self.env)
+            umu_run.download_proton(result_dl, result_env, thread_pool)
             # Prefix
             umu_run.setup_pfx(self.env["WINEPREFIX"])
             # Env
@@ -2594,7 +2605,8 @@ class TestGameLauncher(unittest.TestCase):
             # Args
             result = __main__.parse_args()
             # Check
-            umu_run.check_env(self.env, thread_pool)
+            result_env, result_dl = umu_run.check_env(self.env)
+            umu_run.download_proton(result_dl, result_env, thread_pool)
             # Prefix
             umu_run.setup_pfx(self.env["WINEPREFIX"])
             # Env
@@ -2724,7 +2736,8 @@ class TestGameLauncher(unittest.TestCase):
             # Args
             result = __main__.parse_args()
             # Check
-            umu_run.check_env(self.env, thread_pool)
+            result_env, result_dl = umu_run.check_env(self.env)
+            umu_run.download_proton(result_dl, result_env, thread_pool)
             # Prefix
             umu_run.setup_pfx(self.env["WINEPREFIX"])
             # Env
@@ -3208,12 +3221,11 @@ class TestGameLauncher(unittest.TestCase):
         Expects the directory $HOME/Games/umu/$GAMEID to not be created
         when UMU_NO_PROTON=1 and GAMEID is set in the host environment.
         """
-        result = None
+        result_env, result_dl = None, None
         # Mock $HOME
         mock_home = Path(self.test_file)
 
         with (
-            ThreadPoolExecutor() as thread_pool,
             # Mock the internal call to Path.home(). Otherwise, some of our
             # assertions may fail when running this test suite locally if
             # the user already has that dir
@@ -3221,8 +3233,8 @@ class TestGameLauncher(unittest.TestCase):
         ):
             os.environ["UMU_NO_PROTON"] = "1"
             os.environ["GAMEID"] = "foo"
-            result = umu_run.check_env(self.env, thread_pool)
-            self.assertTrue(result is self.env)
+            result_env, result_dl = umu_run.check_env(self.env)
+            self.assertTrue(result_env is self.env)
             path = mock_home.joinpath("Games", "umu", os.environ["GAMEID"])
             # Ensure we did not create the target nor its parents up to $HOME
             self.assertFalse(path.exists(), f"Expected {path} to not exist")
@@ -3241,20 +3253,17 @@ class TestGameLauncher(unittest.TestCase):
         Expects the WINE prefix directory to not be created when
         UMU_NO_PROTON=1 and WINEPREFIX is set in the host environment.
         """
-        result = None
+        result_env, result_dl = None, None
 
-        with (
-            ThreadPoolExecutor() as thread_pool,
-        ):
-            os.environ["WINEPREFIX"] = "123"
-            os.environ["UMU_NO_PROTON"] = "1"
-            os.environ["GAMEID"] = "foo"
-            result = umu_run.check_env(self.env, thread_pool)
-            self.assertTrue(result is self.env)
-            self.assertFalse(
-                Path(os.environ["WINEPREFIX"]).exists(),
-                f"Expected directory {os.environ['WINEPREFIX']} to not exist",
-            )
+        os.environ["WINEPREFIX"] = "123"
+        os.environ["UMU_NO_PROTON"] = "1"
+        os.environ["GAMEID"] = "foo"
+        result_env, result_dl = umu_run.check_env(self.env)
+        self.assertTrue(result_env is self.env)
+        self.assertFalse(
+            Path(os.environ["WINEPREFIX"]).exists(),
+            f"Expected directory {os.environ['WINEPREFIX']} to not exist",
+        )
 
     def test_env_proton_nodir(self):
         """Test check_env when $PROTONPATH in the case we failed to set it.
@@ -3269,7 +3278,8 @@ class TestGameLauncher(unittest.TestCase):
         ):
             os.environ["WINEPREFIX"] = self.test_file
             os.environ["GAMEID"] = self.test_file
-            umu_run.check_env(self.env, thread_pool)
+            result_env, result_dl = umu_run.check_env(self.env)
+            umu_run.download_proton(result_dl, result_env, thread_pool)
 
     def test_env_wine_empty(self):
         """Test check_env when $WINEPREFIX is empty.
@@ -3285,7 +3295,8 @@ class TestGameLauncher(unittest.TestCase):
         ):
             os.environ["WINEPREFIX"] = ""
             os.environ["GAMEID"] = self.test_file
-            umu_run.check_env(self.env, thread_pool)
+            result_env, result_dl = umu_run.check_env(self.env)
+            umu_run.download_proton(result_dl, result_env, thread_pool)
 
     def test_env_gameid_empty(self):
         """Test check_env when $GAMEID is empty.
@@ -3301,7 +3312,8 @@ class TestGameLauncher(unittest.TestCase):
         ):
             os.environ["WINEPREFIX"] = ""
             os.environ["GAMEID"] = ""
-            umu_run.check_env(self.env, thread_pool)
+            result_env, result_dl = umu_run.check_env(self.env)
+            umu_run.download_proton(result_dl, result_env, thread_pool)
 
     def test_env_wine_dir(self):
         """Test check_env when $WINEPREFIX is not a directory.
@@ -3322,7 +3334,8 @@ class TestGameLauncher(unittest.TestCase):
         )
 
         with ThreadPoolExecutor() as thread_pool:
-            umu_run.check_env(self.env, thread_pool)
+            result_env, result_dl = umu_run.check_env(self.env)
+            umu_run.download_proton(result_dl, result_env, thread_pool)
 
         # After this, the WINEPREFIX and new dirs should be created
         self.assertTrue(
@@ -3351,15 +3364,16 @@ class TestGameLauncher(unittest.TestCase):
             path_to_tmp,
         )
 
-        result = None
+        result_env, result_dl = None, None
         os.environ["WINEPREFIX"] = unexpanded_path
         os.environ["GAMEID"] = self.test_file
         os.environ["PROTONPATH"] = unexpanded_path
 
         with ThreadPoolExecutor() as thread_pool:
-            result = umu_run.check_env(self.env, thread_pool)
+            result_env, result_dl = umu_run.check_env(self.env)
+            umu_run.download_proton(result_dl, result_env, thread_pool)
 
-        self.assertTrue(result is self.env, "Expected the same reference")
+        self.assertTrue(result_env is self.env, "Expected the same reference")
         self.assertEqual(
             self.env["WINEPREFIX"],
             unexpanded_path,
@@ -3376,15 +3390,16 @@ class TestGameLauncher(unittest.TestCase):
 
     def test_env_vars(self):
         """Test check_env when setting $WINEPREFIX, $GAMEID and $PROTONPATH."""
-        result = None
+        result_env, result_dl = None, None
         os.environ["WINEPREFIX"] = self.test_file
         os.environ["GAMEID"] = self.test_file
         os.environ["PROTONPATH"] = self.test_file
 
         with ThreadPoolExecutor() as thread_pool:
-            result = umu_run.check_env(self.env, thread_pool)
+            result_env, result_dl = umu_run.check_env(self.env)
+            umu_run.download_proton(result_dl, result_env, thread_pool)
 
-        self.assertTrue(result is self.env, "Expected the same reference")
+        self.assertTrue(result_env is self.env, "Expected the same reference")
         self.assertEqual(
             self.env["WINEPREFIX"],
             self.test_file,
@@ -3415,8 +3430,9 @@ class TestGameLauncher(unittest.TestCase):
             ):
                 os.environ["WINEPREFIX"] = self.test_file
                 os.environ["GAMEID"] = self.test_file
-                result = umu_run.check_env(self.env, thread_pool)
-                self.assertTrue(result is self.env, "Expected the same reference")
+                result_env, result_dl = umu_run.check_env(self.env)
+                umu_run.download_proton(result_dl, result_env, thread_pool)
+                self.assertTrue(result_env is self.env, "Expected the same reference")
                 self.assertFalse(os.environ["PROTONPATH"])
 
     def test_env_vars_wine(self):
@@ -3424,7 +3440,7 @@ class TestGameLauncher(unittest.TestCase):
 
         Expects GAMEID and PROTONPATH to be set for the command line:
         """
-        result = None
+        result_env, result_dl = None, None
         mock_gameid = "umu-default"
         mock_protonpath = str(self.test_proton_dir)
 
@@ -3437,8 +3453,8 @@ class TestGameLauncher(unittest.TestCase):
         # and the GAMEID is 'umu-default'
         with patch.object(umu_run, "get_umu_proton", new_callable=mock_get_umu_proton):
             os.environ["WINEPREFIX"] = self.test_file
-            result = umu_run.check_env(self.env, self.test_session_pools)
-            self.assertTrue(result, self.env)
+            result_env, result_dl = umu_run.check_env(self.env)
+            self.assertTrue(result_env, self.env)
             self.assertEqual(os.environ["GAMEID"], mock_gameid)
             self.assertEqual(os.environ["GAMEID"], self.env["GAMEID"])
             self.assertEqual(os.environ["PROTONPATH"], mock_protonpath)
@@ -3452,7 +3468,7 @@ class TestGameLauncher(unittest.TestCase):
 
         Expects PROTONPATH, GAMEID, and WINEPREFIX to be set
         """
-        result = None
+        result_env, result_dl = None, None
         mock_gameid = "umu-default"
         mock_protonpath = str(self.test_proton_dir)
         mock_wineprefix = "/home/foo/Games/umu/umu-default"
@@ -3472,8 +3488,8 @@ class TestGameLauncher(unittest.TestCase):
             patch.object(umu_run, "get_umu_proton", new_callable=mock_get_umu_proton),
             patch.object(Path, "mkdir", return_value=mock_set_wineprefix()),
         ):
-            result = umu_run.check_env(self.env, self.test_session_pools)
-            self.assertTrue(result, self.env)
+            result_env, result_dl = umu_run.check_env(self.env)
+            self.assertTrue(result_env, self.env)
             self.assertEqual(os.environ["GAMEID"], mock_gameid)
             self.assertEqual(os.environ["GAMEID"], self.env["GAMEID"])
             self.assertEqual(os.environ["PROTONPATH"], mock_protonpath)

--- a/umu/umu_test_plugins.py
+++ b/umu/umu_test_plugins.py
@@ -64,11 +64,14 @@ class TestGameLauncherPlugins(unittest.TestCase):
         # /usr/share/umu
         self.test_user_share = Path("./tmp.jl3W4MtO57")
         # ~/.local/share/Steam/compatibilitytools.d
-        self.test_local_share = Path("./tmp.WUaQAk7hQJ")
         self.test_runtime_version = ("sniper", "steamrt3", "1628350")
+        self.test_local_share_parent = Path("./tmp.WUaQAk7hQJ")
+        self.test_local_share = self.test_local_share_parent.joinpath(
+            self.test_runtime_version[1]
+        )
 
         self.test_user_share.mkdir(exist_ok=True)
-        self.test_local_share.mkdir(exist_ok=True)
+        self.test_local_share.mkdir(parents=True, exist_ok=True)
         self.test_cache.mkdir(exist_ok=True)
         self.test_compat.mkdir(exist_ok=True)
         self.test_proton_dir.mkdir(exist_ok=True)
@@ -223,7 +226,7 @@ class TestGameLauncherPlugins(unittest.TestCase):
 
         # Build
         with self.assertRaisesRegex(FileNotFoundError, "_v2-entry-point"):
-            umu_run.build_command(self.env, self.test_local_share, test_command)
+            umu_run.build_command(self.env, self.test_local_share_parent, self.test_runtime_version[1], test_command)
 
     def test_build_command_proton(self):
         """Test build_command.
@@ -301,7 +304,7 @@ class TestGameLauncherPlugins(unittest.TestCase):
 
         # Build
         with self.assertRaisesRegex(FileNotFoundError, "proton"):
-            umu_run.build_command(self.env, self.test_local_share, test_command)
+            umu_run.build_command(self.env, self.test_local_share_parent, self.test_runtime_version[1], test_command)
 
     def test_build_command_toml(self):
         """Test build_command.
@@ -326,7 +329,7 @@ class TestGameLauncherPlugins(unittest.TestCase):
         Path(toml_path).touch()
 
         # Mock the shim file
-        shim_path = Path(self.test_local_share, "umu-shim")
+        shim_path = Path(self.test_local_share_parent, "umu-shim")
         shim_path.touch()
 
         with Path(toml_path).open(mode="w", encoding="utf-8") as file:
@@ -381,7 +384,7 @@ class TestGameLauncherPlugins(unittest.TestCase):
             os.environ[key] = val
 
         # Build
-        test_command = umu_run.build_command(self.env, self.test_local_share)
+        test_command = umu_run.build_command(self.env, self.test_local_share_parent, self.test_runtime_version[1])
 
         # Verify contents of the command
         entry_point, opt1, verb, opt2, shim, proton, verb2, exe = [*test_command]
@@ -619,23 +622,23 @@ class TestGameLauncherPlugins(unittest.TestCase):
             # prepare for building the command
             self.assertEqual(
                 self.env["EXE"],
-                unexpanded_exe,
-                "Expected path not to be expanded",
+                str(Path(unexpanded_exe).expanduser()),
+                "Expected path to be expanded",
             )
             self.assertEqual(
                 self.env["PROTONPATH"],
-                unexpanded_path,
-                "Expected path not to be expanded",
+                str(Path(unexpanded_path).expanduser()),
+                "Expected path to be expanded",
             )
             self.assertEqual(
                 self.env["WINEPREFIX"],
-                unexpanded_path,
-                "Expected path not to be expanded",
+                str(Path(unexpanded_path).expanduser()),
+                "Expected path to be expanded",
             )
             self.assertEqual(
                 self.env["GAMEID"],
                 unexpanded_path,
-                "Expectd path not to be expanded",
+                "Expected path to be expanded",
             )
 
     def test_set_env_toml_opts(self):
@@ -699,12 +702,12 @@ class TestGameLauncherPlugins(unittest.TestCase):
             self.assertTrue(self.env["EXE"], "Expected EXE to be set")
             self.assertEqual(
                 self.env["PROTONPATH"],
-                self.test_file,
+                str(Path(self.test_file).expanduser()),
                 "Expected PROTONPATH to be set",
             )
             self.assertEqual(
                 self.env["WINEPREFIX"],
-                self.test_file,
+                str(Path(self.test_file).expanduser()),
                 "Expected WINEPREFIX to be set",
             )
             self.assertEqual(
@@ -753,12 +756,12 @@ class TestGameLauncherPlugins(unittest.TestCase):
             self.assertTrue(self.env["EXE"], "Expected EXE to be set")
             self.assertEqual(
                 self.env["PROTONPATH"],
-                self.test_file,
+                str(Path(self.test_file).expanduser()),
                 "Expected PROTONPATH to be set",
             )
             self.assertEqual(
                 self.env["WINEPREFIX"],
-                self.test_file,
+                str(Path(self.test_file).expanduser()),
                 "Expected WINEPREFIX to be set",
             )
             self.assertEqual(


### PR DESCRIPTION
After further discussion on Discord wrt #410, I am re-opening this with an few changes.

Specifically, umu will allow a tool without a runtime requirement to run only if `UMU_NO_RUNTIME=1` is set, otherwise it will complain that it cannot resolve the required runtime. This ensures that the user is absolutely certain they want to run the tool without a runtime and they accept full responsibility if something doesn't work.
