### PR TITLE
fix steam remote-play, remote-play together and gamerecording 

### DIFF
--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -225,8 +225,7 @@ def set_env(
     if match(r"^umu-[\d\w]+$", env["UMU_ID"]):
         env["STEAM_COMPAT_APP_ID"] = env["UMU_ID"][env["UMU_ID"].find("-") + 1 :]
     env["SteamAppId"] = env["STEAM_COMPAT_APP_ID"]
-    env["SteamGameId"] = env["SteamAppId"]
-
+    env["SteamGameId"] = os.environ.get("SteamGameId", env["SteamAppId"])
     # PATHS
     env["WINEPREFIX"] = str(pfx)
     env["PROTONPATH"] = str(protonpath)

--- a/umu/umu_test.py
+++ b/umu/umu_test.py
@@ -2561,12 +2561,6 @@ class TestGameLauncher(unittest.TestCase):
                 self.env["STEAM_COMPAT_APP_ID"],
                 "Expected SteamAppId to be STEAM_COMPAT_APP_ID",
             )
-            self.assertEqual(
-                self.env["SteamGameId"],
-                self.env["SteamAppId"],
-                "Expected SteamGameId to be STEAM_COMPAT_APP_ID",
-            )
-
             # PATHS
             self.assertEqual(
                 self.env["STEAM_COMPAT_SHADER_PATH"],
@@ -2677,12 +2671,6 @@ class TestGameLauncher(unittest.TestCase):
                 self.env["STEAM_COMPAT_APP_ID"],
                 "Expected SteamAppId to be STEAM_COMPAT_APP_ID",
             )
-            self.assertEqual(
-                self.env["SteamGameId"],
-                self.env["SteamAppId"],
-                "Expected SteamGameId to be STEAM_COMPAT_APP_ID",
-            )
-
             # PATHS
             self.assertEqual(
                 self.env["STEAM_COMPAT_SHADER_PATH"],
@@ -2798,12 +2786,6 @@ class TestGameLauncher(unittest.TestCase):
                 self.env["STEAM_COMPAT_APP_ID"],
                 "Expected SteamAppId to be STEAM_COMPAT_APP_ID",
             )
-            self.assertEqual(
-                self.env["SteamGameId"],
-                self.env["SteamAppId"],
-                "Expected SteamGameId to be STEAM_COMPAT_APP_ID",
-            )
-
             # PATHS
             self.assertEqual(
                 self.env["STEAM_COMPAT_SHADER_PATH"],
@@ -2932,12 +2914,6 @@ class TestGameLauncher(unittest.TestCase):
                 self.env["STEAM_COMPAT_APP_ID"],
                 "Expected SteamAppId to be STEAM_COMPAT_APP_ID",
             )
-            self.assertEqual(
-                self.env["SteamGameId"],
-                self.env["SteamAppId"],
-                "Expected SteamGameId to be STEAM_COMPAT_APP_ID",
-            )
-
             # PATHS
             self.assertEqual(
                 self.env["STEAM_COMPAT_SHADER_PATH"],


### PR DESCRIPTION
Steam expects the `SteamGameId` environment variable to stay unchanged in order for anything using Video-Capture to work, like remote-play, remote-play together and gamerecording. Thus we should leave it alone if it's set. 

In that case (or generally) SteamGameId is not supposed to equal SteamAppId.

this fix is neccessary for https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/pull/4493