### PR TITLE
umu_run: use winetricks from PATH if `<proton>/protonfixes/winetricks` does not exist

### DIFF
--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -188,11 +188,10 @@ def set_env(
         # Make an absolute path to winetricks within GE-Proton or UMU-Proton.
         # The launcher will change to the winetricks parent directory before
         # creating the subprocess
-        exe: Path = Path(protonpath, "protonfixes", "winetricks").resolve(strict=True)
-        env["EXE"] = str(exe)
+        exe: Path = Path(protonpath, "protonfixes", "winetricks")
+        # Handle older protons before winetricks was added to the PATH
+        env["EXE"] = str(exe.resolve(strict=True)) if exe.is_file() else "winetricks"
         args = (env["EXE"], args[1])  # type: ignore
-        if not env["STEAM_COMPAT_INSTALL_PATH"]:
-            env["STEAM_COMPAT_INSTALL_PATH"] = str(exe.parent)
     elif is_cmd:
         try:
             # Ensure executable path is absolute, otherwise Proton will fail

--- a/umu/umu_test.py
+++ b/umu/umu_test.py
@@ -2743,11 +2743,6 @@ class TestGameLauncher(unittest.TestCase):
                 "Expected EXE to be normalized and expanded",
             )
             self.assertEqual(
-                self.env["STEAM_COMPAT_INSTALL_PATH"],
-                Path(path_exe).parent.as_posix(),
-                "Expected STEAM_COMPAT_INSTALL_PATH to be set",
-            )
-            self.assertEqual(
                 self.env["PROTONPATH"],
                 Path(path_exe).parent.parent.as_posix(),
                 "Expected PROTONPATH to be normalized and expanded",


### PR DESCRIPTION
This is the `umu-launcher` counterpart to https://github.com/Open-Wine-Components/umu-protonfixes/pull/319. Since winetricks is in `PATH` we don't need to set its absolute path in umu.

For backwards compatibility with older Protons with umu support, the old path is checked first, and it is used if it exists.
