### PR TITLE
use an external reaper and let gamescope handle running in steammode

### DIFF
--- a/umu/umu_consts.py
+++ b/umu/umu_consts.py
@@ -29,13 +29,6 @@ class HTTPMethod(Enum):
     TRACE = "TRACE"
 
 
-class GamescopeAtom(Enum):
-    """Represent Gamescope-specific X11 atom names."""
-
-    SteamGame = "STEAM_GAME"
-    BaselayerAppId = "GAMESCOPECTRL_BASELAYER_APPID"
-
-
 class FileLock(Enum):
     """Files placed with an exclusive lock via flock(2)."""
 

--- a/umu/umu_reaper.py
+++ b/umu/umu_reaper.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+
+import logging
+import os
+import sys
+from argparse import Namespace
+from ctypes import CDLL, byref, c_int, create_string_buffer
+from ctypes.util import find_library
+from logging import getLogger
+
+# Constant defined in prctl.h
+# See prctl(2) for more details
+PR_SET_CHILD_SUBREAPER = 36
+PR_SET_NAME = 15
+
+def get_libc() -> str:
+    """Find libc.so from the user's system."""
+    return find_library("c") or ""
+
+
+def subreaper(args: Namespace, other: list[str]) -> int:  # noqa: D103
+    logger = getLogger("subreaper")
+    logging.basicConfig(
+        format="[%(name)s] %(levelname)s: %(message)s",
+        level=logging.DEBUG if args.debug else logging.INFO,
+        stream=sys.stderr,
+    )
+
+    logger.debug("command: %s", args)
+    logger.debug("arguments: %s", other)
+
+    command: list[str] = [args.command, *other]
+    workdir: str = args.workdir
+    child_status: int = 0
+
+    libc: str = get_libc()
+    prctl = CDLL(libc).prctl
+    prctl.restype = c_int
+    prctl.argtypes = [
+        c_int,
+        # c_ulong,
+        # c_ulong,
+        # c_ulong,
+        # c_ulong,
+    ]
+
+    proc_name = b"reaper"
+    buff = create_string_buffer(len(proc_name)+1)
+    buff.value = proc_name
+    prctl_ret = prctl(PR_SET_NAME, byref(buff), 0, 0, 0)
+    logger.debug("prctl PR_SET_NAME exited with status: %s", prctl_ret)
+
+    prctl_ret = prctl(PR_SET_CHILD_SUBREAPER, 1, 0, 0, 0, 0)
+    logger.debug("prctl PR_SET_CHILD_SUBREAPER exited with status: %s", prctl_ret)
+
+    pid = os.fork()  # pylint: disable=E1101
+    if pid == -1:
+        logger.error("Fork failed")
+
+    if pid == 0:
+        sys.stdout.flush()
+        sys.stderr.flush()
+        os.chdir(workdir)
+        os.execvp(command[0], command)  # noqa: S606
+
+    while True:
+        try:
+            child_pid, child_status = os.wait()  # pylint: disable=E1101
+            logger.info("Child %s exited with wait status: %s", child_pid, child_status)
+        except ChildProcessError as e:
+            logger.info(e)
+            break
+
+    return child_status
+
+
+if __name__ == "__main__":
+    sep = sys.argv.index("--")
+    argv = sys.argv[sep+1:]
+    debug = os.environ.get("UMU_REAPER_DEBUG") in {"1", "debug"}
+    args = Namespace(command=argv.pop(0), workdir=os.getcwd(), debug=debug)  # noqa: PTH109
+    subreaper(args, argv)
+
+
+__all__ = ["subreaper"]

--- a/umu/umu_runtime.py
+++ b/umu/umu_runtime.py
@@ -66,6 +66,107 @@ def create_shim(file_path: Path):
     # Make the script executable
     file_path.chmod(0o700)
 
+def create_reaper(file_path: Path):
+    """Create a python reaper at the specified file path.
+
+    Args:
+        file_path (Path): The path where the reaper script will be created.
+
+    """
+    script_content = (
+        '#!/usr/bin/env python3\n'
+        '\n'
+        'import logging\n'
+        'import os\n'
+        'import sys\n'
+        'from argparse import Namespace\n'
+        'from ctypes import CDLL, c_int, c_ulong, create_string_buffer, byref\n'
+        'from ctypes.util import find_library\n'
+        'from logging import getLogger\n'
+        'from typing import List\n'
+        '\n'
+        '# Constant defined in prctl.h\n'
+        '# See prctl(2) for more details\n'
+        'PR_SET_CHILD_SUBREAPER = 36\n'
+        'PR_SET_NAME = 15\n'
+        '\n'
+        'def get_libc() -> str:\n'
+        '    """Find libc.so from the user\'s system."""\n'
+        '    return find_library("c") or ""\n'
+        '\n'
+        '\n'
+        'def subreaper(args: Namespace, other: List[str]) -> int:\n'
+        '    logger = getLogger("subreaper")\n'
+        '    logging.basicConfig(\n'
+        '        format="[%(name)s] %(levelname)s: %(message)s",\n'
+        '        level=logging.DEBUG if args.debug else logging.INFO,\n'
+        '        stream=sys.stderr,\n'
+        '    )\n'
+        '\n'
+        '    logger.debug("command: %s", args)\n'
+        '    logger.debug("arguments: %s", other)\n'
+        '\n'
+        '    command: List[str] = [args.command, *other]\n'
+        '    workdir: str = args.workdir\n'
+        '    child_status: int = 0\n'
+        '\n'
+        '    libc: str = get_libc()\n'
+        '    prctl = CDLL(libc).prctl\n'
+        '    prctl.restype = c_int\n'
+        '    prctl.argtypes = [\n'
+        '        c_int,\n'
+        '        # c_ulong,\n'
+        '        # c_ulong,\n'
+        '        # c_ulong,\n'
+        '        # c_ulong,\n'
+        '    ]\n'
+        '\n'
+        '    proc_name = b"reaper"\n'
+        '    buff = create_string_buffer(len(proc_name)+1)\n'
+        '    buff.value = proc_name\n'
+        '    prctl_ret = prctl(PR_SET_NAME, byref(buff), 0, 0, 0)\n'
+        '    logger.debug("prctl PR_SET_NAME exited with status: %s", prctl_ret)\n'
+        '\n'
+        '    prctl_ret = prctl(PR_SET_CHILD_SUBREAPER, 1, 0, 0, 0, 0)\n'
+        '    logger.debug("prctl PR_SET_CHILD_SUBREAPER exited with status: %s", prctl_ret)\n'
+        '\n'
+        '    pid = os.fork()  # pylint: disable=E1101\n'
+        '    if pid == -1:\n'
+        '        logger.error("Fork failed")\n'
+        '\n'
+        '    if pid == 0:\n'
+        '        sys.stdout.flush()\n'
+        '        sys.stderr.flush()\n'
+        '        os.chdir(workdir)\n'
+        '        os.execvp(command[0], command)  # noqa: S606\n'
+        '\n'
+        '    while True:\n'
+        '        try:\n'
+        '            child_pid, child_status = os.wait()  # pylint: disable=E1101\n'
+        '            logger.info("Child %s exited with wait status: %s", child_pid, child_status)\n'
+        '        except ChildProcessError as e:\n'
+        '            logger.info(e)\n'
+        '            break\n'
+        '\n'
+        '    return child_status\n'
+        '\n'
+        '\n'
+        'if __name__ == "__main__":\n'
+        '    sep = sys.argv.index("--")\n'
+        '    argv = sys.argv[sep+1:]\n'
+        '    args = Namespace(command=argv.pop(0), workdir=os.getcwd(), debug=os.environ.get("UMU_REAPER_DEBUG") in {"1", "debug"})\n'
+        '    subreaper(args, argv)\n'
+        '\n'
+        '\n'
+        '__all__ = ["subreaper"]'
+    )
+
+    # Write the script content to the specified file path
+    with file_path.open("w") as file:
+        file.write(script_content)
+
+    # Make the script executable
+    file_path.chmod(0o700)
 
 def _install_umu(
     runtime_ver: RuntimeVersion,
@@ -260,6 +361,7 @@ def _install_umu(
     local.joinpath("_v2-entry-point").rename(local.joinpath("umu"))
 
     create_shim(local / "umu-shim")
+    create_reaper(local / "reaper")
 
     # Validate the runtime after moving the files
     check_runtime(local, runtime_ver)
@@ -372,6 +474,10 @@ def _update_umu(
     # Restore shim if missing
     if not local.joinpath("umu-shim").is_file():
         create_shim(local / "umu-shim")
+
+    # Restore reaper if missing
+    if not local.joinpath("reaper").is_file():
+        create_reaper(local / "reaper")
 
     log.info("%s is up to date", variant)
 

--- a/umu/umu_test.py
+++ b/umu/umu_test.py
@@ -6,7 +6,6 @@ import sys
 import tarfile
 import unittest
 from argparse import Namespace
-from array import array
 from collections.abc import Generator
 from concurrent.futures import ThreadPoolExecutor
 from importlib.util import find_spec
@@ -21,12 +20,6 @@ from tempfile import (
     gettempdir,
 )
 from unittest.mock import MagicMock, Mock, patch
-
-from Xlib.display import Display
-from Xlib.error import DisplayConnectionError
-from Xlib.protocol.rq import Event
-from Xlib.X import CreateNotify
-from Xlib.xobject.drawable import Window
 
 sys.path.append(str(Path(__file__).parent.parent))
 
@@ -940,124 +933,6 @@ class TestGameLauncher(unittest.TestCase):
             umu_util.write_file_chunks(mock_file, file2, hasher, chunk_size)
             self.assertTrue(hasher.digest(), "Expected hashed data > 0, received 0")
 
-    def test_get_gamescope_baselayer_appid_err(self):
-        """Test get_gamescope_baselayer_appid on error.
-
-        Expects function be fail safe, handling any exceptions when getting
-        GAMESCOPECTRL_BASELAYER_APPID
-        """
-        mock_display = MagicMock(spec=Display)
-        mock_display.screen.side_effect = DisplayConnectionError(mock_display, "foo")
-
-        result = umu_run.get_gamescope_baselayer_appid(mock_display)
-        self.assertTrue(result is None, f"Expected a value, received: {result}")
-
-    def test_get_gamescope_baselayer_appid(self):
-        """Test get_gamescope_baselayer_appid."""
-        mock_display = MagicMock(spec=Display)
-        mock_screen = MagicMock()
-        mock_root = MagicMock()
-        mock_prop = MagicMock()
-        result = None
-
-        mock_display.screen.return_value = mock_screen
-        mock_display.get_atom.return_value = 0
-        mock_screen.root = mock_root
-        mock_root.get_full_property.return_value = mock_prop
-        mock_prop.value = array("I", [1, 2, 3])
-
-        result = umu_run.get_gamescope_baselayer_appid(mock_display)
-        self.assertTrue(result == [1, 2, 3], f"Expected a value, received: {result}")
-
-    def test_set_steam_game_property_err(self):
-        """Test set_steam_game_property on error.
-
-        Expects function be fail safe, handling any exceptions when setting
-        a new value for STEAM_GAME.
-        """
-        mock_display = MagicMock(spec=Display)
-        mock_window_ids = {"1", "2", "3"}
-        mock_appid = 123
-
-        mock_display.create_resource_object.side_effect = DisplayConnectionError(
-            mock_display, "foo"
-        )
-
-        result = umu_run.set_steam_game_property(
-            mock_display, mock_window_ids, mock_appid
-        )
-
-        self.assertTrue(result is mock_display, f"Expected Display, received: {result}")
-        mock_display.create_resource_object.assert_called()
-
-    def test_set_steam_game_property(self):
-        """Test set_steam_game_property."""
-        mock_display = MagicMock(spec=Display)
-        mock_window = MagicMock(spec=Window)
-        mock_window_ids = {"1", "2", "3"}
-        mock_appid = 123
-
-        mock_display.create_resource_object.return_value = mock_window
-        mock_display.get_atom.return_value = 0
-
-        result = umu_run.set_steam_game_property(
-            mock_display, mock_window_ids, mock_appid
-        )
-        self.assertTrue(result is mock_display, f"Expected Display, received: {result}")
-        mock_display.create_resource_object.assert_called()
-        mock_display.get_atom.assert_called()
-
-    def test_get_window_ids_err(self):
-        """Test get_window_ids on error.
-
-        Expects function to be fail safe, so any exceptions should be handled
-        when returning child windows.
-        """
-        mock_display = MagicMock(spec=Display)
-        mock_event = MagicMock(spec=Event)
-        mock_screen = MagicMock()
-        mock_root = MagicMock()
-        mock_query_tree = MagicMock()
-
-        mock_event.type = CreateNotify
-        mock_display.next_event.return_value = mock_event
-
-        mock_display.screen.return_value = mock_screen
-        mock_screen.root = mock_root
-        mock_root.query_tree.side_effect = DisplayConnectionError(mock_display, "foo")
-        mock_query_tree.children = set()
-
-        result = umu_run.get_window_ids(mock_display)
-
-        # Assertions
-        self.assertTrue(result is None, f"Expected None, received: {result}")
-        mock_display.next_event.assert_called_once()
-        mock_display.screen.assert_called_once()
-        mock_screen.root.query_tree.assert_called_once()
-
-    def test_get_window_ids(self):
-        """Test get_window_ids."""
-        mock_display = MagicMock(spec=Display)
-        mock_event = MagicMock(spec=Event)
-        mock_screen = MagicMock()
-        mock_root = MagicMock()
-        mock_query_tree = MagicMock()
-
-        mock_event.type = CreateNotify
-        mock_display.next_event.return_value = mock_event
-
-        mock_display.screen.return_value = mock_screen
-        mock_screen.root = mock_root
-        mock_root.query_tree.return_value = mock_query_tree
-        mock_query_tree.children = set()
-
-        result = umu_run.get_window_ids(mock_display)
-
-        self.assertTrue(isinstance(result, set), f"Expected a set, received: {result}")
-        mock_display.next_event.assert_called_once()
-        mock_display.screen.assert_called_once()
-        mock_screen.root.query_tree.assert_called_once()
-
     def test_get_steam_layer_id(self):
         """Test get_steam_layer_id.
 
@@ -1097,6 +972,28 @@ class TestGameLauncher(unittest.TestCase):
             self.assertTrue(shim.is_file(), f"Expected '{shim}' to be a file")
             # Ensure there's data
             self.assertTrue(shim.stat().st_size > 0, f"Expected '{shim}' to have data")
+
+    def test_create_reaper_exe(self):
+        """Test create_reaper and ensure it's executable."""
+        reaper = None
+
+        with TemporaryDirectory() as tmp:
+            reaper = Path(tmp, "reaper")
+            umu_runtime.create_reaper(reaper)
+            self.assertTrue(
+                os.access(reaper, os.X_OK), f"Expected '{reaper}' to be executable"
+            )
+
+    def test_create_reaper(self):
+        """Test create_reaper."""
+        reaper = None
+
+        with TemporaryDirectory() as tmp:
+            reaper = Path(tmp, "reaper")
+            umu_runtime.create_reaper(reaper)
+            self.assertTrue(reaper.is_file(), f"Expected '{reaper}' to be a file")
+            # Ensure there's data
+            self.assertTrue(reaper.stat().st_size > 0, f"Expected '{reaper}' to have data")
 
     def test_run_command(self):
         """Test run_command."""
@@ -2185,6 +2082,10 @@ class TestGameLauncher(unittest.TestCase):
         shim_path = Path(self.test_local_share, "umu-shim")
         shim_path.touch()
 
+        # Mock the reaper file
+        reaper_path = Path(self.test_local_share, "reaper")
+        reaper_path.touch()
+
         with (
             patch("sys.argv", ["", self.test_exe]),
             ThreadPoolExecutor() as thread_pool,
@@ -2243,10 +2144,10 @@ class TestGameLauncher(unittest.TestCase):
         )
         self.assertEqual(
             len(test_command),
-            8,
-            f"Expected 8 elements, received {len(test_command)}",
+            12,
+            f"Expected 12 elements, received {len(test_command)}",
         )
-        entry_point, opt1, verb, opt2, shim, proton, verb2, exe = [*test_command]
+        entry_point, opt1, verb, opt2, reaper, opt3, appId, opt4, shim, proton, verb2, exe = [*test_command]
         # The entry point dest could change. Just check if there's a value
         self.assertTrue(entry_point, "Expected an entry point")
         self.assertIsInstance(
@@ -2255,6 +2156,11 @@ class TestGameLauncher(unittest.TestCase):
         self.assertEqual(opt1, "--verb", "Expected --verb")
         self.assertEqual(verb, self.test_verb, "Expected a verb")
         self.assertEqual(opt2, "--", "Expected --")
+        self.assertIsInstance(reaper, os.PathLike, "Expected reaper to be PathLike")
+        self.assertEqual(opt3, "SteamLaunch", "Expected SteamLaunch")
+        self.assertEqual(appId, "AppId=0", "Expected AppId")
+        self.assertEqual(opt4, "--", "Expected --")
+        self.assertEqual(reaper, reaper_path, "Expected the reaper file")
         self.assertIsInstance(shim, os.PathLike, "Expected shim to be PathLike")
         self.assertEqual(shim, shim_path, "Expected the shim file")
         self.assertIsInstance(proton, os.PathLike, "Expected proton to be PathLike")

--- a/umu/umu_test_plugins.py
+++ b/umu/umu_test_plugins.py
@@ -329,6 +329,10 @@ class TestGameLauncherPlugins(unittest.TestCase):
         shim_path = Path(self.test_local_share, "umu-shim")
         shim_path.touch()
 
+        # Mock the reaper file
+        reaper_path = Path(self.test_local_share, "reaper")
+        reaper_path.touch()
+
         with Path(toml_path).open(mode="w", encoding="utf-8") as file:
             file.write(toml_str)
 
@@ -384,7 +388,7 @@ class TestGameLauncherPlugins(unittest.TestCase):
         test_command = umu_run.build_command(self.env, self.test_local_share)
 
         # Verify contents of the command
-        entry_point, opt1, verb, opt2, shim, proton, verb2, exe = [*test_command]
+        entry_point, opt1, verb, opt2, reaper, opt3, appId, opt4, shim, proton, verb2, exe = [*test_command]
         # The entry point dest could change. Just check if there's a value
         self.assertTrue(entry_point, "Expected an entry point")
         self.assertIsInstance(
@@ -393,6 +397,11 @@ class TestGameLauncherPlugins(unittest.TestCase):
         self.assertEqual(opt1, "--verb", "Expected --verb")
         self.assertEqual(verb, self.test_verb, "Expected a verb")
         self.assertEqual(opt2, "--", "Expected --")
+        self.assertIsInstance(reaper, os.PathLike, "Expected reaper to be PathLike")
+        self.assertEqual(opt3, "SteamLaunch", "Expected SteamLaunch")
+        self.assertEqual(appId, "AppId=0", "Expected AppId")
+        self.assertEqual(opt4, "--", "Expected --")
+        self.assertEqual(reaper, reaper_path, "Expected the reaper file")
         self.assertIsInstance(shim, os.PathLike, "Expected shim to be PathLike")
         self.assertEqual(shim, shim_path, "Expected the shim file")
         self.assertIsInstance(proton, os.PathLike, "Expected proton to be PathLike")

--- a/umu/umu_util.py
+++ b/umu/umu_util.py
@@ -17,7 +17,6 @@ from tempfile import gettempdir, mkdtemp
 from typing import Any
 
 from urllib3.response import BaseHTTPResponse
-from Xlib import display
 
 from umu.umu_consts import TMPFS_MIN, UMU_CACHE, UMU_LOCAL, WINETRICKS_SETTINGS_VERBS
 from umu.umu_log import log
@@ -212,20 +211,6 @@ def is_winetricks_verb(
             return False
 
     return True
-
-
-@contextmanager
-def xdisplay(no: str):
-    """Create a Display."""
-    d: display.Display | None = None
-
-    try:
-        d = display.Display(no)
-        yield d
-    finally:
-        if d is not None:
-            d.close()
-
 
 def write_file_chunks(
     path: Path,


### PR DESCRIPTION
In order to bring a window to the front gamescope expects the processes pid 1 to be a process called `reaper`, which has `SteamLaunch AppId=appid` in its cmdline.

Normally Steams own reaper handles that, but when running a steamrt from within a flatpak that reaper can't see everything in the bwrap, causing them to lose that metadata. This causes https://github.com/ValveSoftware/gamescope/issues/1341.

This adds a python subreaper implementation written by @loathingKernel (they also generally helped a lot with this) which re-adds the metadata to all child processes, causing them to appear again, without any of manual code umu currently runs.

This also means that we could completely reliably get the AppId from the cmdline of umus pid 1 (when run from steam), but I have no clue how to do that.

Theoretically we could also use steams built in reaper or this [reaper](https://github.com/Plagman/reaper) (probably the same as steams).

A thread about this change and stuff is in #496 