### PR TITLE
fix: skip unlinking UMU-Latest in compatibilitytools.d

### DIFF
--- a/umu/umu_run.py
+++ b/umu/umu_run.py
@@ -127,11 +127,8 @@ def check_env(
     if os.environ.get("UMU_NO_PROTON") == "1":
         return env
 
-    path: Path = STEAM_COMPAT.joinpath(os.environ.get("PROTONPATH", ""))
-    if os.environ.get("PROTONPATH") and path.name == "UMU-Latest":
-        path.unlink(missing_ok=True)
-
     # Proton Version
+    path: Path = STEAM_COMPAT.joinpath(os.environ.get("PROTONPATH", ""))
     if os.environ.get("PROTONPATH") and path.is_dir():
         os.environ["PROTONPATH"] = str(STEAM_COMPAT.joinpath(os.environ["PROTONPATH"]))
 


### PR DESCRIPTION
Related to https://github.com/Open-Wine-Components/umu-launcher/issues/435.