### PR TITLE
umu_run: create `pfx/creation_sync_guard` file to satisfy proton requirements for partial prefixes

### DIFF
--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -77,6 +77,7 @@ def setup_pfx(path: str) -> None:
         pfx.symlink_to(Path(path).expanduser().resolve(strict=True))
 
     Path(path).joinpath("tracked_files").expanduser().touch()
+    Path(path).joinpath("creation_sync_guard").expanduser().touch()
 
     # Create a symlink of the current user to the steamuser dir or vice versa
     # Default for a new prefix is: unixuser -> steamuser


### PR DESCRIPTION
umu-launcher creates a partial prefix to control some aspects of its folder structure. With Proton 10, since when creating a new prefix the `version` file doesn't exist yet, proton assumes there is no need to upgrade the prefix and `upgrade_pfx()` doesn't run. This has the side-effect of the `pfx/creation_sync_guard` file not being created and proton assumes the prefix was not created properly. As a result it tries to back it up and continue, which also negates any kind of control umu can have on the prefix.

See: https://github.com/ValveSoftware/Proton/blob/proton_10.0/proton#L923-L933
