### PR TITLE
refactor: improve subprocess PID detection for window management

### DIFF
--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -511,6 +511,7 @@ def get_steam_appid(env: MutableMapping) -> int:
 
 
 def _get_pstree_root_pid(env: MutableMapping) -> int:
+    # https://gitlab.steamos.cloud/steamrt/steam-runtime-tools/-/raw/main/pressure-vessel/adverb.1.md
     target = "pv-adverb"
 
     # Find a target process where it's descendents create game windows


### PR DESCRIPTION
The new implementation avoids special-casing Flatpak and setting any arbitrary `bwrap` process as the ancestor PID by setting the child process `pv-adverb` as the targeted ancestor PID. To ensure the target is relevant and that only current app's windows are shown, as there can be many `pv-adverb` process', its environment will be checked for its session token, `UMU_INVOCATION_ID`.