### PR TITLE
fix: create temporary directory on subsequent network errors

### DIFF
--- a/umu/umu_proton.py
+++ b/umu/umu_proton.py
@@ -10,7 +10,7 @@ from itertools import chain
 from pathlib import Path
 from re import split as resplit
 from shutil import move
-from tempfile import TemporaryDirectory
+from tempfile import TemporaryDirectory, mkdtemp
 from typing import Any
 
 from urllib3.exceptions import HTTPError
@@ -264,7 +264,7 @@ def _fetch_proton(
         if cached_parts.is_file():
             log.info("Found '%s' in cache, resuming...", cached_parts.name)
             headers = {"Range": f"bytes={cached_parts.stat().st_size}-"}
-            parts = cached_parts
+            parts = cached_parts.rename(f"{mkdtemp(dir=UMU_CACHE)}/{parts.name}")
             # Rebuild our hashed progress
             with parts.open("rb") as fp:
                 hashsum = file_digest(fp, hashsum.name)

--- a/umu/umu_proton.py
+++ b/umu/umu_proton.py
@@ -259,9 +259,10 @@ def _fetch_proton(
         parts: Path = tmpfs.joinpath(f"{tarball}.parts")
         cached_parts: Path = UMU_CACHE.joinpath(parts.name)
         headers: dict[str, str] | None = None
+        has_cache: bool = cached_parts.is_file()
 
         # Resume from our cached file, if we were interrupted previously
-        if cached_parts.is_file():
+        if has_cache:
             log.info("Found '%s' in cache, resuming...", cached_parts.name)
             headers = {"Range": f"bytes={cached_parts.stat().st_size}-"}
             parts = cached_parts.rename(f"{mkdtemp(dir=UMU_CACHE)}/{parts.name}")
@@ -308,6 +309,9 @@ def _fetch_proton(
                 f"Link: {tar_url}"
             )
             raise ValueError(err)
+
+        if has_cache:
+            move(parts, UMU_CACHE)
 
         log.info("%s: SHA512 is OK", tarball)
 

--- a/umu/umu_runtime.py
+++ b/umu/umu_runtime.py
@@ -163,7 +163,7 @@ def _install_umu(
         if cached_parts.is_file():
             log.info("Found '%s' in cache, resuming...", cached_parts.name)
             headers = {"Range": f"bytes={cached_parts.stat().st_size}-"}
-            parts = cached_parts
+            parts = cached_parts.rename(f"{mkdtemp(dir=UMU_CACHE)}/{parts.name}")
             # Rebuild our hashed progress
             with parts.open("rb") as fp:
                 hashsum = file_digest(fp, hashsum.name)


### PR DESCRIPTION
In the case where a network error occurs again for the user after resuming from a cached Steam Linux Runtime or Proton file, a shutil.Error will be raised from shutil.move due to the destination path already existing:
```
raise Error('Destination path '%s' already exists' % real_dst)
shutil.Error: Destination path '/home/deck/.var/app/com.heroicgameslauncher.hgl/cache/umu/SteamLinuxRuntime_sniper.tar.xz.3.0.20250519.130773.parts' already exists
```
To handle this case, the cached file needs to be moved to a new temporary directory on the same Linux file system before writing to it.