### PR TITLE
derive steam_appid from SteamGameId

### DIFF
--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -504,6 +504,9 @@ def get_steam_appid(env: MutableMapping) -> int:
         with suppress(ValueError, IndexError):
             return int(Path(path).parts[-2])
 
+    with suppress(ValueError):
+            return int(env.get("SteamGameId", "")) >> 32
+
     return steam_appid
 
 


### PR DESCRIPTION
From my testing, the appId that the steammode code expects is always exactly `(SteamGameId - 2²⁵) / 2³²`.

So, I think that after bit shifting by 32bits, it should be usable as a fallback when shader pre-caching is disabled.