### PR TITLE
fix: dynamically link to zstd when vendoring

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -89,7 +89,7 @@ $(OBJDIR)/.build-umu-vendored: | $(OBJDIR)
 	$(info :: Building vendored dependencies )
 	@if [ "$(USE_SYSTEM_PYZSTD)" != "xtrue" ]; then \
 		sed -i 's/setuptools>=64,<74/setuptools/' subprojects/pyzstd/pyproject.toml; \
-		cd subprojects/pyzstd && $(PYTHON_INTERPRETER) -m build -wn --outdir=$(OBJDIR); \
+		cd subprojects/pyzstd && $(PYTHON_INTERPRETER) -m build -wn -C=--build-option=--dynamic-link-zstd --outdir=$(OBJDIR); \
 	fi
 	@if [ "$(USE_SYSTEM_URLLIB)" != "xtrue" ]; then \
 		cd subprojects/urllib3 && \


### PR DESCRIPTION
For months, since commit d72ff27a3fe0d6fae038867a7a8d429394377fab, we were unintentionally statically linking to the zstd library. Users who may have been affected by this are those who were using our packages that have it vendored. Relevant issues related to this: https://github.com/Open-Wine-Components/umu-launcher/issues/448 and https://github.com/Open-Wine-Components/umu-launcher/issues/385.