### PR TITLE
refactor: remove fallback to XRes when acquiring window PIDs

### DIFF
--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -24,7 +24,6 @@ from urllib3.exceptions import TimeoutError as TimeoutErrorUrllib3
 from urllib3.util import Timeout
 from Xlib import X, Xatom, display
 from Xlib.error import DisplayConnectionError
-from Xlib.ext import res as XRes
 from Xlib.protocol.request import GetProperty
 from Xlib.xobject.drawable import Window
 

--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -383,18 +383,6 @@ def get_pstree_from_pid(root_pid: int) -> set[int]:
     return descendants
 
 
-def _query_client_id(d: display.Display, window_id: int) -> int:
-    specs = [{"client": window_id, "mask": XRes.LocalClientPIDMask}]
-    for rid in d.res_query_client_ids(specs).ids:
-        if rid.spec.client <= 0 or rid.spec.mask != XRes.LocalClientPIDMask:
-            continue
-        if not rid.value:
-            continue
-        return int(next(iter(rid.value)))
-
-    return -1
-
-
 def get_window_ids(d: display.Display) -> set[int] | None:
     """Get the list of window ids under the root window for a display."""
     try:
@@ -416,39 +404,31 @@ def get_pstree_window_ids(
     if not window_ids:
         return None
 
+    # Return if _NET_WM_PID does not exist. Its atom existing will be a hard
+    # requirement as, unfortunately, we cannot fallback to X-Res because the
+    # PIDs returned would not map to the ones in the Flatpak's namespace
+    if atom == X.NONE:
+        log.warning("_NET_WM_PID does not exist, skipping window IDs")
+        return None
+
+    # Ensure only the game's windows are returned via _NET_WM_PID
+    # https://specifications.freedesktop.org/wm-spec/1.3/ar01s05.html#id-1.6.14
     for window_id in window_ids:
-        # Ensure only the game's windows are returned via _NET_WM_PID
-        # https://specifications.freedesktop.org/wm-spec/1.3/ar01s05.html#id-1.6.14
-        if atom != X.NONE:
-            window: Window = d.create_resource_object("window", window_id)
-            prop = window.get_full_property(atom, Xatom.CARDINAL)
-            if not prop or not prop.value:
-                continue
-            pid = prop.value.tolist()[0]
-            if pid not in pstree:
-                log.debug(
-                    "PID %s is unrelated to app or not a descendent, skipping", pid
-                )
-                continue
-            log.debug("Window ID %s has PID: %s", window_id, pid)
-            game_window_ids.add(window_id)
+        window: Window = d.create_resource_object("window", window_id)
+        prop = window.get_full_property(atom, Xatom.CARDINAL)
+        if not prop or not prop.value:
             continue
-        log.debug(
-            "_NET_WM_PID not found, falling back to X-Resource to determine window PIDs"
-        )
-        # Determine a window's PID via X-Resource as fallback
-        # https://gitlab.freedesktop.org/xorg/proto/xorgproto/-/raw/master/resproto.txt
-        for client in d.res_query_clients().clients:
-            pid = _query_client_id(d, client.resource_base)
-            if pid < 0:
-                continue
-            if pid not in pstree:
-                log.debug(
-                    "PID %s is unrelated to app or not a descendent, skipping", pid
-                )
-                continue
-            log.debug("Window ID %s has PID: %s", client.resource_base, pid)
-            game_window_ids.add(window_id)
+        pid = prop.value.tolist()[0]
+        if pid not in pstree:
+            log.debug(
+                "PID %s is unrelated to app or not a descendent, skipping window ID: %s",
+                pid,
+                window_id,
+            )
+            continue
+        log.debug("Window ID %s has PID: %s", window_id, pid)
+        game_window_ids.add(window_id)
+        continue
 
     return game_window_ids
 


### PR DESCRIPTION
After a bit of rereview of the refactored window management code, the fallback for detecting window PIDs was unnecessary. The property _NET_WM_PID, typically set by the GUI framework and/or wine, will only be used for detecting and showing the current Flatpak app's windows within the gamescope session.

System Information
---
Heroic Games Launcher:  v2.17.0

OS:
```
NAME="SteamOS"
PRETTY_NAME="SteamOS"
VERSION_CODENAME=holo
ID=steamos
ID_LIKE=arch
ANSI_COLOR="1;35"
HOME_URL="https://www.steampowered.com/"
DOCUMENTATION_URL="https://support.steampowered.com/"
SUPPORT_URL="https://support.steampowered.com/"
BUG_REPORT_URL="https://support.steampowered.com/"
LOGO=steamos
VARIANT_ID=steamdeck
VERSION_ID=3.7.9
BUILD_ID=20250527.1
STEAMOS_DEFAULT_UPDATE_BRANCH=stable
```

Flatpak: Flatpak 1.15.91

VERSIONS.txt:
```
#Name	Version		Runtime	Runtime_Version	Comment
depot	3.0.20250519.130773			# Overall version number
pressure-vessel	0.20250516.0	scout		# pressure-vessel-bin.tar.gz
scripts	0.20250516.0			# from steam-runtime-tools
sniper	3.0.20250519.130773	sniper	3.0.20250519.130773	# sniper_platform_3.0.20250519.130773/
```

Steam: 1748914100